### PR TITLE
🐛 fix: slove when content include <br will be replace all none

### DIFF
--- a/src/Markdown/plugins/remarkBr.ts
+++ b/src/Markdown/plugins/remarkBr.ts
@@ -8,15 +8,14 @@ import { visit } from 'unist-util-visit';
 export const remarkBr = () => {
   return (tree: any) => {
     // First try to process html nodes that might contain br tags
-    visit(tree, 'html', (node, index, parent) => {
+    visit(tree, 'html', (node) => {
       if (!node.value || typeof node.value !== 'string') return;
 
       const brRegex = /<\s*br\s*\/?>/gi;
       if (brRegex.test(node.value)) {
         console.log('Found br tag in HTML node:', node.value);
-        // Replace the html node with a break node
-        parent.children.splice(index, 1, { type: 'break' });
-        return index;
+        // Instead of replacing the entire HTML node, just replace br tags within it
+        node.value = node.value.replaceAll(brRegex, '\n');
       }
     });
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Replace <br> tags within HTML node values with newline characters rather than splicing out the whole node