### PR TITLE
💄 style: Expose `tooltip` overlayStyle prop

### DIFF
--- a/src/ActionIcon/index.tsx
+++ b/src/ActionIcon/index.tsx
@@ -47,7 +47,7 @@ export interface ActionIconProps extends LucideIconProps, FlexboxProps {
    * @description Set the loading status of ActionIcon
    */
   loading?: boolean;
-
+  overlayStyle?: React.CSSProperties;
   /**
    * @description The position of the tooltip relative to the target
    * @enum ["top","left","right","bottom","topLeft","topRight","bottomLeft","bottomRight","leftTop","leftBottom","rightTop","rightBottom"]
@@ -94,6 +94,7 @@ const ActionIcon = forwardRef<HTMLDivElement, ActionIconProps>(
       onClick,
       children,
       loading,
+      overlayStyle,
       tooltipDelay = 0.5,
       fillOpacity,
       fillRule,
@@ -145,7 +146,7 @@ const ActionIcon = forwardRef<HTMLDivElement, ActionIconProps>(
       <Tooltip
         arrow={arrow}
         mouseEnterDelay={tooltipDelay}
-        overlayStyle={{ pointerEvents: 'none', maxWidth: '500px' }}
+        overlayStyle={{ pointerEvents: 'none', ...overlayStyle }}
         placement={placement}
         title={title}
       >

--- a/src/ActionIcon/index.tsx
+++ b/src/ActionIcon/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import React from 'react';
 import { Loader2 } from 'lucide-react';
 import { forwardRef, useMemo } from 'react';
 import { Flexbox, type FlexboxProps } from 'react-layout-kit';

--- a/src/ActionIcon/index.tsx
+++ b/src/ActionIcon/index.tsx
@@ -145,7 +145,7 @@ const ActionIcon = forwardRef<HTMLDivElement, ActionIconProps>(
       <Tooltip
         arrow={arrow}
         mouseEnterDelay={tooltipDelay}
-        overlayStyle={{ pointerEvents: 'none' }}
+        overlayStyle={{ pointerEvents: 'none', maxWidth: '500px' }}
         placement={placement}
         title={title}
       >


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

由于 Antd Tooltip 默认限制宽度为 250px，导致出现以下问题。

![image](https://github.com/lobehub/lobe-ui/assets/20513115/aeed1e6e-46f9-4b41-9d88-505d39980955)

更改后：

![image](https://github.com/lobehub/lobe-ui/assets/20513115/7d773095-3c2e-4458-90ce-f85aba49fd79)


#### 📝 补充信息 | Additional Information

另可考虑设置为 'none' 。
