### PR TITLE
🐛 fix: alert contents should not break in the middle of a word

### DIFF
--- a/src/Alert/style.ts
+++ b/src/Alert/style.ts
@@ -38,7 +38,7 @@ export const useStyles = createStyles(
           .${prefixCls}-alert-message {
             font-weight: ${hasTitle ? 600 : 400};
             line-height: 24px;
-            word-break: break-all;
+            word-break: normal;
           }
           .${prefixCls}-alert-icon {
             display: flex;
@@ -57,7 +57,7 @@ export const useStyles = createStyles(
           css`
             .${prefixCls}-alert-description {
               line-height: 1.5;
-              word-break: break-all;
+              word-break: normal;
               opacity: 0.75;
             }
           `,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs
