### PR TITLE
:sparkles: feat: Add gap props to SliderWithInput

### DIFF
--- a/src/SliderWithInput/index.tsx
+++ b/src/SliderWithInput/index.tsx
@@ -2,10 +2,11 @@ import { InputNumber, type InputNumberProps, Slider } from 'antd';
 import { SliderSingleProps } from 'antd/es/slider';
 import { isNull } from 'lodash-es';
 import { memo, useCallback } from 'react';
-import { Flexbox } from 'react-layout-kit';
+import { CommonSpaceNumber, Flexbox } from 'react-layout-kit';
 
 export interface SliderWithInputProps extends SliderSingleProps {
   controls?: InputNumberProps['controls'];
+  gap?: CommonSpaceNumber | number;
   size?: InputNumberProps['size'];
 }
 
@@ -19,6 +20,7 @@ const SliderWithInput = memo<SliderWithInputProps>(
     defaultValue,
     size,
     controls,
+    gap,
     style,
     className,
     disabled,
@@ -34,7 +36,7 @@ const SliderWithInput = memo<SliderWithInputProps>(
         align={'center'}
         className={className}
         direction={'horizontal'}
-        gap={8}
+        gap={gap ?? 8}
         style={style}
       >
         <Slider


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->
I noticed an issue that text overlaps in lobe-chat, and I think it needs a gap adjustment, so I created this pull request.

#### 📝 补充信息 | Additional Information

![image](https://github.com/lobehub/lobe-ui/assets/35215680/5a5426d2-80df-42dd-bf7f-9e8a48551b24)
not only ja but also en cause this overlaps.
<!-- Add any other context about the Pull Request here. -->
