### PR TITLE
💄 style: remove draggablePanel toggle top area

### DIFF
--- a/src/DraggablePanel/style.ts
+++ b/src/DraggablePanel/style.ts
@@ -230,9 +230,9 @@ export const useStyles = createStyles(
       toggleTop: cx(
         `${prefix}-toggle-top`,
         css`
-          inset-block-start: -${LAYOUT.offset}px;
+          inset-block-start: -8px;
           width: 100%;
-          height: ${LAYOUT.toggleShort}px;
+          height: 0px;
 
           > div {
             inset-inline-start: 50%;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

![image](https://github.com/user-attachments/assets/ff2de568-e0a4-4782-8108-f75899d3b8a8)

如图的触发区域，屏蔽了原本的鼠标操作，不论是选中文字还是拖动右侧滚动条。

也可以讨论下有无更优方案。

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
