### PR TITLE
🐛 fix: `_` cause rendering failure in text mode

### DIFF
--- a/src/hooks/useMarkdown/latex.test.ts
+++ b/src/hooks/useMarkdown/latex.test.ts
@@ -2,6 +2,7 @@ import {
   convertLatexDelimiters,
   escapeLatexPipes,
   escapeMhchemCommands,
+  escapeTextUnderscores,
   isLastFormulaRenderable,
   preprocessLaTeX,
 } from './latex';
@@ -183,5 +184,43 @@ describe('isLastFormulaRenderable', () => {
     // This should attempt to render "x^{" and return false since it's invalid
     // Note: This test assumes that "x^{" is invalid LaTeX which the renderer will reject
     expect(isLastFormulaRenderable('Text $$formula1$$ $$x^{')).toBe(false);
+  });
+});
+
+describe('escapeTextUnderscores', () => {
+  test('escapes underscores within \\text{} commands', () => {
+    const content = '$\\text{node_domain}$';
+    const expected = '$\\text{node\\_domain}$';
+    expect(escapeTextUnderscores(content)).toBe(expected);
+  });
+
+  test('escapes multiple underscores within \\text{} commands', () => {
+    const content = '$\\text{node_domain_name}$';
+    const expected = '$\\text{node\\_domain\\_name}$';
+    expect(escapeTextUnderscores(content)).toBe(expected);
+  });
+
+  test('escapes underscores in multiple \\text{} commands', () => {
+    const content = '$\\text{node_domain}$ and $\\text{user_name}$';
+    const expected = '$\\text{node\\_domain}$ and $\\text{user\\_name}$';
+    expect(escapeTextUnderscores(content)).toBe(expected);
+  });
+
+  test('does not affect text without \\text{} commands', () => {
+    const content = 'This is a regular_text with underscores';
+    expect(escapeTextUnderscores(content)).toBe(content);
+  });
+
+  test('does not modify \\text{} commands without underscores', () => {
+    const content = '$\\text{regular text}$';
+    expect(escapeTextUnderscores(content)).toBe(content);
+  });
+
+  test('handles complex mixed content', () => {
+    const content =
+      'LaTeX $x^2 + \\text{var_name}$ and $\\text{no underscore} + \\text{with_score}$';
+    const expected =
+      'LaTeX $x^2 + \\text{var\\_name}$ and $\\text{no underscore} + \\text{with\\_score}$';
+    expect(escapeTextUnderscores(content)).toBe(expected);
   });
 });

--- a/src/hooks/useMarkdown/latex.ts
+++ b/src/hooks/useMarkdown/latex.ts
@@ -54,6 +54,27 @@ export function escapeLatexPipes(text: string): string {
 }
 
 /**
+ * Escapes underscores within \text{...} commands in LaTeX expressions.
+ * For example, \text{node_domain} becomes \text{node\_domain}.
+ * This function processes the content of \text{} blocks to replace all
+ * occurrences of '_' with '\_'.
+ *
+ * @param text The input string potentially containing LaTeX expressions
+ * @returns The string with underscores escaped within \text{...} commands
+ */
+export function escapeTextUnderscores(text: string): string {
+  // This regular expression finds all \text{...} blocks.
+  // For each match, it takes the content inside the braces (the first capture group),
+  // replaces all underscores '_' with '\_', and then reconstructs the \text{...} command.
+  return text.replaceAll(/\\text{([^}]*)}/g, (match, textContent) => {
+    // match is the full matched string, e.g., "\text{node_domain}"
+    // textContent is the content within the braces, e.g., "node_domain"
+    const escapedTextContent = textContent.replaceAll('_', '\\_');
+    return `\\text{${escapedTextContent}}`;
+  });
+}
+
+/**
  * Preprocesses LaTeX content by performing multiple operations:
  * 1. Protects code blocks from processing
  * 2. Protects existing LaTeX expressions
@@ -66,40 +87,41 @@ export function escapeLatexPipes(text: string): string {
  */
 export function preprocessLaTeX(str: string): string {
   // Step 1: Protect code blocks
-  const codeBlocks: string[] = [];
-  let content = str.replaceAll(/(```[\S\s]*?```|`[^\n`]+`)/g, (match, code) => {
-    codeBlocks.push(code);
-    return `<<CODE_BLOCK_${codeBlocks.length - 1}>>`;
-  });
+  // const codeBlocks: string[] = [];
+  // let content = str.replaceAll(/(```[\S\s]*?```|`[^\n`]+`)/g, (match, code) => {
+  //   codeBlocks.push(code);
+  //   return `<<CODE_BLOCK_${codeBlocks.length - 1}>>`;
+  // });
 
-  // Step 2: Protect existing LaTeX expressions
-  const latexExpressions: string[] = [];
-  content = content.replaceAll(/(\$\$[\S\s]*?\$\$|\\\[[\S\s]*?\\]|\\\(.*?\\\))/g, (match) => {
-    latexExpressions.push(match);
-    return `<<LATEX_${latexExpressions.length - 1}>>`;
-  });
+  // // Step 2: Protect existing LaTeX expressions
+  // const latexExpressions: string[] = [];
+  // content = content.replaceAll(/(\$\$[\S\s]*?\$\$|\\\[[\S\s]*?\\]|\\\(.*?\\\))/g, (match) => {
+  //   latexExpressions.push(match);
+  //   return `<<LATEX_${latexExpressions.length - 1}>>`;
+  // });
 
   // Step 3: Escape dollar signs that are likely currency indicators
   // Deprecated, as it causes parsing errors for formulas starting with a number, such as `$1$`
   // content = content.replaceAll(/\$(?=\d)/g, '\\$');
 
   // Step 4: Restore LaTeX expressions
-  content = content.replaceAll(
-    /<<LATEX_(\d+)>>/g,
-    (_, index) => latexExpressions[Number.parseInt(index)],
-  );
+  // content = content.replaceAll(
+  //   /<<LATEX_(\d+)>>/g,
+  //   (_, index) => latexExpressions[Number.parseInt(index)],
+  // );
 
-  // Step 5: Restore code blocks
-  content = content.replaceAll(
-    /<<CODE_BLOCK_(\d+)>>/g,
-    (_, index) => codeBlocks[Number.parseInt(index)],
-  );
+  // // Step 5: Restore code blocks
+  // content = content.replaceAll(
+  //   /<<CODE_BLOCK_(\d+)>>/g,
+  //   (_, index) => codeBlocks[Number.parseInt(index)],
+  // );
+  let content = str;
 
   // Step 6: Apply additional escaping functions
   content = convertLatexDelimiters(content);
   content = escapeMhchemCommands(content);
   content = escapeLatexPipes(content);
-
+  content = escapeTextUnderscores(content);
   return content;
 }
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

![image](https://github.com/user-attachments/assets/909383ba-e9fb-491a-bb24-4ec4c01feb2b)

对于这种 \text 里有 _ 的统一前加转义符。 

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
