### PR TITLE
🐛 fix(sortable-list): fix DragOverlay position issues after drag operations

### DIFF
--- a/src/SortableList/SortableList.tsx
+++ b/src/SortableList/SortableList.tsx
@@ -4,7 +4,9 @@ import {
   type Active,
   DndContext,
   KeyboardSensor,
+  MeasuringStrategy,
   PointerSensor,
+  closestCenter,
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
@@ -24,8 +26,14 @@ import SortableOverlay from './components/SortableOverlay';
 import { useStyles } from './style';
 import type { SortableListProps } from './type';
 
+const measuringConfig = {
+  droppable: {
+    strategy: MeasuringStrategy.Always,
+  },
+};
+
 const SortableListParent = memo<SortableListProps>(
-  ({ ref, items, onChange, renderItem, gap = 8, ...rest }) => {
+  ({ ref, items, onChange, renderItem, renderOverlay, gap = 8, ...rest }) => {
     const [active, setActive] = useState<Active | null>(null);
     const { styles } = useStyles();
     const activeItem = useMemo(() => items.find((item) => item.id === active?.id), [active, items]);
@@ -36,8 +44,12 @@ const SortableListParent = memo<SortableListProps>(
       }),
     );
 
+    const overlayRenderer = renderOverlay ?? renderItem;
+
     return (
       <DndContext
+        collisionDetection={closestCenter}
+        measuring={measuringConfig}
         modifiers={[restrictToVerticalAxis, restrictToWindowEdges]}
         onDragCancel={() => {
           setActive(null);
@@ -63,7 +75,7 @@ const SortableListParent = memo<SortableListProps>(
             ))}
           </Flexbox>
         </SortableContext>
-        <SortableOverlay>{activeItem ? renderItem(activeItem) : null}</SortableOverlay>
+        <SortableOverlay>{activeItem ? overlayRenderer(activeItem) : null}</SortableOverlay>
       </DndContext>
     );
   },

--- a/src/SortableList/demos/index.tsx
+++ b/src/SortableList/demos/index.tsx
@@ -24,7 +24,7 @@ export default () => {
   const [items, setItems] = useState(data);
 
   const store = useCreateStore();
-  const { gap, ...control }: any = useControls(
+  const { gap, useCustomOverlay, ...control }: any = useControls(
     {
       gap: {
         max: 20,
@@ -32,6 +32,7 @@ export default () => {
         step: 1,
         value: 4,
       },
+      useCustomOverlay: false,
       variant: {
         options: ['borderless', 'filled', 'outlined'],
         value: 'borderless',
@@ -52,6 +53,24 @@ export default () => {
             {item.name}
           </SortableList.Item>
         )}
+        renderOverlay={
+          useCustomOverlay
+            ? (item) => (
+                <div
+                  style={{
+                    background: 'rgba(0, 100, 255, 0.1)',
+                    border: '2px dashed #0064ff',
+                    borderRadius: 8,
+                    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+                    padding: '8px 12px',
+                    transform: 'rotate(2deg)',
+                  }}
+                >
+                  📦 {item.name}
+                </div>
+              )
+            : undefined
+        }
       />
     </StoryBook>
   );

--- a/src/SortableList/type.ts
+++ b/src/SortableList/type.ts
@@ -10,4 +10,9 @@ export interface SortableListProps extends Omit<FlexboxProps, 'onChange'> {
   onChange(items: SortableListItem[]): void;
   ref?: Ref<HTMLUListElement>;
   renderItem(item: SortableListItem): ReactNode;
+  /**
+   * Custom render function for the drag overlay
+   * If not provided, renderItem will be used
+   */
+  renderOverlay?: (item: SortableListItem) => ReactNode;
 }


### PR DESCRIPTION
## Summary

- Fix DragOverlay position calculation issues after drag operations in `SortableList` component
- Add `MeasuringStrategy.Always` to ensure accurate position measurement on every drag
- Add `closestCenter` collision detection for better drag experience
- Add `renderOverlay` prop to allow custom drag overlay rendering

## Changes

### Core Fix
- Added `measuring` config with `MeasuringStrategy.Always` to force re-measurement of element positions
- Added `closestCenter` collision detection algorithm

### New Feature
- Added `renderOverlay` prop to `SortableListProps` interface
- Users can now customize the drag overlay appearance independently from `renderItem`

## Test Plan

- [x] Type check passes
- [x] All existing tests pass
- [x] Demo updated with `useCustomOverlay` toggle to showcase new feature
- [ ] Manual testing: verify drag overlay position is correct after multiple drag operations

## Related Issues

Closes LOBE-1959, LOBE-1960, LOBE-1961

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve SortableList drag-and-drop behavior and support customizable drag overlays.

New Features:
- Add an optional renderOverlay prop to SortableList to allow custom drag overlay rendering independent of renderItem.

Enhancements:
- Use closestCenter collision detection to provide more intuitive drag interactions in SortableList.
- Enable continuous droppable measuring with MeasuringStrategy.Always to keep drag overlay positioning in sync after drag operations.
- Extend the SortableList demo with a useCustomOverlay toggle showcasing the custom overlay capability.