### PR TITLE
🐛 fix: fix latex `\tag` render issue

### DIFF
--- a/src/Markdown/demos/data.ts
+++ b/src/Markdown/demos/data.ts
@@ -115,10 +115,17 @@ f(x) = f(a) + f'(a)(x - a) + \\frac{f''(a)}{2!}(x - a)^2 + \\frac{f'''(a)}{3!}(x
 \\end{equation}
 $$
 
+我是上面公式的行内版本，看看我会不会折行：$ f(x) = f(a) + f'(a)(x - a) + \\frac{f''(a)}{2!}(x - a)^2 + \\frac{f'''(a)}{3!}(x - a)^3 + \\cdots + \\frac{f^{(n)}(a)}{n!}(x - a)^n + R_n(x) $
+
 
 我是一个带有上下标的公式：
 $$
-x^{2} + y^{2} = r^{2}
+q_1 q_2 = (w_1 w_2 - \\vec{v}_1^T \\vec{v}_2, \\, w_1 \\vec{v}_2 + w_2 \\vec{v}_1 + \\vec{v}_1 \\times \\vec{v}_2)
+$$
+
+我是一个带有 tag 的公式：
+$$
+q = a + bi + cj + dk \\tag{1}
 $$
 
 ---

--- a/src/Markdown/style.ts
+++ b/src/Markdown/style.ts
@@ -54,16 +54,12 @@ export const useStyles = createStyles(
             margin-block: 0;
             margin-inline: auto;
           }
-        }
 
-        .katex-html:has(span.tag) {
-          display: flex !important;
-        }
-
-        .katex-html > .tag {
-          position: relative !important;
-          float: right;
-          margin-inline-start: 0.25rem;
+          .tag {
+            position: relative !important;
+            display: inline-block;
+            padding-inline-start: 0.5rem;
+          }
         }
       `,
       root: css`


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

修复了 `\tag` 导致布局出问题的 Bug：

修复前：

![Discord 2025-03-07 17 27 22](https://github.com/user-attachments/assets/8530a7a3-9b41-4ce5-8338-3913187496b1)

修复后：

![image](https://github.com/user-attachments/assets/4980e795-98c4-47ea-aca3-31ea64091e75)


#### 📝 补充信息 | Additional Information

Ref: https://github.com/Locietta/blog-lost-pieces/commit/3f97d3ae49cca6fd31e0c10f33a0e5739743f0f4
