### PR TITLE
🐛 fix: No display of time

### DIFF
--- a/src/ChatItem/components/Title.tsx
+++ b/src/ChatItem/components/Title.tsx
@@ -14,7 +14,7 @@ export interface TitleProps {
 }
 
 const Title = memo<TitleProps>(({ showTitle, placement, time, avatar }) => {
-  const { styles } = useStyles({ placement, showTitle });
+  const { styles } = useStyles({ placement, showTitle, time });
 
   return (
     <Flexbox

--- a/src/ChatItem/index.tsx
+++ b/src/ChatItem/index.tsx
@@ -44,6 +44,7 @@ const ChatItem = memo<ChatItemProps>(
       placement,
       primary,
       showTitle,
+      time,
       title: avatar.title,
       type,
     });

--- a/src/ChatItem/style.ts
+++ b/src/ChatItem/style.ts
@@ -10,12 +10,14 @@ export const useStyles = createStyles(
       primary,
       avatarSize,
       editing,
+      time,
     }: {
       avatarSize?: number;
       editing?: boolean;
       placement?: 'left' | 'right';
       primary?: boolean;
       showTitle?: boolean;
+      time?: number;
       title?: string;
       type?: 'block' | 'pure';
     },
@@ -172,7 +174,7 @@ export const useStyles = createStyles(
           position: relative;
           overflow: hidden;
           max-width: 100%;
-          margin-top: -16px;
+          margin-top: ${time ? -16 : 0}px;
 
           ${responsive.mobile} {
             overflow-x: auto;

--- a/src/ChatItem/style.ts
+++ b/src/ChatItem/style.ts
@@ -82,9 +82,6 @@ export const useStyles = createStyles(
         type === 'pure' && pureContainerStylish,
         css`
           position: relative;
-
-          overflow: hidden;
-
           width: 100%;
           max-width: 100vw;
           padding: 16px;

--- a/src/ChatItem/style.ts
+++ b/src/ChatItem/style.ts
@@ -9,7 +9,6 @@ export const useStyles = createStyles(
       title,
       primary,
       avatarSize,
-      showTitle,
       editing,
     }: {
       avatarSize?: number;
@@ -173,6 +172,7 @@ export const useStyles = createStyles(
           position: relative;
           overflow: hidden;
           max-width: 100%;
+          margin-top: -16px;
 
           ${responsive.mobile} {
             overflow-x: auto;
@@ -193,11 +193,6 @@ export const useStyles = createStyles(
       ),
       messageExtra: cx('message-extra'),
       name: css`
-        position: ${showTitle ? 'relative' : 'absolute'};
-        top: ${showTitle ? 'unset' : '-16px'};
-        right: ${placement === 'right' ? '0' : 'unset'};
-        left: ${placement === 'left' ? '0' : 'unset'};
-
         margin-bottom: 6px;
 
         font-size: 12px;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

Close: https://github.com/lobehub/lobe-chat/issues/1140

我看之前是 @canisminor1990 为了处理报错信息 https://github.com/lobehub/lobe-ui/commit/7c21f47d8d0c0d5866498b99addb80d8e5882e24#diff-8d2be2777c93df37569ab0218f9dbe44c9788721797faf5842480a6387d802aeR65 所以加的 overflow: hide，修改后这种情况不受影响

<img width="570" alt="image" src="https://github.com/lobehub/lobe-ui/assets/29084441/4d4185c9-5ab0-43d4-91f3-d495e8b5fea7">

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
文档预览正常
<img width="706" alt="image" src="https://github.com/lobehub/lobe-ui/assets/29084441/270eaff6-d7b8-4925-be8e-d2fff0f3227f">
左侧消息正常
<img width="528" alt="image" src="https://github.com/lobehub/lobe-ui/assets/29084441/e85f1afc-7629-46aa-9acc-64ed005af6b3">
右侧消息正常
<img width="306" alt="image" src="https://github.com/lobehub/lobe-ui/assets/29084441/01124618-dfe5-47c4-9267-d72927ae9a8d">
不知道别的地方会有影响不 @arvinxx @canisminor1990 

