### PR TITLE
🐛 fix: hydration mismatch in grid background

### DIFF
--- a/src/GridBackground/index.tsx
+++ b/src/GridBackground/index.tsx
@@ -22,6 +22,8 @@ export interface GridBackgroundProps extends DivProps {
   strokeWidth?: number;
 }
 
+const initialGroup = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
+
 const GridBackground = memo<GridBackgroundProps>(
   ({
     flip,
@@ -51,20 +53,18 @@ const GridBackground = memo<GridBackgroundProps>(
       [reverse, colorFront, strokeWidth],
     );
 
-    const [randomGroup, setRandomGroup] = useState(
-      random ? [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14] : undefined,
-    );
+    const [group, setGroup] = useState(random ? initialGroup : undefined);
     useEffect(() => {
-      setRandomGroup((randomGroup) => (randomGroup ? shuffle(randomGroup) : randomGroup));
-    }, []);
+      setGroup(random ? shuffle(initialGroup) : undefined);
+    }, [random]);
 
     const HighlightGrid = useCallback(() => {
-      if (!randomGroup)
+      if (!group)
         return <Grid style={{ '--duration': `${animationDuration}s` } as any} {...gridProps} />;
 
       return (
         <>
-          {randomGroup.map((item, index) => {
+          {group.map((item, index) => {
             return (
               <Grid
                 key={item}
@@ -81,7 +81,7 @@ const GridBackground = memo<GridBackgroundProps>(
           })}
         </>
       );
-    }, [randomGroup, animationDuration, gridProps]);
+    }, [group, animationDuration, gridProps]);
 
     return (
       <div

--- a/src/GridBackground/index.tsx
+++ b/src/GridBackground/index.tsx
@@ -2,7 +2,7 @@
 
 import { useSize } from 'ahooks';
 import { shuffle } from 'lodash-es';
-import { memo, useCallback, useMemo, useRef } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { DivProps } from '@/types';
 
@@ -51,14 +51,20 @@ const GridBackground = memo<GridBackgroundProps>(
       [reverse, colorFront, strokeWidth],
     );
 
+    const [randomGroup, setRandomGroup] = useState(
+      random ? [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14] : undefined,
+    );
+    useEffect(() => {
+      setRandomGroup((randomGroup) => (randomGroup ? shuffle(randomGroup) : randomGroup));
+    }, []);
+
     const HighlightGrid = useCallback(() => {
-      if (!random)
+      if (!randomGroup)
         return <Grid style={{ '--duration': `${animationDuration}s` } as any} {...gridProps} />;
 
-      const group = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
       return (
         <>
-          {shuffle(group).map((item, index) => {
+          {randomGroup.map((item, index) => {
             return (
               <Grid
                 key={item}
@@ -75,7 +81,7 @@ const GridBackground = memo<GridBackgroundProps>(
           })}
         </>
       );
-    }, [random, animationDuration, gridProps]);
+    }, [randomGroup, animationDuration, gridProps]);
 
     return (
       <div


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

There is a hydration mismatch because HighlightGrid is not pure (depends on shuffle), this fixes the problem by randomizing group in an effect.

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
