### PR TITLE
✨ feat: Avatar supports ReactNode

### DIFF
--- a/src/Avatar/demos/ReactNode.tsx
+++ b/src/Avatar/demos/ReactNode.tsx
@@ -1,0 +1,6 @@
+import { UserOutlined } from '@ant-design/icons';
+import { Avatar } from '@lobehub/ui';
+
+export default () => {
+  return <Avatar avatar={<UserOutlined />} />;
+};

--- a/src/Avatar/index.md
+++ b/src/Avatar/index.md
@@ -9,6 +9,10 @@ description: Avatar is a component that displays a user's profile picture or ini
 
 <code src="./demos/index.tsx" nopadding></code>
 
+## ReactNode
+
+<code src="./demos/ReactNode.tsx" center></code>
+
 ## Emoji
 
 <code src="./demos/Emoji.tsx" center></code>

--- a/src/Avatar/index.tsx
+++ b/src/Avatar/index.tsx
@@ -1,5 +1,5 @@
 import { Avatar as AntAvatar, type AvatarProps as AntAvatarProps } from 'antd';
-import { memo, useMemo } from 'react';
+import { type ReactNode, isValidElement, memo, useMemo } from 'react';
 
 import FluentEmoji from '@/FluentEmoji';
 import { getEmoji } from '@/utils/getEmojiByCharacter';
@@ -11,7 +11,7 @@ export interface AvatarProps extends AntAvatarProps {
   /**
    * @description The URL or base64 data of the avatar image
    */
-  avatar?: string;
+  avatar?: string | ReactNode;
   /**
    * @description The background color of the avatar
    */
@@ -44,15 +44,21 @@ const Avatar = memo<AvatarProps>(
     style,
     ...rest
   }) => {
-    const isImage = Boolean(
-      avatar && ['/', 'http', 'data:'].some((index) => avatar.startsWith(index)),
+    const isStringAvatar = typeof avatar === 'string';
+    const isDefaultAntAvatar = Boolean(
+      avatar &&
+        (['/', 'http', 'data:'].some((index) => isStringAvatar && avatar.startsWith(index)) ||
+          isValidElement(avatar)),
     );
 
-    const emoji = useMemo(() => avatar && !isImage && getEmoji(avatar), [avatar]);
+    const emoji = useMemo(
+      () => avatar && !isDefaultAntAvatar && isStringAvatar && getEmoji(avatar),
+      [avatar],
+    );
 
     const { styles, cx } = useStyles({ background, isEmoji: Boolean(emoji), size });
 
-    const text = String(isImage ? title : avatar);
+    const text = String(isDefaultAntAvatar ? title : avatar);
 
     const avatarProps = {
       className: cx(styles.avatar, className),
@@ -62,7 +68,7 @@ const Avatar = memo<AvatarProps>(
       ...rest,
     };
 
-    return isImage ? (
+    return isDefaultAntAvatar ? (
       <AntAvatar src={avatar} {...avatarProps} />
     ) : (
       <AntAvatar {...avatarProps}>

--- a/src/types/meta.ts
+++ b/src/types/meta.ts
@@ -1,9 +1,11 @@
+import { type ReactNode } from 'react';
+
 export interface MetaData {
   /**
    * 角色头像
    * @description 可选参数，如果不传则使用默认头像
    */
-  avatar?: string;
+  avatar?: string | ReactNode;
   /**
    *  背景色
    * @description 可选参数，如果不传则使用默认背景色


### PR DESCRIPTION
#### 💻 变更类型 | Change Type
[Ant Design 的 Avatar 的 src 属性](https://ant.design/components/avatar-cn#avatar) 是支持 ReactNode 的，可以进行头像自定义

目前 lobe-ui 的 Avatar 组件 src 不支持 ReactNode，满足不了我们的设计需求😢

本次修改，让 src 支持 ReactNode，以实现头像自定义

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
