### PR TITLE
🐛 fix: fixed footnotes render when href not have should render div replace A 

### DIFF
--- a/src/Markdown/components/Footnotes.tsx
+++ b/src/Markdown/components/Footnotes.tsx
@@ -49,9 +49,10 @@ const DefaultFootnotes = memo<{ dataSource: any[] }>(({ dataSource }) => {
     >
       {items.map(({ children, props }, index) => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { node, ...rest } = props;
+        const { node, href, ...rest } = props;
+        const Container = href ? A : 'div';
         return (
-          <A {...rest} key={index}>
+          <Container {...(href ? { href, ...rest } : rest)} key={index}>
             <Block
               align={'stretch'}
               horizontal
@@ -67,7 +68,7 @@ const DefaultFootnotes = memo<{ dataSource: any[] }>(({ dataSource }) => {
                 {children}
               </Text>
             </Block>
-          </A>
+          </Container>
         );
       })}
     </Flexbox>
@@ -77,9 +78,9 @@ const DefaultFootnotes = memo<{ dataSource: any[] }>(({ dataSource }) => {
 const Footnotes = memo<FootnotesProps>(({ children, ...rest }) => {
   const links = useMemo(() => {
     try {
-      return JSON.parse(rest['data-footnote-links'] || '');
+      return JSON.parse(rest['data-footnote-links'] || '[]');
     } catch (error) {
-      console.error(error);
+      console.error('Failed to parse footnote links:', error);
       return [];
     }
   }, [rest['data-footnote-links']]);


### PR DESCRIPTION
…place A

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

- fix https://github.com/lobehub/lobe-chat/issues/9241
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix footnotes rendering when href is missing and improve parsing of footnote links

Bug Fixes:
- Render footnote items without href inside a div instead of an anchor
- Provide a default '[]' fallback for empty footnote links and enhance error logging when parsing fails