### PR TITLE
refactor: TooltipGroup for shared tooltip instances and enhance Tooltip functionality

### DIFF
--- a/src/Accordion/AccordionItem.tsx
+++ b/src/Accordion/AccordionItem.tsx
@@ -1,18 +1,16 @@
 'use client';
 
-import { LazyMotion, m } from 'motion/react';
 import { KeyboardEvent, memo, useCallback, useMemo } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
 import Block from '@/Block';
 import Text from '@/Text';
+import { LazyMotion, m } from '@/motion';
 
 import ArrowIcon from './ArrowIcon';
 import { useAccordionContext } from './context';
 import { useStyles } from './style';
 import type { AccordionItemProps } from './type';
-
-const loadFeatures = () => import('motion/react').then((res) => res.domAnimation);
 
 const AccordionItem = memo<AccordionItemProps>(
   ({
@@ -181,7 +179,7 @@ const AccordionItem = memo<AccordionItemProps>(
       }
 
       return (
-        <LazyMotion features={loadFeatures}>
+        <LazyMotion>
           <m.div {...motionProps} style={{ overflow: 'hidden' }}>
             <div
               className={cx('accordion-content', styles.content, classNames?.content)}

--- a/src/ActionIcon/type.ts
+++ b/src/ActionIcon/type.ts
@@ -12,8 +12,7 @@ interface ActionIconSizeConfig extends IconSizeConfig {
 export type ActionIconSize = number | IconSizeType | ActionIconSizeConfig;
 
 export interface ActionIconProps
-  extends Partial<LucideIconProps>,
-    Omit<CenterProps, 'title' | 'children'> {
+  extends Partial<LucideIconProps>, Omit<CenterProps, 'title' | 'children'> {
   active?: boolean;
   danger?: boolean;
   disabled?: boolean;
@@ -25,6 +24,6 @@ export interface ActionIconProps
   size?: ActionIconSize;
   spin?: boolean;
   title?: TooltipProps['title'];
-  tooltipProps?: Omit<TooltipProps, 'title'>;
+  tooltipProps?: Omit<TooltipProps, 'children' | 'title'>;
   variant?: 'borderless' | 'filled' | 'outlined';
 }

--- a/src/Avatar/type.ts
+++ b/src/Avatar/type.ts
@@ -18,21 +18,21 @@ export interface AvatarProps extends AntAvatarProps {
   size?: number;
   sliceText?: boolean;
   title?: string;
-  tooltipProps?: Omit<TooltipProps, 'title'>;
+  tooltipProps?: Omit<TooltipProps, 'children' | 'title'>;
   unoptimized?: boolean;
   variant?: 'borderless' | 'filled' | 'outlined';
 }
 
-export interface AvatarGroupItemType
-  extends Pick<
-    AvatarProps,
-    'avatar' | 'title' | 'alt' | 'onClick' | 'style' | 'className' | 'loading'
-  > {
+export interface AvatarGroupItemType extends Pick<
+  AvatarProps,
+  'avatar' | 'title' | 'alt' | 'onClick' | 'style' | 'className' | 'loading'
+> {
   key: string;
 }
 
 export interface AvatarGroupProps
-  extends Pick<
+  extends
+    Pick<
       AvatarProps,
       | 'variant'
       | 'bordered'

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import {
-  FloatingArrow,
-  FloatingPortal,
   arrow as arrowMiddleware,
   autoUpdate,
   flip,
@@ -25,16 +23,14 @@ import {
   useRef,
   useState,
 } from 'react';
-import { Flexbox } from 'react-layout-kit';
 import { mergeRefs } from 'react-merge-refs';
 
-import Hotkey from '@/Hotkey';
 import { antdPlacementToFloating } from '@/Tooltip/antdPlacementToFloating';
-import { AnimatePresence, LazyMotion, m } from '@/motion';
 import { composeEventHandlers } from '@/utils/composeEventHandlers';
 
+import TooltipFloating from './TooltipFloating';
+import TooltipPortal from './TooltipPortal';
 import { TooltipGroupContext, type TooltipGroupItem } from './groupContext';
-import { useStyles } from './style';
 import type { TooltipProps } from './type';
 
 const TooltipInGroup: FC<TooltipProps> = ({
@@ -180,7 +176,6 @@ const TooltipStandalone: FC<TooltipProps> = ({
   portalled = true,
   getPopupContainer,
 }) => {
-  const { styles, cx } = useStyles();
   const arrowRef = useRef<SVGSVGElement | null>(null);
   const [uncontrolledOpen, setUncontrolledOpen] = useState(Boolean(defaultOpen));
 
@@ -191,27 +186,6 @@ const TooltipStandalone: FC<TooltipProps> = ({
   };
 
   const floatingPlacement = useMemo(() => antdPlacementToFloating(placement), [placement]);
-
-  const transformOrigin = useMemo(() => {
-    const basePlacement = String(floatingPlacement).split('-')[0];
-    switch (basePlacement) {
-      case 'top': {
-        return 'bottom center';
-      }
-      case 'bottom': {
-        return 'top center';
-      }
-      case 'left': {
-        return 'center right';
-      }
-      case 'right': {
-        return 'center left';
-      }
-      default: {
-        return 'center';
-      }
-    }
-  }, [floatingPlacement]);
 
   const middleware = useMemo(() => {
     const base = [offset(8), flip(), shift({ padding: 8 })];
@@ -277,61 +251,23 @@ const TooltipStandalone: FC<TooltipProps> = ({
       : undefined;
 
   const floatingNode = (
-    <LazyMotion>
-      <AnimatePresence>
-        {mergedOpen && title && (
-          <m.div
-            animate={{ opacity: 1 }}
-            className={cx(styles.tooltip, classNames?.container, classNames?.root, className)}
-            exit={{ opacity: 0 }}
-            initial={{ opacity: 0 }}
-            key="tooltip"
-            ref={refs.setFloating}
-            style={
-              styleProps?.root
-                ? {
-                    ...floatingStyles,
-                    zIndex,
-                    ...styleProps.container,
-                    ...styleProps.root,
-                  }
-                : { ...floatingStyles, zIndex, ...styleProps?.container }
-            }
-            transition={{ duration: 0.12, ease: [0.4, 0, 0.2, 1] }}
-            {...getFloatingProps()}
-          >
-            <m.div
-              animate={{ scale: 1 }}
-              exit={{ scale: 0.98 }}
-              initial={{ scale: 0.96 }}
-              style={{ transformOrigin }}
-              transition={{ duration: 0.12, ease: [0.4, 0, 0.2, 1] }}
-            >
-              <div className={cx(styles.content, classNames?.content)} style={styleProps?.content}>
-                {hotkey ? (
-                  <Flexbox align={'center'} gap={8} horizontal justify={'space-between'}>
-                    <span>{title}</span>
-                    <Hotkey inverseTheme keys={hotkey} {...hotkeyProps} />
-                  </Flexbox>
-                ) : (
-                  title
-                )}
-              </div>
-              {arrow && (
-                <FloatingArrow
-                  className={cx(styles.arrow, classNames?.arrow)}
-                  context={context}
-                  height={6}
-                  ref={arrowRef}
-                  style={styleProps?.arrow}
-                  width={12}
-                />
-              )}
-            </m.div>
-          </m.div>
-        )}
-      </AnimatePresence>
-    </LazyMotion>
+    <TooltipFloating
+      arrow={arrow}
+      arrowRef={arrowRef}
+      className={className}
+      classNames={classNames}
+      context={context}
+      floatingProps={getFloatingProps()}
+      floatingStyles={floatingStyles}
+      hotkey={hotkey}
+      hotkeyProps={hotkeyProps}
+      open={mergedOpen}
+      placement={floatingPlacement}
+      setFloating={refs.setFloating}
+      styles={styleProps}
+      title={title}
+      zIndex={zIndex}
+    />
   );
 
   return (
@@ -340,7 +276,7 @@ const TooltipStandalone: FC<TooltipProps> = ({
       {!disabled &&
         title &&
         (portalled ? (
-          <FloatingPortal root={portalRoot}>{floatingNode}</FloatingPortal>
+          <TooltipPortal root={portalRoot}>{floatingNode}</TooltipPortal>
         ) : (
           floatingNode
         ))}

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -1,41 +1,360 @@
 'use client';
 
-import { Tooltip as AntdTooltip } from 'antd';
-import { memo } from 'react';
+import {
+  FloatingArrow,
+  FloatingPortal,
+  arrow as arrowMiddleware,
+  autoUpdate,
+  flip,
+  offset,
+  shift,
+  useDismiss,
+  useFloating,
+  useFocus,
+  useHover,
+  useInteractions,
+  useRole,
+} from '@floating-ui/react';
+import {
+  type FC,
+  cloneElement,
+  isValidElement,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Flexbox } from 'react-layout-kit';
+import { mergeRefs } from 'react-merge-refs';
 
 import Hotkey from '@/Hotkey';
+import { antdPlacementToFloating } from '@/Tooltip/antdPlacementToFloating';
+import { AnimatePresence, LazyMotion, m } from '@/motion';
+import { composeEventHandlers } from '@/utils/composeEventHandlers';
 
+import { TooltipGroupContext, type TooltipGroupItem } from './groupContext';
 import { useStyles } from './style';
 import type { TooltipProps } from './type';
 
-const Tooltip = memo<TooltipProps>(
-  ({ ref, hotkey, className, arrow = false, title, hotkeyProps, ...rest }) => {
-    const { styles, cx } = useStyles();
+const TooltipInGroup: FC<TooltipProps> = ({
+  ref,
+  hotkey,
+  className,
+  arrow = false,
+  title,
+  hotkeyProps,
+  children,
+  placement = 'top',
+  openDelay,
+  closeDelay,
+  mouseEnterDelay = 0,
+  mouseLeaveDelay = 0,
+  onOpenChange,
+  disabled,
+  classNames,
+  styles: styleProps,
+  zIndex,
+  portalled = true,
+  getPopupContainer,
+}) => {
+  const group = useContext(TooltipGroupContext);
+  const triggerElRef = useRef<HTMLElement | null>(null);
 
-    return (
-      <AntdTooltip
-        arrow={arrow}
-        classNames={{
-          root: cx(styles.tooltip, className),
-        }}
-        ref={ref}
-        title={
-          hotkey ? (
-            <Flexbox align={'center'} gap={8} horizontal justify={'space-between'}>
-              <span>{title}</span>
-              <Hotkey inverseTheme keys={hotkey} {...hotkeyProps} />
-            </Flexbox>
-          ) : (
-            title
-          )
-        }
-        {...rest}
-      />
+  const item: TooltipGroupItem = useMemo(
+    () => ({
+      arrow,
+      className,
+      classNames,
+      closeDelay,
+      disabled,
+      getPopupContainer,
+      hotkey,
+      hotkeyProps,
+      mouseEnterDelay,
+      mouseLeaveDelay,
+      onOpenChange,
+      openDelay,
+      placement,
+      portalled,
+      styles: styleProps,
+      title,
+      zIndex,
+    }),
+    [
+      arrow,
+      className,
+      classNames,
+      closeDelay,
+      disabled,
+      getPopupContainer,
+      hotkey,
+      hotkeyProps,
+      mouseEnterDelay,
+      mouseLeaveDelay,
+      onOpenChange,
+      openDelay,
+      placement,
+      portalled,
+      styleProps,
+      title,
+      zIndex,
+    ],
+  );
+
+  const trigger = useMemo(() => {
+    if (!isValidElement(children)) return <span>{children}</span>;
+
+    const needsWrapper =
+      typeof children.type === 'string' && Boolean((children.props as any)?.disabled);
+
+    if (needsWrapper) return <span style={{ display: 'inline-flex' }}>{children}</span>;
+
+    return children;
+  }, [children]);
+
+  const referenceNode = useMemo(() => {
+    if (!isValidElement(trigger)) return trigger;
+
+    const originalRef = (trigger as any).ref;
+    const triggerProps: any = trigger.props || {};
+
+    const setTriggerEl = (node: any) => {
+      triggerElRef.current = node instanceof HTMLElement ? node : null;
+    };
+
+    return cloneElement(trigger as any, {
+      ...triggerProps,
+      onBlur: composeEventHandlers(triggerProps.onBlur, (e: any) => {
+        group?.closeFromTrigger(e.currentTarget as HTMLElement, item);
+      }),
+      onFocus: composeEventHandlers(triggerProps.onFocus, (e: any) => {
+        group?.openFromTrigger(e.currentTarget as HTMLElement, item);
+      }),
+      onKeyDown: composeEventHandlers(triggerProps.onKeyDown, (e: any) => {
+        if (e?.key === 'Escape') group?.closeImmediately();
+      }),
+      onPointerEnter: composeEventHandlers(triggerProps.onPointerEnter, (e: any) => {
+        group?.openFromTrigger(e.currentTarget as HTMLElement, item);
+      }),
+      onPointerLeave: composeEventHandlers(triggerProps.onPointerLeave, (e: any) => {
+        group?.closeFromTrigger(e.currentTarget as HTMLElement, item);
+      }),
+      ref: mergeRefs([originalRef, setTriggerEl, ref]),
+    });
+  }, [group, item, ref, trigger]);
+
+  useEffect(() => {
+    return () => {
+      if (!group) return;
+      const el = triggerElRef.current;
+      if (el && group.isActiveTrigger(el)) group.closeImmediately();
+    };
+  }, [group]);
+
+  return referenceNode as any;
+};
+
+TooltipInGroup.displayName = 'TooltipInGroup';
+
+const TooltipStandalone: FC<TooltipProps> = ({
+  ref,
+  hotkey,
+  className,
+  arrow = false,
+  title,
+  hotkeyProps,
+  children,
+  placement = 'top',
+  openDelay,
+  closeDelay,
+  mouseEnterDelay = 0,
+  mouseLeaveDelay = 0,
+  open,
+  defaultOpen,
+  onOpenChange,
+  disabled,
+  classNames,
+  styles: styleProps,
+  zIndex,
+  portalled = true,
+  getPopupContainer,
+}) => {
+  const { styles, cx } = useStyles();
+  const arrowRef = useRef<SVGSVGElement | null>(null);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(Boolean(defaultOpen));
+
+  const mergedOpen = open ?? uncontrolledOpen;
+  const setOpen = (next: boolean) => {
+    if (open === undefined) setUncontrolledOpen(next);
+    onOpenChange?.(next);
+  };
+
+  const floatingPlacement = useMemo(() => antdPlacementToFloating(placement), [placement]);
+
+  const transformOrigin = useMemo(() => {
+    const basePlacement = String(floatingPlacement).split('-')[0];
+    switch (basePlacement) {
+      case 'top': {
+        return 'bottom center';
+      }
+      case 'bottom': {
+        return 'top center';
+      }
+      case 'left': {
+        return 'center right';
+      }
+      case 'right': {
+        return 'center left';
+      }
+      default: {
+        return 'center';
+      }
+    }
+  }, [floatingPlacement]);
+
+  const middleware = useMemo(() => {
+    const base = [offset(8), flip(), shift({ padding: 8 })];
+    if (arrow) base.push(arrowMiddleware({ element: arrowRef }));
+    return base;
+  }, [arrow]);
+
+  const { context, floatingStyles, refs } = useFloating({
+    middleware,
+    onOpenChange: setOpen,
+    open: disabled ? false : mergedOpen,
+    placement: floatingPlacement,
+    whileElementsMounted: autoUpdate,
+  });
+
+  const resolvedDelay = useMemo(
+    () => ({
+      close: closeDelay ?? mouseLeaveDelay * 1000,
+      open: openDelay ?? mouseEnterDelay * 1000,
+    }),
+    [closeDelay, mouseEnterDelay, mouseLeaveDelay, openDelay],
+  );
+
+  const hover = useHover(context, {
+    delay: resolvedDelay,
+    enabled: !disabled,
+    move: false,
+  });
+  const focus = useFocus(context, { enabled: !disabled });
+  const dismiss = useDismiss(context, { enabled: !disabled });
+  const role = useRole(context, { role: 'tooltip' });
+
+  const { getFloatingProps, getReferenceProps } = useInteractions([hover, focus, dismiss, role]);
+
+  const trigger = useMemo(() => {
+    if (!isValidElement(children)) return <span>{children}</span>;
+
+    const needsWrapper =
+      typeof children.type === 'string' && Boolean((children.props as any)?.disabled);
+
+    if (needsWrapper) return <span style={{ display: 'inline-flex' }}>{children}</span>;
+
+    return children;
+  }, [children]);
+
+  const referenceNode = useMemo(() => {
+    if (!isValidElement(trigger)) return trigger;
+
+    const originalRef = (trigger as any).ref;
+
+    return cloneElement(
+      trigger as any,
+      getReferenceProps({
+        ...(trigger.props as any),
+        ref: mergeRefs([originalRef, refs.setReference, ref]),
+      }),
     );
-  },
-);
+  }, [getReferenceProps, ref, refs.setReference, trigger]);
 
-Tooltip.displayName = 'Tooltip';
+  const portalRoot =
+    getPopupContainer && refs.reference.current
+      ? getPopupContainer(refs.reference.current as any)
+      : undefined;
+
+  const floatingNode = (
+    <LazyMotion>
+      <AnimatePresence>
+        {mergedOpen && title && (
+          <m.div
+            animate={{ opacity: 1 }}
+            className={cx(styles.tooltip, classNames?.container, classNames?.root, className)}
+            exit={{ opacity: 0 }}
+            initial={{ opacity: 0 }}
+            key="tooltip"
+            ref={refs.setFloating}
+            style={
+              styleProps?.root
+                ? {
+                    ...floatingStyles,
+                    zIndex,
+                    ...styleProps.container,
+                    ...styleProps.root,
+                  }
+                : { ...floatingStyles, zIndex, ...styleProps?.container }
+            }
+            transition={{ duration: 0.12, ease: [0.4, 0, 0.2, 1] }}
+            {...getFloatingProps()}
+          >
+            <m.div
+              animate={{ scale: 1 }}
+              exit={{ scale: 0.98 }}
+              initial={{ scale: 0.96 }}
+              style={{ transformOrigin }}
+              transition={{ duration: 0.12, ease: [0.4, 0, 0.2, 1] }}
+            >
+              <div className={cx(styles.content, classNames?.content)} style={styleProps?.content}>
+                {hotkey ? (
+                  <Flexbox align={'center'} gap={8} horizontal justify={'space-between'}>
+                    <span>{title}</span>
+                    <Hotkey inverseTheme keys={hotkey} {...hotkeyProps} />
+                  </Flexbox>
+                ) : (
+                  title
+                )}
+              </div>
+              {arrow && (
+                <FloatingArrow
+                  className={cx(styles.arrow, classNames?.arrow)}
+                  context={context}
+                  height={6}
+                  ref={arrowRef}
+                  style={styleProps?.arrow}
+                  width={12}
+                />
+              )}
+            </m.div>
+          </m.div>
+        )}
+      </AnimatePresence>
+    </LazyMotion>
+  );
+
+  return (
+    <>
+      {referenceNode}
+      {!disabled &&
+        title &&
+        (portalled ? (
+          <FloatingPortal root={portalRoot}>{floatingNode}</FloatingPortal>
+        ) : (
+          floatingNode
+        ))}
+    </>
+  );
+};
+
+export const Tooltip: FC<TooltipProps> = (props) => {
+  const group = useContext(TooltipGroupContext);
+
+  // Group mode is intentionally hover/focus driven; keep standalone behavior for controlled cases.
+  const canUseGroup = Boolean(group) && props.open === undefined && props.defaultOpen === undefined;
+
+  return canUseGroup ? <TooltipInGroup {...props} /> : <TooltipStandalone {...props} />;
+};
 
 export default Tooltip;

--- a/src/Tooltip/TooltipFloating.tsx
+++ b/src/Tooltip/TooltipFloating.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import type { FloatingContext, Placement } from '@floating-ui/react';
+import { FloatingArrow } from '@floating-ui/react';
+import type { CSSProperties, ReactNode, RefObject } from 'react';
+import { useMemo } from 'react';
+import { Flexbox } from 'react-layout-kit';
+
+import Hotkey from '@/Hotkey';
+import { AnimatePresence, LazyMotion, m } from '@/motion';
+
+import { useStyles } from './style';
+import type { TooltipProps } from './type';
+
+type TooltipFloatingProps = {
+  arrow?: boolean;
+  arrowRef?: RefObject<SVGSVGElement | null>;
+
+  className?: TooltipProps['className'];
+  classNames?: TooltipProps['classNames'];
+  context?: FloatingContext;
+
+  floatingProps?: Record<string, any>;
+
+  floatingStyles: CSSProperties;
+  hotkey?: TooltipProps['hotkey'];
+  hotkeyProps?: TooltipProps['hotkeyProps'];
+
+  /**
+   * Enable Framer Motion layout/position tweening when provided.
+   * Useful for TooltipGroup where the floating position changes frequently.
+   */
+  layoutId?: string;
+
+  open: boolean;
+  placement?: Placement;
+
+  setFloating: (node: HTMLElement | null) => void;
+  styles?: TooltipProps['styles'];
+  title?: ReactNode;
+  zIndex?: TooltipProps['zIndex'];
+};
+
+const TooltipFloating = ({
+  open,
+  title,
+  placement,
+  floatingStyles,
+  setFloating,
+  floatingProps,
+  arrow,
+  arrowRef,
+  context,
+  hotkey,
+  hotkeyProps,
+  layoutId,
+  className,
+  classNames,
+  styles: styleProps,
+  zIndex,
+}: TooltipFloatingProps) => {
+  const { styles, cx } = useStyles();
+
+  const transformOrigin = useMemo(() => {
+    const basePlacement = String(placement || 'top').split('-')[0];
+    switch (basePlacement) {
+      case 'top': {
+        return 'bottom center';
+      }
+      case 'bottom': {
+        return 'top center';
+      }
+      case 'left': {
+        return 'center right';
+      }
+      case 'right': {
+        return 'center left';
+      }
+      default: {
+        return 'center';
+      }
+    }
+  }, [placement]);
+
+  return (
+    <LazyMotion>
+      <AnimatePresence>
+        {open && title && (
+          <m.div
+            animate={{ opacity: 1 }}
+            className={cx(styles.tooltip, classNames?.container, classNames?.root, className)}
+            exit={{ opacity: 0 }}
+            initial={{ opacity: 0 }}
+            key="tooltip"
+            ref={setFloating as any}
+            role="tooltip"
+            style={
+              styleProps?.root
+                ? {
+                    ...floatingStyles,
+                    zIndex,
+                    ...styleProps.container,
+                    ...styleProps.root,
+                  }
+                : { ...floatingStyles, zIndex, ...styleProps?.container }
+            }
+            transition={{ duration: 0.12, ease: [0.4, 0, 0.2, 1] }}
+            {...floatingProps}
+          >
+            <m.div
+              animate={{ scale: 1 }}
+              exit={{ scale: 0.98 }}
+              initial={{ scale: 0.96 }}
+              layout={layoutId ? 'position' : undefined}
+              layoutId={layoutId}
+              style={{ transformOrigin }}
+              transition={{ duration: 0.12, ease: [0.4, 0, 0.2, 1] }}
+            >
+              <div className={cx(styles.content, classNames?.content)} style={styleProps?.content}>
+                {hotkey ? (
+                  <Flexbox align={'center'} gap={8} horizontal justify={'space-between'}>
+                    <span>{title}</span>
+                    <Hotkey inverseTheme keys={hotkey} {...hotkeyProps} />
+                  </Flexbox>
+                ) : (
+                  title
+                )}
+              </div>
+              {arrow && context && (
+                <FloatingArrow
+                  className={cx(styles.arrow, classNames?.arrow)}
+                  context={context}
+                  height={6}
+                  ref={arrowRef as any}
+                  style={styleProps?.arrow}
+                  width={12}
+                />
+              )}
+            </m.div>
+          </m.div>
+        )}
+      </AnimatePresence>
+    </LazyMotion>
+  );
+};
+
+TooltipFloating.displayName = 'TooltipFloating';
+
+export default TooltipFloating;

--- a/src/Tooltip/TooltipGroup.tsx
+++ b/src/Tooltip/TooltipGroup.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+import {
+  FloatingArrow,
+  FloatingPortal,
+  arrow as arrowMiddleware,
+  autoUpdate,
+  flip,
+  offset,
+  shift,
+  useFloating,
+} from '@floating-ui/react';
+import { type ReactNode, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Flexbox } from 'react-layout-kit';
+
+import Hotkey from '@/Hotkey';
+import { antdPlacementToFloating } from '@/Tooltip/antdPlacementToFloating';
+import { AnimatePresence, LazyMotion, m } from '@/motion';
+
+import { TooltipGroupContext, type TooltipGroupItem } from './groupContext';
+import { useStyles } from './style';
+
+type TooltipGroupProps = {
+  children: ReactNode;
+};
+
+const TooltipGroup = memo<TooltipGroupProps>(({ children }) => {
+  const { styles, cx } = useStyles();
+  const arrowRef = useRef<SVGSVGElement | null>(null);
+  const openTimerRef = useRef<number | null>(null);
+  const closeTimerRef = useRef<number | null>(null);
+
+  const [active, setActive] = useState<{
+    item: TooltipGroupItem;
+    triggerEl: HTMLElement;
+  } | null>(null);
+  const [open, setOpen] = useState(false);
+  const activeRef = useRef<typeof active>(null);
+
+  useEffect(() => {
+    activeRef.current = active;
+  }, [active]);
+
+  const floatingPlacement = useMemo(
+    () => antdPlacementToFloating(active?.item.placement),
+    [active?.item.placement],
+  );
+
+  const transformOrigin = useMemo(() => {
+    const basePlacement = String(floatingPlacement).split('-')[0];
+    switch (basePlacement) {
+      case 'top': {
+        return 'bottom center';
+      }
+      case 'bottom': {
+        return 'top center';
+      }
+      case 'left': {
+        return 'center right';
+      }
+      case 'right': {
+        return 'center left';
+      }
+      default: {
+        return 'center';
+      }
+    }
+  }, [floatingPlacement]);
+
+  const middleware = useMemo(() => {
+    const base = [offset(8), flip(), shift({ padding: 8 })];
+    if (active?.item.arrow) base.push(arrowMiddleware({ element: arrowRef }));
+    return base;
+  }, [active?.item.arrow]);
+
+  const { context, floatingStyles, refs } = useFloating({
+    middleware,
+    open,
+    placement: floatingPlacement,
+    whileElementsMounted: autoUpdate,
+  });
+
+  useEffect(() => {
+    if (!active?.triggerEl) return;
+    refs.setReference(active.triggerEl);
+  }, [active?.triggerEl, refs]);
+
+  const clearTimers = useCallback(() => {
+    if (openTimerRef.current) window.clearTimeout(openTimerRef.current);
+    if (closeTimerRef.current) window.clearTimeout(closeTimerRef.current);
+    openTimerRef.current = null;
+    closeTimerRef.current = null;
+  }, []);
+
+  const closeImmediately = useCallback(() => {
+    clearTimers();
+    setOpen(false);
+    activeRef.current?.item.onOpenChange?.(false);
+  }, [clearTimers]);
+
+  const isActiveTrigger = useCallback((triggerEl: HTMLElement) => {
+    return Boolean(activeRef.current && activeRef.current.triggerEl === triggerEl);
+  }, []);
+
+  const closeFromTrigger = useCallback(
+    (triggerEl: HTMLElement, item: TooltipGroupItem) => {
+      if (!activeRef.current || activeRef.current.triggerEl !== triggerEl) return;
+
+      clearTimers();
+
+      const delayMs = item.closeDelay ?? (item.mouseLeaveDelay ?? 0) * 1000;
+      if (delayMs <= 0) {
+        setOpen(false);
+        item.onOpenChange?.(false);
+        return;
+      }
+
+      closeTimerRef.current = window.setTimeout(() => {
+        setOpen(false);
+        item.onOpenChange?.(false);
+      }, delayMs);
+    },
+    [clearTimers],
+  );
+
+  const openFromTrigger = useCallback(
+    (triggerEl: HTMLElement, item: TooltipGroupItem) => {
+      if (!triggerEl) return;
+      if (!item.title) return;
+      if (item.disabled) return;
+
+      clearTimers();
+      setActive({ item, triggerEl });
+
+      const delayMs = item.openDelay ?? (item.mouseEnterDelay ?? 0) * 1000;
+      if (delayMs <= 0) {
+        setOpen(true);
+        item.onOpenChange?.(true);
+        return;
+      }
+
+      openTimerRef.current = window.setTimeout(() => {
+        setOpen(true);
+        item.onOpenChange?.(true);
+      }, delayMs);
+    },
+    [clearTimers],
+  );
+
+  const api = useMemo(
+    () => ({ closeFromTrigger, closeImmediately, isActiveTrigger, openFromTrigger }),
+    [closeFromTrigger, closeImmediately, isActiveTrigger, openFromTrigger],
+  );
+
+  useEffect(() => {
+    return () => {
+      clearTimers();
+    };
+  }, [clearTimers]);
+
+  const portalRoot =
+    active?.item.getPopupContainer && active?.triggerEl
+      ? active.item.getPopupContainer(active.triggerEl)
+      : undefined;
+
+  const floatingNode = (
+    <LazyMotion>
+      <AnimatePresence>
+        {open && active?.item.title && (
+          <m.div
+            animate={{ opacity: 1 }}
+            className={cx(
+              styles.tooltip,
+              active.item.classNames?.container,
+              active.item.classNames?.root,
+              active.item.className,
+            )}
+            exit={{ opacity: 0 }}
+            initial={{ opacity: 0 }}
+            key="tooltip"
+            ref={refs.setFloating}
+            role="tooltip"
+            style={
+              active.item.styles?.root
+                ? {
+                    ...floatingStyles,
+                    zIndex: active.item.zIndex,
+                    ...active.item.styles.container,
+                    ...active.item.styles.root,
+                  }
+                : {
+                    ...floatingStyles,
+                    zIndex: active.item.zIndex,
+                    ...active.item.styles?.container,
+                  }
+            }
+            transition={{ duration: 0.12, ease: [0.4, 0, 0.2, 1] }}
+          >
+            <m.div
+              animate={{ scale: 1 }}
+              exit={{ scale: 0.98 }}
+              initial={{ scale: 0.96 }}
+              style={{ transformOrigin }}
+              transition={{ duration: 0.12, ease: [0.4, 0, 0.2, 1] }}
+            >
+              <div
+                className={cx(styles.content, active.item.classNames?.content)}
+                style={active.item.styles?.content}
+              >
+                {active.item.hotkey ? (
+                  <Flexbox align={'center'} gap={8} horizontal justify={'space-between'}>
+                    <span>{active.item.title}</span>
+                    <Hotkey inverseTheme keys={active.item.hotkey} {...active.item.hotkeyProps} />
+                  </Flexbox>
+                ) : (
+                  active.item.title
+                )}
+              </div>
+              {active.item.arrow && (
+                <FloatingArrow
+                  className={cx(styles.arrow, active.item.classNames?.arrow)}
+                  context={context}
+                  height={6}
+                  ref={arrowRef}
+                  style={active.item.styles?.arrow}
+                  width={12}
+                />
+              )}
+            </m.div>
+          </m.div>
+        )}
+      </AnimatePresence>
+    </LazyMotion>
+  );
+
+  return (
+    <TooltipGroupContext.Provider value={api}>
+      {children}
+      {active?.item.title &&
+        !active.item.disabled &&
+        ((active.item.portalled ?? true) ? (
+          <FloatingPortal root={portalRoot}>{floatingNode}</FloatingPortal>
+        ) : (
+          floatingNode
+        ))}
+    </TooltipGroupContext.Provider>
+  );
+});
+
+TooltipGroup.displayName = 'TooltipGroup';
+
+export default TooltipGroup;

--- a/src/Tooltip/TooltipPortal.tsx
+++ b/src/Tooltip/TooltipPortal.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+
+type TooltipPortalProps = {
+  children: ReactNode;
+  root?: HTMLElement | ShadowRoot | null;
+};
+
+const PORTAL_ATTR = 'data-lobe-ui-tooltip-portal';
+
+// Reuse one portal container per root (document.body by default).
+const containerMap = new WeakMap<object, HTMLElement>();
+
+const getOrCreateContainer = (root: HTMLElement | ShadowRoot): HTMLElement => {
+  const cached = containerMap.get(root);
+  if (cached && cached.isConnected) return cached;
+
+  const el = document.createElement('div');
+  el.setAttribute(PORTAL_ATTR, 'true');
+  root.append(el);
+  containerMap.set(root, el);
+  return el;
+};
+
+const resolveRoot = (root?: HTMLElement | ShadowRoot | null): HTMLElement | ShadowRoot | null => {
+  if (root) return root;
+  if (typeof document === 'undefined') return null;
+  return document.body;
+};
+
+const TooltipPortal = ({ children, root }: TooltipPortalProps) => {
+  const [container, setContainer] = useState<HTMLElement | null>(() => {
+    const resolved = resolveRoot(root);
+    if (!resolved) return null;
+    return getOrCreateContainer(resolved);
+  });
+
+  if (!container && typeof document !== 'undefined') {
+    setContainer(getOrCreateContainer(document.body));
+  }
+
+  if (!container) return null;
+  return createPortal(children, container);
+};
+
+export default TooltipPortal;

--- a/src/Tooltip/antdPlacementToFloating.ts
+++ b/src/Tooltip/antdPlacementToFloating.ts
@@ -1,0 +1,60 @@
+import type { Placement } from '@floating-ui/react';
+
+/**
+ * Convert Ant Design legacy placements to Floating UI placements.
+ *
+ * Notes:
+ * - Floating UI placements like `top-start` are passed through.
+ * - Ant Design legacy placements like `topLeft` are mapped to Floating UI.
+ */
+export const antdPlacementToFloating = (
+  placement?:
+    | Placement
+    | 'topLeft'
+    | 'topRight'
+    | 'bottomLeft'
+    | 'bottomRight'
+    | 'leftTop'
+    | 'leftBottom'
+    | 'rightTop'
+    | 'rightBottom'
+    | 'top'
+    | 'bottom'
+    | 'left'
+    | 'right',
+): Placement => {
+  if (!placement) return 'top';
+
+  // Floating UI placements are already compatible.
+  if (typeof placement === 'string' && placement.includes('-')) return placement as Placement;
+
+  switch (placement) {
+    case 'topLeft': {
+      return 'top-start';
+    }
+    case 'topRight': {
+      return 'top-end';
+    }
+    case 'bottomLeft': {
+      return 'bottom-start';
+    }
+    case 'bottomRight': {
+      return 'bottom-end';
+    }
+    case 'leftTop': {
+      return 'left-start';
+    }
+    case 'leftBottom': {
+      return 'left-end';
+    }
+    case 'rightTop': {
+      return 'right-start';
+    }
+    case 'rightBottom': {
+      return 'right-end';
+    }
+    default: {
+      return placement as Placement;
+    }
+  }
+};

--- a/src/Tooltip/demos/group.tsx
+++ b/src/Tooltip/demos/group.tsx
@@ -1,0 +1,24 @@
+import { Button, Tooltip, TooltipGroup } from '@lobehub/ui';
+import { StoryBook, useCreateStore } from '@lobehub/ui/storybook';
+import { Flexbox } from 'react-layout-kit';
+
+export default () => {
+  const store = useCreateStore();
+  return (
+    <StoryBook levaStore={store}>
+      <Flexbox gap={12} horizontal>
+        <TooltipGroup>
+          <Tooltip closeDelay={1000} title="First tooltip">
+            <Button type="primary">First</Button>
+          </Tooltip>
+          <Tooltip closeDelay={1000} title="Second tooltip">
+            <Button>Second</Button>
+          </Tooltip>
+          <Tooltip arrow placement="bottom" title="With arrow">
+            <Button>Arrow</Button>
+          </Tooltip>
+        </TooltipGroup>
+      </Flexbox>
+    </StoryBook>
+  );
+};

--- a/src/Tooltip/groupContext.ts
+++ b/src/Tooltip/groupContext.ts
@@ -1,0 +1,14 @@
+import { createContext } from 'react';
+
+import type { TooltipProps } from './type';
+
+export type TooltipGroupItem = Omit<TooltipProps, 'children' | 'open' | 'defaultOpen'>;
+
+export type TooltipGroupApi = {
+  closeFromTrigger: (triggerEl: HTMLElement, item: TooltipGroupItem) => void;
+  closeImmediately: () => void;
+  isActiveTrigger: (triggerEl: HTMLElement) => boolean;
+  openFromTrigger: (triggerEl: HTMLElement, item: TooltipGroupItem) => void;
+};
+
+export const TooltipGroupContext = createContext<TooltipGroupApi | null>(null);

--- a/src/Tooltip/index.md
+++ b/src/Tooltip/index.md
@@ -9,19 +9,35 @@ description: The Tooltip component is used to provide additional information to 
 
 <code src="./demos/index.tsx" nopadding></code>
 
+## Tooltip Group (Singleton)
+
+Wrap multiple tooltips in `TooltipGroup` to share a single floating instance. When you hover/focus different triggers, the tooltip only updates the anchor + content, reducing per-tooltip overhead.
+
+<code src="./demos/group.tsx" nopadding></code>
+
 ## APIs
 
 ### Tooltip
 
-| Property    | Description                                 | Type                                                         | Default |
-| ----------- | ------------------------------------------- | ------------------------------------------------------------ | ------- |
-| title       | Content of the tooltip                      | `ReactNode`                                                  | -       |
-| hotkey      | Keyboard shortcut to display in the tooltip | `string`                                                     | -       |
-| hotkeyProps | Props for the Hotkey component              | `Omit<HotkeyProps, 'keys'>`                                  | -       |
-| arrow       | Whether the tooltip has an arrow pointer    | `boolean`                                                    | `false` |
-| placement   | Position of the tooltip                     | `'top' \| 'left' \| 'right' \| 'bottom' \| 'topLeft' \| ...` | `'top'` |
+| Property        | Description                                                        | Type                                                      | Default |
+| --------------- | ------------------------------------------------------------------ | --------------------------------------------------------- | ------- |
+| title           | Content of the tooltip                                             | `ReactNode`                                               | -       |
+| hotkey          | Keyboard shortcut to display in the tooltip                        | `string`                                                  | -       |
+| hotkeyProps     | Props for the Hotkey component                                     | `Omit<HotkeyProps, 'keys'>`                               | -       |
+| arrow           | Whether the tooltip has an arrow pointer                           | `boolean`                                                 | `false` |
+| placement       | Position of the tooltip                                            | `Floating UI Placement \| 'topLeft' \| ... (AntD legacy)` | `'top'` |
+| openDelay       | Delay before opening (ms). Takes precedence over `mouseEnterDelay` | `number`                                                  | -       |
+| closeDelay      | Delay before closing (ms). Takes precedence over `mouseLeaveDelay` | `number`                                                  | -       |
+| mouseEnterDelay | Delay before opening (seconds, AntD compatible)                    | `number`                                                  | `0`     |
+| mouseLeaveDelay | Delay before closing (seconds, AntD compatible)                    | `number`                                                  | `0`     |
 
-In addition to the above properties, Tooltip inherits all properties from Ant Design's Tooltip component (except for 'title', which has been enhanced to support hotkeys).
+Tooltip is built on top of `@floating-ui/react` (Base Tooltip). For compatibility, it keeps a subset of Ant Design Tooltip-like props (e.g. `mouseEnterDelay`, `mouseLeaveDelay`, legacy `placement` values, and `styles/classNames`).
+
+### TooltipGroup
+
+| Property | Description                                           | Type        | Default |
+| -------- | ----------------------------------------------------- | ----------- | ------- |
+| children | Tooltip subtree that shares a single tooltip instance | `ReactNode` | -       |
 
 #### Hotkey Support
 

--- a/src/Tooltip/index.tsx
+++ b/src/Tooltip/index.tsx
@@ -1,2 +1,3 @@
 export { default } from './Tooltip';
+export { default as TooltipGroup } from './TooltipGroup';
 export type * from './type';

--- a/src/Tooltip/style.ts
+++ b/src/Tooltip/style.ts
@@ -1,30 +1,31 @@
 import { createStyles } from 'antd-style';
 
-export const useStyles = createStyles(({ css, token, prefixCls }) => {
+export const useStyles = createStyles(({ css, token }) => {
   return {
+    arrow: css`
+      fill: ${token.colorText};
+    `,
+    content: css`
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      min-height: unset;
+      padding: 8px;
+      border-radius: ${token.borderRadiusSM}px;
+
+      color: ${token.colorBgLayout};
+      word-break: normal;
+
+      background-color: ${token.colorText};
+    `,
     tooltip: css`
-      .${prefixCls}-tooltip-inner {
-        display: flex;
-        align-items: center;
-        justify-content: center;
+      pointer-events: none;
 
-        min-height: unset;
-        padding-block: 4px;
-        padding-inline: 8px;
-
-        color: ${token.colorBgLayout};
-        word-break: normal;
-
-        background-color: ${token.colorText};
-        border-radius: ${token.borderRadiusSM}px;
-      }
-
-      .${prefixCls}-tooltip-arrow {
-        &::before,
-        &::after {
-          background: ${token.colorText};
-        }
-      }
+      /* Keep the class name for backwards compatibility and user overrides */
+      position: relative;
+      z-index: 114514;
+      filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 12%));
     `,
   };
 });

--- a/src/Tooltip/type.ts
+++ b/src/Tooltip/type.ts
@@ -1,12 +1,125 @@
-import type { TooltipProps as AntdTooltipProps } from 'antd';
-import type { TooltipRef } from 'antd/lib/tooltip';
-import type { ReactNode, Ref } from 'react';
+import type { Placement } from '@floating-ui/react';
+import type { CSSProperties, ReactElement, ReactNode, Ref } from 'react';
 
 import type { HotkeyProps } from '@/Hotkey';
 
-export type TooltipProps = Omit<AntdTooltipProps, 'title'> & {
+export type TooltipPlacement =
+  | Placement
+  | 'topLeft'
+  | 'top'
+  | 'topRight'
+  | 'leftTop'
+  | 'left'
+  | 'leftBottom'
+  | 'rightTop'
+  | 'right'
+  | 'rightBottom'
+  | 'bottomLeft'
+  | 'bottom'
+  | 'bottomRight';
+
+export type TooltipProps = {
+  /**
+   * Whether the tooltip has an arrow pointer.
+   */
+  arrow?: boolean;
+  /**
+   * Trigger element. Prefer a single React element.
+   */
+  children: ReactElement | ReactNode;
+
+  /**
+   * Custom className for the tooltip floating root.
+   */
+  className?: string;
+  /**
+   * Compatible with Ant Design `classNames` shape (subset).
+   */
+  classNames?: {
+    arrow?: string;
+    container?: string;
+    content?: string;
+    root?: string;
+  };
+
+  /**
+   * Delay (in milliseconds) before closing the tooltip.
+   * Takes precedence over `mouseLeaveDelay`.
+   */
+  closeDelay?: number;
+  /**
+   * Uncontrolled initial open state.
+   */
+  defaultOpen?: boolean;
+  /**
+   * Disable tooltip behavior.
+   */
+  disabled?: boolean;
+  /**
+   * An Ant Design compatible escape hatch for portal container.
+   */
+  getPopupContainer?: (triggerNode: HTMLElement) => HTMLElement;
+
   hotkey?: string;
   hotkeyProps?: Omit<HotkeyProps, 'keys'>;
-  ref?: Ref<TooltipRef>;
+  /**
+   * Delay (in seconds) before showing the tooltip on hover.
+   * Kept compatible with Ant Design `Tooltip`.
+   */
+  mouseEnterDelay?: number;
+
+  /**
+   * Delay (in seconds) before hiding the tooltip on hover out.
+   * Kept compatible with Ant Design `Tooltip`.
+   */
+  mouseLeaveDelay?: number;
+
+  /**
+   * Callback when open state changes.
+   */
+  onOpenChange?: (open: boolean) => void;
+
+  /**
+   * Controlled open state.
+   */
+  open?: boolean;
+
+  /**
+   * Delay (in milliseconds) before opening the tooltip.
+   * Takes precedence over `mouseEnterDelay`.
+   */
+  openDelay?: number;
+
+  /**
+   * Tooltip placement. Supports Floating UI placements and Ant Design legacy placements.
+   */
+  placement?: TooltipPlacement;
+
+  /**
+   * Render tooltip in a portal attached to body.
+   */
+  portalled?: boolean;
+
+  ref?: Ref<HTMLElement>;
+
+  /**
+   * Compatible with Ant Design `styles` shape (subset).
+   */
+  styles?: {
+    arrow?: CSSProperties;
+    /**
+     * Backwards-compatible alias for the floating root style.
+     */
+    container?: CSSProperties;
+    content?: CSSProperties;
+    root?: CSSProperties;
+  };
+  /**
+   * Tooltip content.
+   */
   title: ReactNode;
+  /**
+   * z-index for tooltip floating root.
+   */
+  zIndex?: number;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,7 @@ export {
 } from './ThemeProvider';
 export { default as ThemeSwitch, type ThemeSwitchProps } from './ThemeSwitch';
 export { default as Toc, type TocProps } from './Toc';
-export { default as Tooltip, type TooltipProps } from './Tooltip';
+export { default as Tooltip, TooltipGroup, type TooltipProps } from './Tooltip';
 export type * from './types';
 export { copyToClipboard } from './utils/copyToClipboard';
 export { type CDN, genCdnUrl } from './utils/genCdnUrl';

--- a/src/motion/LazyMotion.tsx
+++ b/src/motion/LazyMotion.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { LazyMotion as MotionLazyMotion } from 'motion/react';
+import { memo } from 'react';
+import type { ComponentProps } from 'react';
+
+import { loadFeatures } from './loadFeatures';
+
+type MotionLazyMotionProps = ComponentProps<typeof MotionLazyMotion>;
+
+export type LobeLazyMotionProps = Omit<MotionLazyMotionProps, 'features'> & {
+  /**
+   * Optional override for Motion features.
+   * Defaults to the shared lazy-loaded `loadFeatures`.
+   */
+  features?: MotionLazyMotionProps['features'];
+};
+
+/**
+ * A project-wide `LazyMotion` wrapper that provides a shared default `features` loader.
+ */
+export const LazyMotion = memo<LobeLazyMotionProps>(({ features, ...props }) => (
+  <MotionLazyMotion features={features ?? loadFeatures} {...props} />
+));
+
+LazyMotion.displayName = 'LazyMotion';

--- a/src/motion/index.ts
+++ b/src/motion/index.ts
@@ -1,0 +1,3 @@
+export { LazyMotion, type LobeLazyMotionProps } from './LazyMotion';
+export { loadFeatures } from './loadFeatures';
+export { AnimatePresence, m } from 'motion/react';

--- a/src/motion/loadFeatures.ts
+++ b/src/motion/loadFeatures.ts
@@ -1,0 +1,11 @@
+import { LazyMotion as MotionLazyMotion } from 'motion/react';
+import type { ComponentProps } from 'react';
+
+/**
+ * Shared lazy-loaded Motion features bundle.
+ * Using a dynamic import keeps the initial bundle lighter and avoids repeating this logic across components.
+ */
+type MotionLazyMotionProps = ComponentProps<typeof MotionLazyMotion>;
+
+export const loadFeatures: MotionLazyMotionProps['features'] = () =>
+  import('motion/react').then((res) => (res as any).domAnimation);

--- a/src/utils/composeEventHandlers.ts
+++ b/src/utils/composeEventHandlers.ts
@@ -1,0 +1,29 @@
+/**
+ * Composes two event handlers together, calling the external handler first,
+ * then the internal handler if the event hasn't been prevented.
+ *
+ * @template E - The event type
+ * @param theirHandler - The external event handler (may be undefined)
+ * @param ourHandler - The internal event handler
+ * @returns A composed event handler that calls both handlers in sequence
+ *
+ * @example
+ * ```tsx
+ * <button
+ *   onClick={composeEventHandlers(externalOnClick, (e) => {
+ *     // Internal handler logic
+ *   })}
+ * />
+ * ```
+ */
+export const composeEventHandlers =
+  <E>(
+    theirHandler: ((event: E) => void) | undefined,
+    ourHandler: (event: E) => void,
+  ): ((event: E) => void) =>
+  (event) => {
+    theirHandler?.(event);
+    // @ts-ignore - compatible with React SyntheticEvent shape
+    if (event?.defaultPrevented) return;
+    ourHandler(event);
+  };


### PR DESCRIPTION
- Added TooltipGroup component to manage multiple tooltips with a single floating instance, improving performance and usability.
- Updated Tooltip component to support TooltipGroup integration, allowing for dynamic tooltip content updates.
- Enhanced TooltipProps to include new properties for better control over tooltip behavior and appearance.
- Introduced utility functions for converting Ant Design placements to Floating UI placements for better compatibility.
- Updated styles and documentation to reflect the new TooltipGroup feature and its usage.


Before: 

https://github.com/user-attachments/assets/e1a94d75-7d66-4a57-bf81-fbfe21da974c

After:

https://github.com/user-attachments/assets/8c712797-da45-4722-82f1-d369da27fe2b


And the antd tooltip has been removed, performance has speed up about ~2x.


Signed-off-by: Innei <tukon479@gmail.com>
