### PR TITLE
💄 style: Allow `SliderWithInput` to have no input limit

### DIFF
--- a/src/SliderWithInput/SliderWithInput.tsx
+++ b/src/SliderWithInput/SliderWithInput.tsx
@@ -25,6 +25,7 @@ const SliderWithInput = memo<SliderWithInputProps>(
     classNames,
     styles,
     disabled,
+    unlimitedInput = false,
     ...rest
   }) => {
     const handleOnchange = (value: number | null) => {
@@ -63,7 +64,7 @@ const SliderWithInput = memo<SliderWithInputProps>(
           controls={size !== 'small' || controls}
           defaultValue={defaultValue}
           disabled={disabled}
-          max={max}
+          max={unlimitedInput ? undefined : max}
           min={min}
           onChange={(v) => handleOnchange(Number(v))}
           size={size}

--- a/src/SliderWithInput/SliderWithInput.tsx
+++ b/src/SliderWithInput/SliderWithInput.tsx
@@ -14,7 +14,7 @@ const SliderWithInput = memo<SliderWithInputProps>(
     step,
     value,
     onChange,
-    max,
+    max = 100,
     min,
     defaultValue,
     size,

--- a/src/SliderWithInput/demos/index.tsx
+++ b/src/SliderWithInput/demos/index.tsx
@@ -3,5 +3,5 @@ import { useState } from 'react';
 
 export default () => {
   const [value, setValue] = useState(0);
-  return <SliderWithInput onChange={setValue} style={{ width: 300 }} value={value} />;
+  return <SliderWithInput max={100} onChange={setValue} style={{ width: 300 }} value={value} />;
 };

--- a/src/SliderWithInput/index.md
+++ b/src/SliderWithInput/index.md
@@ -11,16 +11,17 @@ description: SliderWithInput combines a slider with an input number field, allow
 
 ## APIs
 
-| Property     | Description                              | Type                                                | Default |
-| ------------ | ---------------------------------------- | --------------------------------------------------- | ------- |
-| value        | Current value                            | `number`                                            | -       |
-| defaultValue | Default value                            | `number`                                            | -       |
-| min          | Minimum value                            | `number`                                            | -       |
-| max          | Maximum value                            | `number`                                            | -       |
-| step         | Value step for slider and input          | `number`                                            | -       |
-| size         | Size of the input field                  | `'small' \| 'middle' \| 'large'`                    | -       |
-| controls     | Whether to show number controls in input | `boolean`                                           | -       |
-| gap          | Space between slider and input           | `number`                                            | `16`    |
-| disabled     | Whether component is disabled            | `boolean`                                           | -       |
-| styles       | Custom styles for components             | `{ input?: CSSProperties; slider?: CSSProperties }` | -       |
-| classNames   | Custom class names for components        | `{ input?: string; slider?: string }`               | -       |
+| Property       | Description                                   | Type                                                | Default |
+| -------------- | --------------------------------------------- | --------------------------------------------------- | ------- |
+| value          | Current value                                 | `number`                                            | -       |
+| defaultValue   | Default value                                 | `number`                                            | -       |
+| min            | Minimum value                                 | `number`                                            | -       |
+| max            | Maximum value                                 | `number`                                            | `100`   |
+| step           | Value step for slider and input               | `number`                                            | -       |
+| size           | Size of the input field                       | `'small' \| 'middle' \| 'large'`                    | -       |
+| controls       | Whether to show number controls in input      | `boolean`                                           | -       |
+| gap            | Space between slider and input                | `number`                                            | `16`    |
+| disabled       | Whether component is disabled                 | `boolean`                                           | -       |
+| unlimitedInput | Whether the input number field has max limits | `boolean`                                           | `false` |
+| styles         | Custom styles for components                  | `{ input?: CSSProperties; slider?: CSSProperties }` | -       |
+| classNames     | Custom class names for components             | `{ input?: string; slider?: string }`               | -       |

--- a/src/SliderWithInput/type.ts
+++ b/src/SliderWithInput/type.ts
@@ -16,5 +16,6 @@ export interface SliderWithInputProps extends Omit<SliderSingleProps, 'className
     input?: CSSProperties;
     slider?: CSSProperties;
   } & SliderSingleProps['styles'];
+  unlimitedInput?: boolean; // 不限制输入框最大值
   variant?: InputNumberProps['variant'];
 }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

在一些参数调节中，SliderWithInput 的最大值作为滑块范围，可能无法照顾到所有场景。

这边增加了一个属性，允许在输入框输入比滑块滑至最右更大的值。

这边也在思考，是允许输入框输入值无限大，还是把增加的属性值作为输入框单独的最大值，似乎没有必要？

### 同时将默认 max 设为了 100，以匹配 antd 滑块自带的 100 最大值。

#### 📝 补充信息 | Additional Information

~~还未测试，等待构建~~

测试了一下，应该能用。
