### PR TITLE
✨ feat add a DownloadButton component

### DIFF
--- a/src/DownloadButton/DownloadButton.tsx
+++ b/src/DownloadButton/DownloadButton.tsx
@@ -1,51 +1,28 @@
 'use client';
 
-import { Check, Download } from 'lucide-react';
+import { Download } from 'lucide-react';
 import React, { memo } from 'react';
 
 import ActionIcon from '@/ActionIcon';
-import { useCopied } from '@/hooks/useCopied';
 import { downloadBlob } from '@/utils/downloadBlob';
 
 import type { DownloadButtonProps } from './type';
 
 const DownloadButton = memo<DownloadButtonProps>(
-  ({
-    active,
-    blobUrl,
-    size,
-    icon,
-    glass = true,
-    onClick,
-    fileName = 'download',
-    fileType = 'svg',
-    disabled = false,
-    ...rest
-  }) => {
-    const { copied, setCopied } = useCopied();
-    const Icon = icon || Download;
-
-    const handleDownload = async (e: React.MouseEvent) => {
+  ({ fileName = 'download', fileType = 'svg', disabled = false, blobUrl, ...rest }) => {
+    const handleDownload = async () => {
       if (!blobUrl || disabled) return;
-
       try {
-        await downloadBlob(blobUrl, `${fileName}.${fileType}`);
-        setCopied();
-        onClick?.(e);
+        await downloadBlob(blobUrl, `${fileName.replace(/\.[^./]+$/, '')}.${fileType}`);
       } catch (error) {
         console.error('Download failed:', error);
       }
     };
-
     return (
       <ActionIcon
-        disabled={disabled || !blobUrl}
-        glass={glass}
-        size={size}
         title={`Download ${fileType.toUpperCase()}`}
         {...rest}
-        active={active || copied}
-        icon={copied ? Check : Icon}
+        icon={Download}
         onClick={handleDownload}
       />
     );

--- a/src/DownloadButton/DownloadButton.tsx
+++ b/src/DownloadButton/DownloadButton.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { Check, Download } from 'lucide-react';
+import React, { memo } from 'react';
+
+import ActionIcon from '@/ActionIcon';
+import { useCopied } from '@/hooks/useCopied';
+import { downloadBlob } from '@/utils/downloadBlob';
+
+import type { DownloadButtonProps } from './type';
+
+const DownloadButton = memo<DownloadButtonProps>(
+  ({
+    active,
+    blobUrl,
+    size,
+    icon,
+    glass = true,
+    onClick,
+    fileName = 'download',
+    fileType = 'svg',
+    disabled = false,
+    ...rest
+  }) => {
+    const { copied, setCopied } = useCopied();
+    const Icon = icon || Download;
+
+    const handleDownload = async (e: React.MouseEvent) => {
+      if (!blobUrl || disabled) return;
+
+      try {
+        await downloadBlob(blobUrl, `${fileName}.${fileType}`);
+        setCopied();
+        onClick?.(e);
+      } catch (error) {
+        console.error('Download failed:', error);
+      }
+    };
+
+    return (
+      <ActionIcon
+        disabled={disabled || !blobUrl}
+        glass={glass}
+        size={size}
+        title={`Download ${fileType.toUpperCase()}`}
+        {...rest}
+        active={active || copied}
+        icon={copied ? Check : Icon}
+        onClick={handleDownload}
+      />
+    );
+  },
+);
+
+DownloadButton.displayName = 'DownloadButton';
+
+export default DownloadButton;

--- a/src/DownloadButton/demos/customFile.tsx
+++ b/src/DownloadButton/demos/customFile.tsx
@@ -18,8 +18,8 @@ export default () => {
         value: false,
       },
       fileName: {
-        description: 'Name of the file to download (without extension)',
-        value: 'sample',
+        description: 'Name of the file to download ',
+        value: 'sample.json',
       },
       fileType: {
         description: 'Type of file to download',

--- a/src/DownloadButton/demos/customFile.tsx
+++ b/src/DownloadButton/demos/customFile.tsx
@@ -1,0 +1,107 @@
+import { DownloadButton } from '@lobehub/ui';
+import { StoryBook, useControls, useCreateStore } from '@lobehub/ui/storybook';
+import { useEffect, useState } from 'react';
+
+export default () => {
+  const store = useCreateStore();
+  const [blobUrl, setBlobUrl] = useState<string>('');
+
+  const options = useControls(
+    {
+      contentType: {
+        description: 'Type of content to download',
+        options: ['SVG Graphic', 'Text Content', 'JSON Data'],
+        value: 'SVG Graphic',
+      },
+      disabled: {
+        description: 'Disable the download button',
+        value: false,
+      },
+      fileName: {
+        description: 'Name of the file to download (without extension)',
+        value: 'sample',
+      },
+      fileType: {
+        description: 'Type of file to download',
+        options: ['svg', 'txt', 'json'],
+        value: 'svg',
+      },
+      glass: {
+        description: 'Apply glass effect to the button',
+        value: true,
+      },
+      size: {
+        description: 'Size of the download button',
+        options: ['small', 'normal', 'large'],
+        value: 'normal',
+      },
+    },
+    { store },
+  );
+
+  useEffect(() => {
+    let content = '';
+    let type = '';
+
+    switch (options.contentType) {
+      case 'SVG Graphic': {
+        content = `
+        <svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+          <rect width="200" height="200" fill="#e6f7ff" />
+          <circle cx="100" cy="100" r="50" fill="#1890ff" />
+          <text x="100" y="105" text-anchor="middle" dominant-baseline="middle" fill="white" font-size="14">
+            SVG Sample
+          </text>
+        </svg>
+      `;
+        type = 'image/svg+xml';
+
+        break;
+      }
+      case 'Text Content': {
+        content = 'Hello, this is a sample text file content.\nYou can download me as a text file!';
+        type = 'text/plain';
+
+        break;
+      }
+      case 'JSON Data': {
+        content = JSON.stringify(
+          {
+            description: 'This is a sample JSON file for download',
+            items: ['item1', 'item2', 'item3'],
+            name: 'Sample Data',
+            value: 12_345,
+          },
+          null,
+          2,
+        );
+        type = 'application/json';
+
+        break;
+      }
+      // No default
+    }
+
+    const blob = new Blob([content], { type });
+    const url = URL.createObjectURL(blob);
+    setBlobUrl(url);
+
+    return () => {
+      if (url) URL.revokeObjectURL(url);
+    };
+  }, [options.contentType]);
+
+  return (
+    <StoryBook levaStore={store}>
+      <DownloadButton
+        blobUrl={options.disabled ? undefined : blobUrl}
+        disabled={options.disabled}
+        fileName={options.fileName}
+        fileType={options.fileType}
+        glass={options.glass}
+        // @ts-ignore demo use correct type
+        size={options.size}
+      />
+    </StoryBook>
+  );
+};

--- a/src/DownloadButton/demos/index.tsx
+++ b/src/DownloadButton/demos/index.tsx
@@ -1,0 +1,10 @@
+import { DownloadButton } from '@lobehub/ui';
+
+export default () => {
+  const svgContent =
+    '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><circle cx="50" cy="50" r="40" fill="blue"/></svg>';
+  const blob = new Blob([svgContent], { type: 'image/svg+xml' });
+  const blobUrl = URL.createObjectURL(blob);
+
+  return <DownloadButton blobUrl={blobUrl} fileName="demo" fileType="svg" />;
+};

--- a/src/DownloadButton/index.md
+++ b/src/DownloadButton/index.md
@@ -17,17 +17,11 @@ description: DownloadButton is a React component used to download content from a
 
 ### DownloadButton
 
-| Property | Description                          | Type                            | Default    |
-| -------- | ------------------------------------ | ------------------------------- | ---------- |
-| blobUrl  | Blob URL for the content to download | `string`                        | -          |
-| fileName | File name (without extension)        | `string`                        | `download` |
-| fileType | File type/extension (e.g., svg, png) | `string`                        | `svg`      |
-| glass    | Apply glass effect to button         | `boolean`                       | `true`     |
-| icon     | Custom icon (before download)        | `ReactNode`                     | `Download` |
-| disabled | Disable the download button          | `boolean`                       | `false`    |
-| active   | Active state of the button           | `boolean`                       | `false`    |
-| size     | Size of the button                   | `ActionIconSize`                | `normal`   |
-| onClick  | Callback function on click           | `(e: React.MouseEvent) => void` | -          |
+| Property | Description                          | Type     | Default    |
+| -------- | ------------------------------------ | -------- | ---------- |
+| blobUrl  | Blob URL for the content to download | `string` | -          |
+| fileName | File name                            | `string` | `download` |
+| fileType | File type/extension (e.g., svg, png) | `string` | `svg`      |
 
 Additionally, DownloadButton inherits all properties from [ActionIcon](/components/action-icon) component except for
 those specified above. When clicked, it automatically changes the icon to a checkmark for 2 seconds to indicate

--- a/src/DownloadButton/index.md
+++ b/src/DownloadButton/index.md
@@ -1,0 +1,34 @@
+---
+nav: Components
+group: Data Entry
+title: DownloadButton
+description: DownloadButton is a React component used to download content from a Blob URL. It provides a button with a download icon that, when clicked, triggers a download of the specified content. It also displays a tooltip indicating the file type being downloaded.
+---
+
+## Default
+
+<code src="./demos/index.tsx" center></code>
+
+## Custom
+
+<code src="./demos/customFile.tsx"></code>
+
+## APIs
+
+### DownloadButton
+
+| Property | Description                          | Type                            | Default    |
+| -------- | ------------------------------------ | ------------------------------- | ---------- |
+| blobUrl  | Blob URL for the content to download | `string`                        | -          |
+| fileName | File name (without extension)        | `string`                        | `download` |
+| fileType | File type/extension (e.g., svg, png) | `string`                        | `svg`      |
+| glass    | Apply glass effect to button         | `boolean`                       | `true`     |
+| icon     | Custom icon (before download)        | `ReactNode`                     | `Download` |
+| disabled | Disable the download button          | `boolean`                       | `false`    |
+| active   | Active state of the button           | `boolean`                       | `false`    |
+| size     | Size of the button                   | `ActionIconSize`                | `normal`   |
+| onClick  | Callback function on click           | `(e: React.MouseEvent) => void` | -          |
+
+Additionally, DownloadButton inherits all properties from [ActionIcon](/components/action-icon) component except for
+those specified above. When clicked, it automatically changes the icon to a checkmark for 2 seconds to indicate
+successful download initiation.

--- a/src/DownloadButton/index.ts
+++ b/src/DownloadButton/index.ts
@@ -1,0 +1,2 @@
+export { default } from './DownloadButton';
+export * from './type';

--- a/src/DownloadButton/type.ts
+++ b/src/DownloadButton/type.ts
@@ -1,0 +1,15 @@
+import React, { ReactNode } from 'react';
+
+import { ActionIconSize } from '@/ActionIcon';
+
+export interface DownloadButtonProps {
+  active?: boolean;
+  blobUrl?: string; // Blob URL，用于下载
+  disabled?: boolean;
+  fileName?: string; // 文件名（不包含扩展名）
+  fileType?: string; // 文件类型/扩展名，如 'svg', 'png', 'pdf' 等
+  glass?: boolean;
+  icon?: ReactNode;
+  onClick?: (e: React.MouseEvent) => void;
+  size?: ActionIconSize;
+}

--- a/src/DownloadButton/type.ts
+++ b/src/DownloadButton/type.ts
@@ -1,15 +1,7 @@
-import React, { ReactNode } from 'react';
+import { ActionIconProps } from '@/ActionIcon';
 
-import { ActionIconSize } from '@/ActionIcon';
-
-export interface DownloadButtonProps {
-  active?: boolean;
-  blobUrl?: string; // Blob URL，用于下载
-  disabled?: boolean;
-  fileName?: string; // 文件名（不包含扩展名）
-  fileType?: string; // 文件类型/扩展名，如 'svg', 'png', 'pdf' 等
-  glass?: boolean;
-  icon?: ReactNode;
-  onClick?: (e: React.MouseEvent) => void;
-  size?: ActionIconSize;
+export interface DownloadButtonProps extends ActionIconProps {
+  blobUrl?: string;
+  fileName?: string;
+  fileType?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export { default as ColorSwatches, type ColorSwatchesProps } from './ColorSwatch
 export { type Config, default as ConfigProvider, useCdnFn } from './ConfigProvider';
 export { default as CopyButton, type CopyButtonProps } from './CopyButton';
 export { default as DatePicker, type DatePickerProps } from './DatePicker';
+export { default as DownloadButton, type DownloadButtonProps } from './DownloadButton';
 export {
   default as DraggablePanel,
   DraggablePanelBody,

--- a/src/utils/downloadBlob.ts
+++ b/src/utils/downloadBlob.ts
@@ -1,0 +1,18 @@
+export const downloadBlob = async (blobUrl: string, fileName: string): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    try {
+      const link = document.createElement('a');
+      link.href = blobUrl;
+      link.download = fileName;
+      link.style.display = 'none';
+
+      document.body.append(link);
+      link.click();
+      link.remove();
+
+      resolve();
+    } catch (error) {
+      reject(error);
+    }
+  });
+};


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

添加一个DownloadButton 组件 ,希望能后续加到如FullFeatured Mermaid 或者Markdown 代码块上,便于直接下载代码片段或者mermaid 绘制的svg 图像
Add a DownloadButton component, hoping to later add it to features like FullFeatured Mermaid or Markdown code blocks, to facilitate direct downloading of code snippets or SVG images drawn by Mermaid

#### 📝 补充信息 | Additional Information

API参考

| Property | Description                          | Type     | Default    |
| -------- | ------------------------------------ | -------- | ---------- |
| blobUrl  | Blob URL for the content to download | `string` | -          |
| fileName | File name                            | `string` | `download` |
| fileType | File type/extension (e.g., svg, png) | `string` | `svg`      |

Here is a demo Video:

https://github.com/user-attachments/assets/d6402cb5-5830-41be-8d09-46b368f692fc


