### PR TITLE
🐛 fix(mermaid): handle firefox svg display issue by setting width/height

### DIFF
--- a/src/Mermaid/SyntaxMermaid/index.tsx
+++ b/src/Mermaid/SyntaxMermaid/index.tsx
@@ -47,8 +47,10 @@ const SyntaxMermaid = memo<SyntaxMermaidProps>(
         if (svgElement && svgElement.hasAttribute('viewBox')) {
           const viewBox = svgElement.getAttribute('viewBox')!;
           const viewBoxParts = viewBox.split(' ');
-          svgElement.setAttribute('width', viewBoxParts[2]);
-          svgElement.setAttribute('height', viewBoxParts[3]);
+          if (Array.isArray(viewBoxParts) && viewBoxParts.length === 4) {
+            svgElement.setAttribute('width', viewBoxParts[2]);
+            svgElement.setAttribute('height', viewBoxParts[3]);
+          }
           finalSvgString = new XMLSerializer().serializeToString(svgDoc);
         }
       }

--- a/src/Mermaid/SyntaxMermaid/index.tsx
+++ b/src/Mermaid/SyntaxMermaid/index.tsx
@@ -37,9 +37,25 @@ const SyntaxMermaid = memo<SyntaxMermaidProps>(
 
     useEffect(() => {
       if (isLoading || !data) return;
-      // 创建Blob对象
-      const svgBlob = new Blob([data], { type: 'image/svg+xml' });
-      // 创建并保存Blob URL
+      let finalSvgString = data;
+
+      // 修复Firefox点击预览mermaid图时宽高为0导致不显示的异常
+      if (navigator.userAgent.includes('Firefox')) {
+        const parser = new DOMParser();
+        const svgDoc = parser.parseFromString(data, 'image/svg+xml');
+        const svgElement = svgDoc.documentElement;
+        if (svgElement && svgElement.hasAttribute('viewBox')) {
+          const viewBox = svgElement.getAttribute('viewBox')!;
+          const viewBoxParts = viewBox.split(' ');
+          svgElement.setAttribute('width', viewBoxParts[2]);
+          svgElement.setAttribute('height', viewBoxParts[3]);
+          finalSvgString = new XMLSerializer().serializeToString(svgDoc);
+        }
+      }
+
+      // // 创建Blob对象
+      const svgBlob = new Blob([finalSvgString], { type: 'image/svg+xml' });
+      // // 创建并保存Blob URL
       const url = URL.createObjectURL(svgBlob);
       setBlobUrl(url);
     }, [isLoading, data]);


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->
修复 Firefox 点击mermaid图预览时不显示问题 https://github.com/lobehub/lobe-chat/issues/8243

![20250623150056_rec_](https://github.com/user-attachments/assets/86e71c1a-4c9f-4219-bf69-b1b668a13a8a)


#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Add logic to parse the SVG viewBox and apply width/height attributes for Firefox to ensure mermaid diagrams render correctly.