### PR TITLE
✨ feat: ActionIconGorup items support loading

### DIFF
--- a/src/ActionIconGroup/ActionIconGroup.tsx
+++ b/src/ActionIconGroup/ActionIconGroup.tsx
@@ -78,12 +78,13 @@ const ActionIconGroup = memo<ActionIconGroupProps>(
       >
         {items?.length > 0 &&
           items.map((item) => {
-            const { icon, key, label, onClick, danger, ...itemRest } = item;
+            const { icon, key, label, onClick, danger, loading, ...itemRest } = item;
             return (
               <ActionIcon
                 danger={danger}
                 icon={icon}
                 key={key}
+                loading={loading}
                 onClick={(e) => {
                   onActionClick?.({
                     domEvent: e,
@@ -98,7 +99,7 @@ const ActionIconGroup = memo<ActionIconGroupProps>(
                   placement: tooltipPlacement,
                 }}
                 {...actionIconProps}
-                disabled={disabled || itemRest?.disabled}
+                disabled={disabled || loading || itemRest?.disabled}
               />
             );
           })}

--- a/src/ActionIconGroup/demos/data.tsx
+++ b/src/ActionIconGroup/demos/data.tsx
@@ -6,6 +6,7 @@ export const items: ActionIconGroupProps['items'] = [
     icon: Copy,
     key: 'copy',
     label: 'Copy',
+    loading: true,
   },
   {
     disabled: true,

--- a/src/Menu/type.ts
+++ b/src/Menu/type.ts
@@ -12,6 +12,7 @@ import type { IconContentConfig, IconProps } from '@/Icon';
 export interface MenuItemType extends RcMenuItemType {
   danger?: boolean;
   icon?: IconProps['icon'];
+  loading?: boolean;
   title?: string;
 }
 export interface SubMenuType<T extends MenuItemType = MenuItemType>


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Supports configuring loading for individual items


<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Add per-item loading support to ActionIconGroup and adjust item types and disabled logic.

New Features:
- Allow configuring loading state for individual ActionIconGroup items.

Enhancements:
- Include item loading flag in disabled logic to prevent interaction while loading.
- Extend ActionIconGroup and Menu item type definitions with loading property.

Documentation:
- Update ActionIconGroup demo to demonstrate item loading state.