### PR TITLE
🐛 fix: do not break in-between words in tooltips

### DIFF
--- a/src/Tooltip/style.ts
+++ b/src/Tooltip/style.ts
@@ -13,7 +13,7 @@ export const useStyles = createStyles(({ css, token, prefixCls }) => {
         padding-inline: 8px;
 
         color: ${token.colorBgLayout};
-        word-break: break-all;
+        word-break: normal;
 
         background-color: ${token.colorText};
         border-radius: ${token.borderRadiusSM}px;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

This fixes the issue where contents of tooltips break in-between words make it both hard to read and aesthetically unpleasant. 

#### 📝 补充信息 | Additional Information

An example:

![CleanShot 2024-06-23 at 11 24 46@2x](https://github.com/lobehub/lobe-ui/assets/25026967/edc14569-cf0e-4601-8741-117ccb1f8fb8)


