### PR TITLE
Fix markdown styles in safari

### DIFF
--- a/src/Markdown/markdown.style.ts
+++ b/src/Markdown/markdown.style.ts
@@ -263,7 +263,10 @@ export const useStyles = createStyles(
       `,
       p: css`
         p {
-          margin-block: calc(var(--lobe-markdown-margin-multiple) * 1em);
+          /* stylelint-disable declaration-block-no-redundant-longhand-properties */
+          margin-block-start: calc(var(--lobe-markdown-margin-multiple) * 1em);
+          margin-block-end: calc(var(--lobe-markdown-margin-multiple) * 1em);
+          /* stylelint-enable declaration-block-no-redundant-longhand-properties */
           line-height: var(--lobe-markdown-line-height);
           letter-spacing: 0.02em;
         }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change
Optimize the compatibility of Markdown styles in the Safari browser to fix the issue with the incorrect display of the ChatItem component.
[ChatItem](https://ui.lobehub.com/components/chat-item)
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
