### PR TITLE
💄 fix: mobile tab bugs

### DIFF
--- a/src/MobileTabBar/style.ts
+++ b/src/MobileTabBar/style.ts
@@ -38,7 +38,8 @@ export const useStyles = createStyles(({ css, token }) => {
       width: 100%;
 
       font-size: 12px;
-      line-height: 1;
+      line-height: 1.125em;
+      margin-top: -0.125em;
       text-align: center;
       text-overflow: ellipsis;
       white-space: nowrap;

--- a/src/MobileTabBar/style.ts
+++ b/src/MobileTabBar/style.ts
@@ -9,6 +9,7 @@ export const useStyles = createStyles(({ css, token }) => {
     container: css`
       overflow: hidden;
       flex: none;
+      user-select: none;
 
       width: 100vw;
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type
- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change
This change fixes two styling bugs for the mobile tabs:
<ul>
<li> The descender is cut of <br/>
<img width="204"  alt="Bildschirmfoto 2024-02-24 um 15 37 22" src="https://github.com/lobehub/lobe-ui/assets/7888005/ab5ee69f-1c00-4c73-bcf7-bc5efb4dcd89">
<img width="209" alt="Bildschirmfoto 2024-02-24 um 15 37 54" src="https://github.com/lobehub/lobe-ui/assets/7888005/f5ceac48-85f6-4daa-97ca-cc16a587fc5b">
</li>
<li> Accidental selection of the tab title <br/>
<img width="204"  alt="Bildschirmfoto 2024-02-24 um 15 37 22" src="https://github.com/lobehub/lobe-ui/assets/7888005/1ebed6a5-2262-4bbe-807e-336fcab27ef0">
</li>
</ul>
