### PR TITLE
💄 style: Add `...rest` to Drawer

### DIFF
--- a/src/Modal/index.tsx
+++ b/src/Modal/index.tsx
@@ -141,6 +141,7 @@ const Modal = memo<ModalProps>(
             ...restStyles,
           }}
           title={title}
+          {...rest}
         >
           {children}
         </Drawer>


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

使移动端 Drawer 能引入剩余属性，主要目标是 zIndex。从而使模型选取下拉框不会覆盖自定义模型配置页。

#### 📝 补充信息 | Additional Information

https://github.com/lobehub/lobe-chat/pull/2318#discussion_r1589921691
