### PR TITLE
Update style.ts

### DIFF
--- a/src/DraggablePanel/style.ts
+++ b/src/DraggablePanel/style.ts
@@ -32,7 +32,7 @@ export const useStyles = createStyles(
       pointer-events: ${showHandlerWideArea ? 'all' : 'none'};
 
       position: absolute;
-      z-index: 101;
+      z-index: 10;
 
       opacity: 0;
 

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -9,8 +9,8 @@ export type TooltipProps = AntdTooltipProps;
 
 const Tooltip = memo<TooltipProps>(({ className, arrow = false, ...rest }) => {
   const { styles, cx } = useStyles();
-
-  return <AntdTooltip arrow={arrow} overlayClassName={cx(styles.tooltip, className)} {...rest} />;
+  const isMobile = /android|iphone|ipad|ipod/i.test(navigator.userAgent);
+  return <AntdTooltip arrow={arrow} overlayClassName={cx(styles.tooltip, className)} trigger={isMobile ? 'click' : 'hover'} {...rest} />;
 });
 
 export default Tooltip;

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -9,8 +9,8 @@ export type TooltipProps = AntdTooltipProps;
 
 const Tooltip = memo<TooltipProps>(({ className, arrow = false, ...rest }) => {
   const { styles, cx } = useStyles();
-  const isMobile = /android|iphone|ipad|ipod/i.test(navigator.userAgent);
-  return <AntdTooltip arrow={arrow} overlayClassName={cx(styles.tooltip, className)} trigger={isMobile ? 'click' : 'hover'} {...rest} />;
+
+  return <AntdTooltip arrow={arrow} overlayClassName={cx(styles.tooltip, className)} {...rest} />;
 });
 
 export default Tooltip;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

隔壁 LobeHub 的“上传图片”提示页 z-index: 10000000 效果被父元素 z-index: 10 覆盖，导致出现下面的层次错误。

修改本处 z-index 是最简易的解决方案，或者考虑重新安排 LobeHub 相关元素的层叠情况。

#### 📝 补充信息 | Additional Information

（注意中间的“向下折叠”按钮，还有侧边栏“向左折叠”按钮也会显示）

![image](https://github.com/lobehub/lobe-ui/assets/20513115/9f1dd39d-6076-4fd8-a53e-0e59f4206848)

此为“上传图片”提示页的父元素。

![image](https://github.com/lobehub/lobe-ui/assets/20513115/bd543b4e-9f54-4849-86fa-e6174e696f34)

