### PR TITLE
:rotating_light: fix: do not directly re-export antd's internal type

### DIFF
--- a/src/Img/index.tsx
+++ b/src/Img/index.tsx
@@ -4,25 +4,25 @@ import type { ImageProps } from 'antd';
 import { type ElementType, Ref, createElement, memo, use, useMemo } from 'react';
 
 import { ConfigContext } from '@/ConfigProvider';
-import type { ImgProps } from '@/types';
+import type { ImgProps as HtmlImgeProps } from '@/types';
 
 const createContainer = (as: ElementType) => memo((props: any) => createElement(as, props));
 
-const Img = memo<ImgProps & ImageProps & { ref?: Ref<HTMLImageElement>; unoptimized?: boolean }>(
-  ({ unoptimized, ...rest }) => {
-    const config = use(ConfigContext);
-    const render = config?.imgAs || 'img';
+type ImgProps = HtmlImgeProps & ImageProps & { ref?: Ref<HTMLImageElement>; unoptimized?: boolean };
 
-    const ImgContainer = useMemo(() => createContainer(render), [render]);
+const Img = memo<ImgProps>(({ unoptimized, ...rest }) => {
+  const config = use(ConfigContext);
+  const render = config?.imgAs || 'img';
 
-    return (
-      <ImgContainer
-        unoptimized={unoptimized === undefined ? config?.imgUnoptimized : unoptimized}
-        {...rest}
-      />
-    );
-  },
-);
+  const ImgContainer = useMemo(() => createContainer(render), [render]);
+
+  return (
+    <ImgContainer
+      unoptimized={unoptimized === undefined ? config?.imgUnoptimized : unoptimized}
+      {...rest}
+    />
+  );
+});
 
 Img.displayName = 'Img';
 

--- a/src/brand/Logo3d/index.tsx
+++ b/src/brand/Logo3d/index.tsx
@@ -9,9 +9,11 @@ import { ImgProps } from '@/types';
 
 import { LOGO_3D } from '../LobeHub/style';
 
-const Logo3d = memo<
-  Omit<ImgProps & ImageProps, 'width' | 'height' | 'src'> & { size?: number | string }
->(({ size = '1em', style, alt = 'LobeHub', ...rest }) => {
+type Logo3dProps = Omit<ImgProps & ImageProps, 'width' | 'height' | 'src'> & {
+  size?: number | string;
+};
+
+const Logo3d = memo<Logo3dProps>(({ size = '1em', style, alt = 'LobeHub', ...rest }) => {
   const genCdnUrl = useCdnFn();
   return (
     <Img alt={alt} height={size} src={genCdnUrl(LOGO_3D)} style={style} width={size} {...rest} />


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Currently, when we build the library with a fresh environment (i.e. no `bun.lockb` file), we will get the error like below:

```
event - Generate declaration files...
error - src/Img/index.tsx:11:7 - TS4023: Exported variable 'Img' has or is using name 'PreviewType' from external module "/home/runner/work/lobe-msm-build/lobe-ui/node_modules/antd/es/image/index" but cannot be named.
error - src/brand/Logo3d/index.tsx:12:7 - TS4023: Exported variable 'Logo3d' has or is using name 'PreviewType' from external module "/home/runner/work/lobe-msm-build/lobe-ui/node_modules/antd/es/image/index" but cannot be named.
error - src/Img/index.tsx:11:7 - TS4023: Exported variable 'Img' has or is using name 'PreviewType' from external module "/home/runner/work/lobe-msm-build/lobe-ui/node_modules/antd/es/image/index" but cannot be named.
error - src/brand/Logo3d/index.tsx:12:7 - TS4023: Exported variable 'Logo3d' has or is using name 'PreviewType' from external module "/home/runner/work/lobe-msm-build/lobe-ui/node_modules/antd/es/image/index" but cannot be named.
error - Error: Declaration generation failed.
    at getDeclarations (/home/runner/work/lobe-msm-build/lobe-ui/node_modules/father/dist/builder/bundless/dts/index.js:200:19)
    at transformFiles (/home/runner/work/lobe-msm-build/lobe-ui/node_modules/father/dist/builder/bundless/index.js:111:58)
    at async bundless (/home/runner/work/lobe-msm-build/lobe-ui/node_modules/father/dist/builder/bundless/index.js:141:17)
    at async builder (/home/runner/work/lobe-msm-build/lobe-ui/node_modules/father/dist/builder/index.js:48:25)
    at async Command.fn (/home/runner/work/lobe-msm-build/lobe-ui/node_modules/father/dist/commands/build.js:15:13)
    at async Service.run (/home/runner/work/lobe-msm-build/lobe-ui/node_modules/@umijs/core/dist/service/service.js:328:15)
    at async Service.run2 (/home/runner/work/lobe-msm-build/lobe-ui/node_modules/father/dist/service/service.js:58:16)
    at async Object.run (/home/runner/work/lobe-msm-build/lobe-ui/node_modules/father/dist/cli/cli.js:37:9)
error: script "build" exited with code 1
```

This is caused by using `ImageProps` from `antd` as a part of the type of our exported components. `ImageProps` internally uses the private (i.e. not exported) `PreviewType`, and when TypeScript exports the type of our components, it tries to refer `PreviewType` which is not exported, thus "unnamed" (unable to name it an appropriate name), leading the errors above.

A simple solution here is to give a name to our components' type once, so that TypeScript can avoid to refer the internal `PreviewType`.


#### 📝 补充信息 | Additional Information

To reproduce the errors, do not forget to remove `bun.lockb` in your env, as perhaps https://github.com/ant-design/ant-design/pull/53739 3 days ago introduced this errors.

<!-- Add any other context about the Pull Request here. -->
