### PR TITLE
🐛 fix: Code blocks cannot switch highlight languages

### DIFF
--- a/src/Highlighter/FullFeatured.tsx
+++ b/src/Highlighter/FullFeatured.tsx
@@ -1,12 +1,13 @@
 import { Select, type SelectProps } from 'antd';
 import { ChevronDown, ChevronRight } from 'lucide-react';
-import { ReactNode, memo, useState } from 'react';
+import React, { ReactNode, memo, useState } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
 import ActionIcon from '@/ActionIcon';
 import CopyButton from '@/CopyButton';
 import { languageMap } from '@/hooks/useHighlight';
 
+import SyntaxHighlighter from './SyntaxHighlighter';
 import { useStyles } from './style';
 import { HighlighterProps } from './type';
 
@@ -19,6 +20,20 @@ interface HighlighterFullFeaturedProps extends Omit<HighlighterProps, 'children'
   children: ReactNode;
   content: string;
 }
+
+const convertChildrenToString = (children: ReactNode): string => {
+  return React.Children.toArray(children)
+    .map((child) => {
+      if (typeof child === 'string' || typeof child === 'number') {
+        return child;
+      }
+      if (React.isValidElement(child)) {
+        return convertChildrenToString((child as any).props.children);
+      }
+      return '';
+    })
+    .join('');
+};
 
 export const HighlighterFullFeatured = memo<HighlighterFullFeaturedProps>(
   ({
@@ -55,6 +70,8 @@ export const HighlighterFullFeatured = memo<HighlighterFullFeaturedProps>(
           originalNode: origianlActions,
         })
       : origianlActions;
+
+    const childrenString = convertChildrenToString(children).trim();
 
     return (
       <div
@@ -97,7 +114,7 @@ export const HighlighterFullFeatured = memo<HighlighterFullFeaturedProps>(
             {actions}
           </Flexbox>
         </Flexbox>
-        {children}
+        <SyntaxHighlighter language={lang}>{childrenString}</SyntaxHighlighter>
       </div>
     );
   },


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

原本切换代码框顶部的语言，高亮不会跟随切换。

由于不熟悉项目，采用的是非常粗暴的方法，希望有更好的替代方案。

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
