### PR TITLE
🐛 fix: Fix Code blocks direction in lists

### DIFF
--- a/src/Highlighter/SyntaxHighlighter/style.ts
+++ b/src/Highlighter/SyntaxHighlighter/style.ts
@@ -15,18 +15,19 @@ export const useStyles = createStyles(({ css, token, cx, prefixCls, stylish }) =
         height: 34px;
         padding-block: 0;
         padding-inline: 8px;
+        border-radius: ${token.borderRadius};
 
         font-family: ${token.fontFamilyCode};
         color: ${token.colorTextTertiary};
-
-        border-radius: ${token.borderRadius};
       `,
     ),
     shiki: cx(
       `${prefix}-shiki`,
       css`
+        direction: ltr;
         margin: 0;
         padding: 0;
+        text-align: start;
 
         .shiki {
           overflow-x: auto;
@@ -69,10 +70,10 @@ export const useStyles = createStyles(({ css, token, cx, prefixCls, stylish }) =
           .highlighted-word {
             padding-block: 0.1em;
             padding-inline: 0.2em;
-
-            background: ${token.colorFillTertiary};
             border: 1px solid ${token.colorBorderSecondary};
             border-radius: ${token.borderRadius}px;
+
+            background: ${token.colorFillTertiary};
           }
 
           .diff {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- Fix code blocks direction in high level component styling (including list items)

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

I have changed `text-align` property of the shiki class style to `start` that all code blocks (in any component ) direction turn to ltr
