### PR TITLE
🐛 fix: Handling invalid Markdown bold

### DIFF
--- a/src/ChatItem/type.ts
+++ b/src/ChatItem/type.ts
@@ -1,12 +1,11 @@
 import { ReactNode } from 'react';
-import { FlexboxProps } from 'react-layout-kit';
 
 import { AlertProps } from '@/Alert';
 import { AvatarProps } from '@/Avatar';
 import { EditableMessageProps } from '@/EditableMessage';
 import { DivProps, MetaData } from '@/types';
 
-export interface ChatItemProps extends FlexboxProps {
+export interface ChatItemProps {
   /**
    * @description Actions to be displayed in the chat item
    */

--- a/src/ChatItem/type.ts
+++ b/src/ChatItem/type.ts
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { FlexboxProps } from 'react-layout-kit';
 
 import { AlertProps } from '@/Alert';
 import { AvatarProps } from '@/Avatar';

--- a/src/Markdown/index.tsx
+++ b/src/Markdown/index.tsx
@@ -21,7 +21,7 @@ import { CodeFullFeatured, CodeLite } from './CodeBlock';
 import type { TypographyProps } from './Typography';
 import { useStyles as useMarkdownStyles } from './markdown.style';
 import { useStyles } from './style';
-import { escapeBrackets, escapeMhchem } from './utils';
+import { escapeBrackets, escapeMhchem, fixMarkdownBold } from './utils';
 
 export interface MarkdownProps extends TypographyProps {
   allowHtml?: boolean;
@@ -63,6 +63,11 @@ const Markdown = memo<MarkdownProps>(
     const { styles: mdStyles } = useMarkdownStyles({ fontSize, headerMultiple, marginMultiple });
     const isChatMode = variant === 'chat';
 
+    const escapedContent = useMemo(() => {
+      if (!enableLatex) return children;
+      return fixMarkdownBold(escapeMhchem(escapeBrackets(children)));
+    }, [children, enableLatex]);
+    
     const escapedContent = useMemo(() => {
       if (!enableLatex) return children;
       return escapeMhchem(escapeBrackets(children));

--- a/src/Markdown/index.tsx
+++ b/src/Markdown/index.tsx
@@ -62,15 +62,10 @@ const Markdown = memo<MarkdownProps>(
     const { cx, styles } = useStyles({ fontSize, headerMultiple, lineHeight, marginMultiple });
     const { styles: mdStyles } = useMarkdownStyles({ fontSize, headerMultiple, marginMultiple });
     const isChatMode = variant === 'chat';
-
-    const escapedContent = useMemo(() => {
-      if (!enableLatex) return children;
-      return fixMarkdownBold(escapeMhchem(escapeBrackets(children)));
-    }, [children, enableLatex]);
     
     const escapedContent = useMemo(() => {
-      if (!enableLatex) return children;
-      return escapeMhchem(escapeBrackets(children));
+      if (!enableLatex) return fixMarkdownBold(children);
+      return fixMarkdownBold(escapeMhchem(escapeBrackets(children)));
     }, [children, enableLatex]);
 
     const components: Components = useMemo(

--- a/src/Markdown/utils.test.ts
+++ b/src/Markdown/utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { fixMarkdownBold } from './utils';
+
+describe('fixMarkdownBold', () => {
+  it('should add space after closing bold markers if needed', () => {
+    expect(fixMarkdownBold('**123：**456')).toBe('**123：** 456');
+    expect(fixMarkdownBold('**bold text**')).toBe('**bold text**');
+    expect(fixMarkdownBold('**bold text** and more')).toBe('**bold text** and more');
+    expect(fixMarkdownBold('**123**456')).toBe('**123**456');
+  });
+
+  it('should handle multiple bold sections', () => {
+    expect(fixMarkdownBold('**bold1** **bold2**')).toBe('**bold1** **bold2**');
+    expect(fixMarkdownBold('**123：**456**789:**123')).toBe('**123：** 456**789:** 123');
+  });
+
+  it('should not affect text without bold markers', () => {
+    expect(fixMarkdownBold('normal text')).toBe('normal text');
+  });
+
+  it('should not affect empty strings', () => {
+    expect(fixMarkdownBold('')).toBe('');
+  });
+
+  it('should handle odd number of asterisks', () => {
+    expect(fixMarkdownBold('*text* *')).toBe('*text* *');
+  });
+
+  it('should handle asterisks within words', () => {
+    expect(fixMarkdownBold('t*e*st')).toBe('t*e*st');
+  });
+});

--- a/src/Markdown/utils.ts
+++ b/src/Markdown/utils.ts
@@ -24,7 +24,10 @@ export function fixMarkdownBold(text: string): string {
     if (char === '*') {
       count++;
       if (count % 2 === 0) {
-        if (i + 1 < text.length && text[i + 1] !== ' ') {
+        const prevChar = i > 0 ? text[i - 1] : '';
+        const isPrevCharAlphanumeric = /[a-zA-Z0-9]/.test(prevChar);
+
+        if (i + 1 < text.length && text[i + 1] !== ' ' && !isPrevCharAlphanumeric) {
           result += '* ';
         } else {
           result += '*';

--- a/src/Markdown/utils.ts
+++ b/src/Markdown/utils.ts
@@ -18,31 +18,35 @@ export function escapeMhchem(text: string) {
 
 export function fixMarkdownBold(text: string): string {
   let count = 0;
+  let count2 = 0;
   let result = '';
   for (let i = 0; i < text.length; i++) {
     const char = text[i];
     if (char === '*') {
       count++;
-      if (count % 2 === 0) {
-        const prevChar = i > 0 ? text[i - 1] : '';
-        const nextChar = i + 1 < text.length ? text[i + 1] : '';
+      if (count === 2) {
+        count2++;
+      }
+      if (count > 2) {
+        result += char;
+        continue;
+      }
+      if (count === 2 && count2 % 2 === 0) {
+        const prevChar = i > 0 ? text[i - 2] : '';
         const isPrevCharAlphanumeric = /[a-zA-Z0-9]/.test(prevChar);
-        const isNextCharAlphanumeric = /[a-zA-Z0-9]/.test(nextChar);
 
-        if (!isPrevCharAlphanumeric && isNextCharAlphanumeric) {
-          result += '*';
-        } else if (isPrevCharAlphanumeric && !isNextCharAlphanumeric) {
-          result += '*';
-        } else {
+        if (i + 1 < text.length && text[i + 1] !== ' ' && !isPrevCharAlphanumeric) {
           result += '* ';
+        } else {
+          result += '*';
         }
       } else {
         result += '*';
       }
     } else {
       result += char;
+      count = 0;
     }
   }
   return result;
 }
-

--- a/src/Markdown/utils.ts
+++ b/src/Markdown/utils.ts
@@ -25,12 +25,16 @@ export function fixMarkdownBold(text: string): string {
       count++;
       if (count % 2 === 0) {
         const prevChar = i > 0 ? text[i - 1] : '';
+        const nextChar = i + 1 < text.length ? text[i + 1] : '';
         const isPrevCharAlphanumeric = /[a-zA-Z0-9]/.test(prevChar);
+        const isNextCharAlphanumeric = /[a-zA-Z0-9]/.test(nextChar);
 
-        if (i + 1 < text.length && text[i + 1] !== ' ' && !isPrevCharAlphanumeric) {
-          result += '* ';
-        } else {
+        if (!isPrevCharAlphanumeric && isNextCharAlphanumeric) {
           result += '*';
+        } else if (isPrevCharAlphanumeric && !isNextCharAlphanumeric) {
+          result += '*';
+        } else {
+          result += '* ';
         }
       } else {
         result += '*';
@@ -41,3 +45,4 @@ export function fixMarkdownBold(text: string): string {
   }
   return result;
 }
+

--- a/src/Markdown/utils.ts
+++ b/src/Markdown/utils.ts
@@ -15,3 +15,26 @@ export function escapeBrackets(text: string) {
 export function escapeMhchem(text: string) {
   return text.replaceAll('$\\ce{', '$\\\\ce{').replaceAll('$\\pu{', '$\\\\pu{');
 }
+
+export function fixMarkdownBold(text: string): string {
+  let count = 0;
+  let result = '';
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+    if (char === '*') {
+      count++;
+      if (count % 2 === 0) {
+        if (i + 1 < text.length && text[i + 1] !== ' ') {
+          result += '* ';
+        } else {
+          result += '*';
+        }
+      } else {
+        result += '*';
+      }
+    } else {
+      result += char;
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

处理类似 `**123：**456` 的无效粗体，在偶数个 `**` 之后自动添加空格。

这其实属于 Markdown 固有缺陷，或者大模型不应输出此类结果，但至少 Gemini 热衷于输出此种格式。

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
