### PR TITLE
♻️ refactor: remove layout-kit

### DIFF
--- a/docs/index.tsx
+++ b/docs/index.tsx
@@ -1,5 +1,4 @@
-import { Highlighter, Snippet } from '@lobehub/ui';
-import { Center } from '@lobehub/ui/Flex';
+import { Center, Highlighter, Snippet } from '@lobehub/ui';
 import { Features, FeaturesProps } from '@lobehub/ui/awesome';
 import { useTheme } from 'antd-style';
 import { MoonStar, Palette, Zap } from 'lucide-react';

--- a/docs/index.tsx
+++ b/docs/index.tsx
@@ -1,8 +1,8 @@
 import { Highlighter, Snippet } from '@lobehub/ui';
+import { Center } from '@lobehub/ui/Flex';
 import { Features, FeaturesProps } from '@lobehub/ui/awesome';
 import { useTheme } from 'antd-style';
 import { MoonStar, Palette, Zap } from 'lucide-react';
-import { Center } from 'react-layout-kit';
 
 const items: FeaturesProps['items'] = [
   {

--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
     "react-avatar-editor": "^14.0.0",
     "react-error-boundary": "^6.0.0",
     "react-hotkeys-hook": "^5.2.1",
-    "react-layout-kit": "^2.0.1",
     "react-markdown": "^10.1.0",
     "react-merge-refs": "^3.0.2",
     "react-rnd": "^10.5.2",

--- a/src/Accordion/AccordionItem.tsx
+++ b/src/Accordion/AccordionItem.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { KeyboardEvent, memo, useCallback, useMemo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import Block from '@/Block';
+import { Flexbox } from '@/Flex';
 import Text from '@/Text';
 import { LazyMotion, m } from '@/motion';
 

--- a/src/Accordion/demos/data.tsx
+++ b/src/Accordion/demos/data.tsx
@@ -1,6 +1,7 @@
 import { Accordion, AccordionItem, ActionIcon } from '@lobehub/ui';
 import { MoreHorizontal, Settings } from 'lucide-react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   return (

--- a/src/Accordion/demos/index.tsx
+++ b/src/Accordion/demos/index.tsx
@@ -1,6 +1,7 @@
 import { Accordion, AccordionItem, type AccordionProps } from '@lobehub/ui';
 import { StoryBook, useControls, useCreateStore } from '@lobehub/ui/storybook';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   const store = useCreateStore();

--- a/src/ActionIcon/ActionIcon.tsx
+++ b/src/ActionIcon/ActionIcon.tsx
@@ -3,8 +3,8 @@
 import { cva } from 'class-variance-authority';
 import { Loader2 } from 'lucide-react';
 import { type MouseEventHandler, memo, useCallback, useMemo } from 'react';
-import { Center } from 'react-layout-kit';
 
+import { Center } from '@/Flex';
 import Icon from '@/Icon';
 import Tooltip from '@/Tooltip';
 

--- a/src/ActionIcon/demos/Size.tsx
+++ b/src/ActionIcon/demos/Size.tsx
@@ -1,6 +1,7 @@
 import { ActionIcon } from '@lobehub/ui';
 import { Settings } from 'lucide-react';
-import { Center } from 'react-layout-kit';
+
+import { Center } from '@/Flex';
 
 export default () => {
   return (

--- a/src/ActionIcon/demos/Variant.tsx
+++ b/src/ActionIcon/demos/Variant.tsx
@@ -1,6 +1,7 @@
 import { ActionIcon } from '@lobehub/ui';
 import { Settings } from 'lucide-react';
-import { Center } from 'react-layout-kit';
+
+import { Center } from '@/Flex';
 
 export default () => {
   return (

--- a/src/ActionIcon/type.ts
+++ b/src/ActionIcon/type.ts
@@ -1,5 +1,5 @@
+import type { CenterProps } from '@lobehub/ui/Flex';
 import type { ReactNode, Ref } from 'react';
-import type { CenterProps } from 'react-layout-kit';
 
 import type { IconProps, IconSizeConfig, IconSizeType, LucideIconProps } from '@/Icon';
 import type { TooltipProps } from '@/Tooltip';

--- a/src/ActionIcon/type.ts
+++ b/src/ActionIcon/type.ts
@@ -1,6 +1,6 @@
-import type { CenterProps } from '@lobehub/ui/Flex';
 import type { ReactNode, Ref } from 'react';
 
+import type { CenterProps } from '@/Flex';
 import type { IconProps, IconSizeConfig, IconSizeType, LucideIconProps } from '@/Icon';
 import type { TooltipProps } from '@/Tooltip';
 

--- a/src/ActionIconGroup/ActionIconGroup.tsx
+++ b/src/ActionIconGroup/ActionIconGroup.tsx
@@ -3,10 +3,10 @@
 import { cva } from 'class-variance-authority';
 import { MoreHorizontal } from 'lucide-react';
 import { memo, useMemo } from 'react';
-import { Center } from 'react-layout-kit';
 
 import ActionIcon from '@/ActionIcon';
 import Dropdown from '@/Dropdown';
+import { Center } from '@/Flex';
 
 import { useStyles } from './style';
 import type { ActionIconGroupProps } from './type';

--- a/src/ActionIconGroup/type.ts
+++ b/src/ActionIconGroup/type.ts
@@ -1,5 +1,5 @@
+import type { CenterProps } from '@lobehub/ui/Flex';
 import type { Ref } from 'react';
-import type { CenterProps } from 'react-layout-kit';
 
 import type { ActionIconProps } from '@/ActionIcon';
 import type { DropdownProps } from '@/Dropdown';

--- a/src/ActionIconGroup/type.ts
+++ b/src/ActionIconGroup/type.ts
@@ -1,8 +1,8 @@
-import type { CenterProps } from '@lobehub/ui/Flex';
 import type { Ref } from 'react';
 
 import type { ActionIconProps } from '@/ActionIcon';
 import type { DropdownProps } from '@/Dropdown';
+import type { CenterProps } from '@/Flex';
 import type { MenuInfo, MenuItemType } from '@/Menu';
 
 export type ActionIconGroupEvent = Pick<MenuInfo, 'key' | 'keyPath' | 'domEvent'>;

--- a/src/Alert/Alert.tsx
+++ b/src/Alert/Alert.tsx
@@ -5,10 +5,10 @@ import { cva } from 'class-variance-authority';
 import { camelCase } from 'lodash-es';
 import { AlertTriangle, CheckCircle, Info, X, XCircle } from 'lucide-react';
 import { memo, useMemo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import { Accordion, AccordionItem } from '@/Accordion';
 import ActionIcon from '@/ActionIcon';
+import { Flexbox } from '@/Flex';
 import Icon from '@/Icon';
 
 import { useStyles } from './style';

--- a/src/Avatar/Avatar.tsx
+++ b/src/Avatar/Avatar.tsx
@@ -6,8 +6,8 @@ import { cva } from 'class-variance-authority';
 import { Loader2 } from 'lucide-react';
 import { readableColor } from 'polished';
 import { isValidElement, memo, useMemo } from 'react';
-import { Center } from 'react-layout-kit';
 
+import { Center } from '@/Flex';
 import FluentEmoji from '@/FluentEmoji';
 import Icon from '@/Icon';
 import Img from '@/Img';
@@ -44,8 +44,8 @@ const Avatar = memo<AvatarProps>(
       () =>
         Boolean(
           avatar &&
-            (['/', 'http', 'data:'].some((index) => isStringAvatar && avatar.startsWith(index)) ||
-              isValidElement(avatar)),
+          (['/', 'http', 'data:'].some((index) => isStringAvatar && avatar.startsWith(index)) ||
+            isValidElement(avatar)),
         ),
       [avatar, isStringAvatar],
     );

--- a/src/Avatar/Avatar.tsx
+++ b/src/Avatar/Avatar.tsx
@@ -25,7 +25,7 @@ const Avatar = memo<AvatarProps>(
     animation,
     borderedColor,
     size = 48,
-    shape = 'circle',
+    shape,
     background,
     style,
     unoptimized,
@@ -128,7 +128,7 @@ const Avatar = memo<AvatarProps>(
         size={size}
         src={isDefaultAntAvatar ? defualtAvatar : undefined}
         style={{
-          background: background,
+          background: isDefaultAntAvatar ? background : background || theme.colorBorder,
           boxShadow: bordered
             ? `${theme.colorBgLayout} 0 0 0 2px, ${borderedColor || theme.colorTextTertiary} 0 0 0 4px`
             : undefined,

--- a/src/Avatar/AvatarGroup/index.tsx
+++ b/src/Avatar/AvatarGroup/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import Avatar from '../Avatar';
 import type { AvatarGroupProps } from '../type';

--- a/src/Avatar/demos/Bordered.tsx
+++ b/src/Avatar/demos/Bordered.tsx
@@ -1,6 +1,7 @@
 import { Avatar } from '@lobehub/ui';
 import { useTheme } from 'antd-style';
-import { Center } from 'react-layout-kit';
+
+import { Center } from '@/Flex';
 
 const url = 'https://avatars.githubusercontent.com/u/17870709?v=4';
 

--- a/src/Avatar/demos/Text.tsx
+++ b/src/Avatar/demos/Text.tsx
@@ -1,5 +1,6 @@
 import { Avatar } from '@lobehub/ui';
-import { Center } from 'react-layout-kit';
+
+import { Center } from '@/Flex';
 
 export default () => {
   return (

--- a/src/Avatar/type.ts
+++ b/src/Avatar/type.ts
@@ -1,6 +1,6 @@
+import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { AvatarProps as AntAvatarProps } from 'antd';
 import type { CSSProperties, ReactNode, Ref } from 'react';
-import type { FlexboxProps } from 'react-layout-kit';
 
 import type { TooltipProps } from '@/Tooltip';
 

--- a/src/Avatar/type.ts
+++ b/src/Avatar/type.ts
@@ -1,7 +1,7 @@
-import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { AvatarProps as AntAvatarProps } from 'antd';
 import type { CSSProperties, ReactNode, Ref } from 'react';
 
+import type { FlexboxProps } from '@/Flex';
 import type { TooltipProps } from '@/Tooltip';
 
 export interface AvatarProps extends AntAvatarProps {

--- a/src/Block/Block.tsx
+++ b/src/Block/Block.tsx
@@ -2,7 +2,8 @@
 
 import { cva } from 'class-variance-authority';
 import { memo, useMemo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { useStyles } from './style';
 import type { BlockProps } from './type';

--- a/src/Block/type.ts
+++ b/src/Block/type.ts
@@ -1,5 +1,6 @@
-import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { Ref } from 'react';
+
+import type { FlexboxProps } from '@/Flex';
 
 export interface BlockProps extends FlexboxProps {
   clickable?: boolean;

--- a/src/Block/type.ts
+++ b/src/Block/type.ts
@@ -1,5 +1,5 @@
+import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { Ref } from 'react';
-import type { FlexboxProps } from 'react-layout-kit';
 
 export interface BlockProps extends FlexboxProps {
   clickable?: boolean;

--- a/src/Burger/Burger.tsx
+++ b/src/Burger/Burger.tsx
@@ -3,9 +3,9 @@
 import { Drawer, Menu } from 'antd';
 import { MenuIcon, X } from 'lucide-react';
 import { memo } from 'react';
-import { Center } from 'react-layout-kit';
 
 import ActionIcon from '@/ActionIcon';
+import { Center } from '@/Flex';
 
 import { useStyles } from './style';
 import type { BurgerProps } from './type';

--- a/src/Button/demos/Variant.tsx
+++ b/src/Button/demos/Variant.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@lobehub/ui';
 import { Divider } from 'antd';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   return (

--- a/src/CodeEditor/CodeEditor.tsx
+++ b/src/CodeEditor/CodeEditor.tsx
@@ -2,10 +2,10 @@
 
 import { cva } from 'class-variance-authority';
 import { memo, useMemo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 import useMergeState from 'use-merge-value';
 
 import { useStyles } from '@/CodeEditor/style';
+import { Flexbox } from '@/Flex';
 import SyntaxHighlighter from '@/Highlighter/SyntaxHighlighter';
 
 import { CodeEditorProps } from './type';

--- a/src/CodeEditor/type.ts
+++ b/src/CodeEditor/type.ts
@@ -1,6 +1,6 @@
-import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { CSSProperties, Ref } from 'react';
 
+import type { FlexboxProps } from '@/Flex';
 import type { TextAreaProps } from '@/types';
 
 export interface CodeEditorProps

--- a/src/CodeEditor/type.ts
+++ b/src/CodeEditor/type.ts
@@ -1,11 +1,10 @@
+import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { CSSProperties, Ref } from 'react';
-import type { FlexboxProps } from 'react-layout-kit';
 
 import type { TextAreaProps } from '@/types';
 
 export interface CodeEditorProps
-  extends TextAreaProps,
-    Pick<FlexboxProps, 'width' | 'height' | 'flex'> {
+  extends TextAreaProps, Pick<FlexboxProps, 'width' | 'height' | 'flex'> {
   classNames?: {
     highlight?: string;
     textarea?: string;

--- a/src/Collapse/Collapse.tsx
+++ b/src/Collapse/Collapse.tsx
@@ -4,8 +4,8 @@ import { Collapse as AntdCollapse, ConfigProvider } from 'antd';
 import { cva } from 'class-variance-authority';
 import { ChevronDown } from 'lucide-react';
 import { isValidElement, memo, useMemo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
+import { Flexbox } from '@/Flex';
 import Icon from '@/Icon';
 
 import { DEFAULT_PADDING, getPadding, useStyles } from './style';

--- a/src/Collapse/demos/Padding.tsx
+++ b/src/Collapse/demos/Padding.tsx
@@ -1,5 +1,6 @@
 import { Collapse } from '@lobehub/ui';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { items } from './data';
 

--- a/src/ColorSwatches/ColorSwatches.tsx
+++ b/src/ColorSwatches/ColorSwatches.tsx
@@ -5,9 +5,9 @@ import chroma from 'chroma-js';
 import { CheckIcon } from 'lucide-react';
 import { readableColor, rgba } from 'polished';
 import { memo, useMemo } from 'react';
-import { Center, Flexbox } from 'react-layout-kit';
 import useMergeState from 'use-merge-value';
 
+import { Center, Flexbox } from '@/Flex';
 import Icon from '@/Icon';
 import Tooltip from '@/Tooltip';
 

--- a/src/ColorSwatches/type.ts
+++ b/src/ColorSwatches/type.ts
@@ -1,5 +1,6 @@
-import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { Key, ReactNode, Ref } from 'react';
+
+import type { FlexboxProps } from '@/Flex';
 
 interface ColorSwatchesItemType {
   color: string;

--- a/src/ColorSwatches/type.ts
+++ b/src/ColorSwatches/type.ts
@@ -1,5 +1,5 @@
+import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { Key, ReactNode, Ref } from 'react';
-import type { FlexboxProps } from 'react-layout-kit';
 
 interface ColorSwatchesItemType {
   color: string;

--- a/src/DraggablePanel/DraggablePanel.tsx
+++ b/src/DraggablePanel/DraggablePanel.tsx
@@ -16,9 +16,9 @@ import {
   useRef,
   useTransition,
 } from 'react';
-import { Center } from 'react-layout-kit';
 import useControlledState from 'use-merge-value';
 
+import { Center } from '@/Flex';
 import Icon from '@/Icon';
 
 import { useStyles } from './style';

--- a/src/DraggablePanel/components/DraggablePanelBody.tsx
+++ b/src/DraggablePanel/components/DraggablePanelBody.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
+import { Flexbox } from '@/Flex';
 import { type DivProps } from '@/types';
 
 import { useStyles } from './style';

--- a/src/DraggablePanel/components/DraggablePanelContainer.tsx
+++ b/src/DraggablePanel/components/DraggablePanelContainer.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
+import { Flexbox } from '@/Flex';
 import { type DivProps } from '@/types';
 
 import { useStyles } from './style';

--- a/src/DraggablePanel/components/DraggablePanelFooter.tsx
+++ b/src/DraggablePanel/components/DraggablePanelFooter.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
+import { Flexbox } from '@/Flex';
 import { type DivProps } from '@/types';
 
 import { useStyles } from './style';

--- a/src/DraggablePanel/components/DraggablePanelHeader.tsx
+++ b/src/DraggablePanel/components/DraggablePanelHeader.tsx
@@ -2,10 +2,10 @@
 
 import { PanelLeft, Pin, PinOff } from 'lucide-react';
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 import useControlledState from 'use-merge-value';
 
 import ActionIcon from '@/ActionIcon';
+import { Flexbox } from '@/Flex';
 import { type DivProps } from '@/types';
 
 import { useStyles } from './style';

--- a/src/DraggablePanel/demos/Layout.tsx
+++ b/src/DraggablePanel/demos/Layout.tsx
@@ -6,7 +6,8 @@ import {
   DraggablePanelHeader,
 } from '@lobehub/ui';
 import { useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   const [expand, setExpand] = useState(true);

--- a/src/DraggablePanel/demos/index.tsx
+++ b/src/DraggablePanel/demos/index.tsx
@@ -1,6 +1,7 @@
 import { DraggablePanel, DraggablePanelProps } from '@lobehub/ui';
 import { StoryBook, useControls, useCreateStore } from '@lobehub/ui/storybook';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   const store = useCreateStore();

--- a/src/DraggableSideNav/DraggableSideNav.tsx
+++ b/src/DraggableSideNav/DraggableSideNav.tsx
@@ -4,9 +4,9 @@ import { useHover } from 'ahooks';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { Resizable, ResizeCallback } from 're-resizable';
 import { CSSProperties, memo, useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
-import { Center, Flexbox } from 'react-layout-kit';
 import useControlledState from 'use-merge-value';
 
+import { Center, Flexbox } from '@/Flex';
 import Icon from '@/Icon';
 
 import { useStyles } from './style';

--- a/src/DraggableSideNav/demos/Body.tsx
+++ b/src/DraggableSideNav/demos/Body.tsx
@@ -1,7 +1,8 @@
 import { Avatar, Menu, Text } from '@lobehub/ui';
 import { FolderIcon } from 'lucide-react';
 import type { FC } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { agents } from './data';
 

--- a/src/DraggableSideNav/demos/Footer.tsx
+++ b/src/DraggableSideNav/demos/Footer.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export const DemoFooter: FC<{ expand: boolean }> = () => {
   return <Flexbox gap={8} padding={8} />;

--- a/src/DraggableSideNav/demos/Header.tsx
+++ b/src/DraggableSideNav/demos/Header.tsx
@@ -1,7 +1,8 @@
 import { ActionIcon, Avatar, Menu, type MenuItemType, Text } from '@lobehub/ui';
 import { ChevronDown, Home, SquareDashedBottom, Users } from 'lucide-react';
 import type { FC } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export const DemoHeader: FC<{
   activeKey: string;

--- a/src/DraggableSideNav/demos/index.tsx
+++ b/src/DraggableSideNav/demos/index.tsx
@@ -1,7 +1,8 @@
 import { DraggableSideNav } from '@lobehub/ui';
 import { StoryBook, useControls, useCreateStore } from '@lobehub/ui/storybook';
 import { useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { DemoBody } from './Body';
 import { DemoFooter } from './Footer';

--- a/src/Drawer/Drawer.tsx
+++ b/src/Drawer/Drawer.tsx
@@ -4,9 +4,9 @@ import { Drawer as AntdDrawer } from 'antd';
 import { useTheme } from 'antd-style';
 import { XIcon } from 'lucide-react';
 import { CSSProperties, memo, useMemo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import ActionIcon from '@/ActionIcon';
+import { Flexbox } from '@/Flex';
 
 import type { DrawerProps } from './type';
 

--- a/src/Dropdown/demos/ContextMenu.tsx
+++ b/src/Dropdown/demos/ContextMenu.tsx
@@ -1,5 +1,6 @@
 import { Dropdown } from '@lobehub/ui';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { menu } from './data';
 

--- a/src/EditableText/ControlInput.tsx
+++ b/src/EditableText/ControlInput.tsx
@@ -3,9 +3,9 @@
 import type { InputRef } from 'antd';
 import { RotateCcw, Save } from 'lucide-react';
 import { memo, useEffect, useRef, useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import ActionIcon, { type ActionIconProps } from '@/ActionIcon';
+import { Flexbox } from '@/Flex';
 import Input, { type InputProps } from '@/Input';
 
 export interface ControlInputProps extends Omit<InputProps, 'onChange' | 'value' | 'onAbort'> {

--- a/src/EditableText/EditableText.tsx
+++ b/src/EditableText/EditableText.tsx
@@ -4,10 +4,10 @@ import { cx } from 'antd-style';
 import { Edit3 } from 'lucide-react';
 import { memo, useMemo } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
-import { Flexbox } from 'react-layout-kit';
 import useControlledState from 'use-merge-value';
 
 import ActionIcon from '@/ActionIcon';
+import { Flexbox } from '@/Flex';
 
 import ControlInput from './ControlInput';
 import type { EditableTextProps } from './type';

--- a/src/EditableText/type.ts
+++ b/src/EditableText/type.ts
@@ -1,10 +1,11 @@
+import type { FlexboxProps } from '@lobehub/ui/Flex';
 import { CSSProperties } from 'react';
-import type { FlexboxProps } from 'react-layout-kit';
 
 import type { ControlInputProps } from '@/EditableText/ControlInput';
 
 export interface EditableTextProps
-  extends Omit<FlexboxProps, 'onChange' | 'onBlur' | 'onFocus'>,
+  extends
+    Omit<FlexboxProps, 'onChange' | 'onBlur' | 'onFocus'>,
     Pick<
       ControlInputProps,
       | 'onChange'

--- a/src/EditableText/type.ts
+++ b/src/EditableText/type.ts
@@ -1,7 +1,7 @@
-import type { FlexboxProps } from '@lobehub/ui/Flex';
 import { CSSProperties } from 'react';
 
 import type { ControlInputProps } from '@/EditableText/ControlInput';
+import type { FlexboxProps } from '@/Flex';
 
 export interface EditableTextProps
   extends

--- a/src/EmojiPicker/AvatarUploader.tsx
+++ b/src/EmojiPicker/AvatarUploader.tsx
@@ -5,9 +5,9 @@ import { useTheme } from 'antd-style';
 import { ChevronLeftIcon, ImageUpIcon } from 'lucide-react';
 import { memo, useCallback, useRef, useState } from 'react';
 import AvatarEditor from 'react-avatar-editor';
-import { Center, Flexbox } from 'react-layout-kit';
 
 import Button from '@/Button';
+import { Center, Flexbox } from '@/Flex';
 import Icon from '@/Icon';
 import Tag from '@/Tag';
 import Text from '@/Text';

--- a/src/EmojiPicker/EmojiPicker.tsx
+++ b/src/EmojiPicker/EmojiPicker.tsx
@@ -5,12 +5,12 @@ import Picker from '@emoji-mart/react';
 import { Popover } from 'antd';
 import { SmileIcon, TrashIcon, UploadIcon } from 'lucide-react';
 import { memo, useRef, useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
 import useSWR from 'swr';
 import useMergeState from 'use-merge-value';
 
 import ActionIcon from '@/ActionIcon';
 import Avatar from '@/Avatar';
+import { Flexbox } from '@/Flex';
 import Icon from '@/Icon';
 import Tabs, { TabsProps } from '@/Tabs';
 import Tooltip from '@/Tooltip';

--- a/src/EmojiPicker/demos/Control.tsx
+++ b/src/EmojiPicker/demos/Control.tsx
@@ -1,6 +1,7 @@
 import { Button, EmojiPicker } from '@lobehub/ui';
 import { useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   const [open, setOpen] = useState(false);

--- a/src/Empty/Empty.tsx
+++ b/src/Empty/Empty.tsx
@@ -3,9 +3,9 @@
 import { Empty as AntEmpty } from 'antd';
 import { useTheme } from 'antd-style';
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import Block from '@/Block';
+import { Flexbox } from '@/Flex';
 import FluentEmoji from '@/FluentEmoji';
 import Icon from '@/Icon';
 import Text from '@/Text';

--- a/src/Empty/type.ts
+++ b/src/Empty/type.ts
@@ -1,7 +1,7 @@
-import { FlexboxProps } from '@lobehub/ui/Flex';
 import { ReactNode } from 'react';
 
 import { BlockProps } from '@/Block';
+import { FlexboxProps } from '@/Flex';
 import { IconProps } from '@/Icon';
 import { TextProps } from '@/Text';
 

--- a/src/Empty/type.ts
+++ b/src/Empty/type.ts
@@ -1,5 +1,5 @@
+import { FlexboxProps } from '@lobehub/ui/Flex';
 import { ReactNode } from 'react';
-import { FlexboxProps } from 'react-layout-kit';
 
 import { BlockProps } from '@/Block';
 import { IconProps } from '@/Icon';

--- a/src/FileTypeIcon/FileTypeIcon.tsx
+++ b/src/FileTypeIcon/FileTypeIcon.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { memo, useMemo } from 'react';
-import { Center } from 'react-layout-kit';
+
+import { Center } from '@/Flex';
 
 import FileIcon from './components/FileIcon';
 import FolderIcon from './components/FolderIcon';

--- a/src/FileTypeIcon/demos/Icon.tsx
+++ b/src/FileTypeIcon/demos/Icon.tsx
@@ -1,7 +1,8 @@
 import { FileTypeIcon, Icon } from '@lobehub/ui';
 import { createStyles, useTheme } from 'antd-style';
 import { ArrowUpIcon, PlusIcon } from 'lucide-react';
-import { Center, Flexbox } from 'react-layout-kit';
+
+import { Center, Flexbox } from '@/Flex';
 
 const useStyles = createStyles(({ css, token }) => {
   return {
@@ -12,12 +13,12 @@ const useStyles = createStyles(({ css, token }) => {
 
       width: 150px;
       height: 100px;
+      border-radius: ${token.borderRadiusLG}px;
 
       font-weight: 500;
       text-align: center;
 
       background: ${token.colorFillTertiary};
-      border-radius: ${token.borderRadiusLG}px;
       box-shadow: 0 0 0 1px ${token.colorFillTertiary} inset;
     `,
     glow: css`

--- a/src/Flex/style.css
+++ b/src/Flex/style.css
@@ -1,20 +1,36 @@
 .lobe-flex {
+  /* Define defaults on the element itself to avoid CSS variable inheritance leaking to nested Flex */
+  --lobe-flex: 0 1 auto;
+  --lobe-flex-direction: column;
+  --lobe-flex-wrap: nowrap;
+  --lobe-flex-justify: flex-start;
+  --lobe-flex-align: stretch;
+  --lobe-flex-width: auto;
+  --lobe-flex-height: auto;
+  --lobe-flex-padding: 0;
+  /* Keep padding-inline/block aligned with padding by default, and prevent inheriting from parent */
+  --lobe-flex-padding-inline: var(--lobe-flex-padding);
+  --lobe-flex-padding-block: var(--lobe-flex-padding);
+  --lobe-flex-gap: 0;
+
   display: flex;
-  flex: var(--lobe-flex, 0 1 auto);
-  flex-direction: var(--lobe-flex-direction, column);
-  flex-wrap: var(--lobe-flex-wrap, nowrap);
-  justify-content: var(--lobe-flex-justify, flex-start);
-  align-items: var(--lobe-flex-align, stretch);
-  width: var(--lobe-flex-width, auto);
-  height: var(--lobe-flex-height, auto);
-  padding: var(--lobe-flex-padding, 0);
-  padding-inline: var(--lobe-flex-padding-inline, initial);
-  padding-block: var(--lobe-flex-padding-block, initial);
-  gap: var(--lobe-flex-gap, 0);
+
+  flex: var(--lobe-flex);
+  flex-direction: var(--lobe-flex-direction);
+  flex-wrap: var(--lobe-flex-wrap);
+  justify-content: var(--lobe-flex-justify);
+  align-items: var(--lobe-flex-align);
+
+  width: var(--lobe-flex-width);
+  height: var(--lobe-flex-height);
+
+  padding: var(--lobe-flex-padding);
+  padding-inline: var(--lobe-flex-padding-inline);
+  padding-block: var(--lobe-flex-padding-block);
+
+  gap: var(--lobe-flex-gap);
 }
 
 .lobe-flex--hidden {
   display: none;
 }
-
-

--- a/src/FluentEmoji/FluentEmoji.tsx
+++ b/src/FluentEmoji/FluentEmoji.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { memo, useMemo, useState } from 'react';
-import { Center } from 'react-layout-kit';
 
 import { useCdnFn } from '@/ConfigProvider';
+import { Center } from '@/Flex';
 import Img from '@/Img';
 
 import { useStyles } from './style';

--- a/src/FluentEmoji/demos/index.tsx
+++ b/src/FluentEmoji/demos/index.tsx
@@ -2,7 +2,8 @@ import { getEmoji, getEmojiNameByCharacter } from '@lobehub/fluent-emoji';
 import { FluentEmoji, type FluentEmojiProps } from '@lobehub/ui';
 import { StoryBook, useControls, useCreateStore } from '@lobehub/ui/storybook';
 import { Button } from 'antd';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   const store = useCreateStore();

--- a/src/Footer/Footer.tsx
+++ b/src/Footer/Footer.tsx
@@ -2,7 +2,8 @@
 
 import RcFooter from 'rc-footer';
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { useStyles } from './style';
 import type { FooterProps } from './type';

--- a/src/Footer/type.ts
+++ b/src/Footer/type.ts
@@ -1,6 +1,7 @@
-import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { FooterProps as RcProps } from 'rc-footer';
 import type { ReactNode } from 'react';
+
+import type { FlexboxProps } from '@/Flex';
 
 export interface FooterProps extends FlexboxProps {
   bottom?: ReactNode;

--- a/src/Footer/type.ts
+++ b/src/Footer/type.ts
@@ -1,6 +1,6 @@
+import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { FooterProps as RcProps } from 'rc-footer';
 import type { ReactNode } from 'react';
-import type { FlexboxProps } from 'react-layout-kit';
 
 export interface FooterProps extends FlexboxProps {
   bottom?: ReactNode;

--- a/src/Form/components/FormFlatGroup.tsx
+++ b/src/Form/components/FormFlatGroup.tsx
@@ -3,7 +3,8 @@
 import { useResponsive } from 'antd-style';
 import { cva } from 'class-variance-authority';
 import { memo, useMemo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { useFlatGroupStyles as useStyles } from '../style';
 import type { FormFlatGroupProps } from '../type';

--- a/src/Form/components/FormFooter.tsx
+++ b/src/Form/components/FormFooter.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { useFooterStyles as useStyles } from '../style';
 import type { FormFooterProps } from '../type';

--- a/src/Form/components/FormGroup.tsx
+++ b/src/Form/components/FormGroup.tsx
@@ -4,9 +4,9 @@ import { useResponsive } from 'antd-style';
 import { cva } from 'class-variance-authority';
 import { isUndefined } from 'lodash-es';
 import { memo, useMemo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import Collapse from '@/Collapse';
+import { Flexbox } from '@/Flex';
 import Icon from '@/Icon';
 
 import { useGroupStyles as useStyles } from '../style';

--- a/src/Form/components/FormSubmitFooter.tsx
+++ b/src/Form/components/FormSubmitFooter.tsx
@@ -5,9 +5,9 @@ import isEqual from 'fast-deep-equal';
 import { InfoIcon } from 'lucide-react';
 import { motion } from 'motion/react';
 import { memo, useEffect, useMemo, useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import Button from '@/Button';
+import { Flexbox } from '@/Flex';
 import Icon from '@/Icon';
 
 import { useSubmitFooterStyles as useStyles } from '../style';

--- a/src/Form/components/FormTitle.tsx
+++ b/src/Form/components/FormTitle.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
+import { Flexbox } from '@/Flex';
 import Tag from '@/Tag';
 
 import { useTitleStyles as useStyles } from '../style';

--- a/src/Form/type.ts
+++ b/src/Form/type.ts
@@ -1,7 +1,7 @@
+import { FlexboxProps } from '@lobehub/ui/Flex';
 import type { FormProps as AntFormProps, DividerProps, FormInstance } from 'antd';
 import { FormItemProps as AntdFormItemProps } from 'antd/es/form/FormItem';
 import { CSSProperties, ReactNode, Ref } from 'react';
-import { FlexboxProps } from 'react-layout-kit';
 
 import type { ButtonProps } from '@/Button';
 import type { CollapseProps } from '@/Collapse';
@@ -60,8 +60,10 @@ export interface FormGroupItemType {
   variant?: FormVariant;
 }
 
-export interface FormGroupProps
-  extends Omit<CollapseProps, 'collapsible' | 'items' | 'defaultActiveKey' | 'activeKey'> {
+export interface FormGroupProps extends Omit<
+  CollapseProps,
+  'collapsible' | 'items' | 'defaultActiveKey' | 'activeKey'
+> {
   active?: boolean;
   children: ReactNode;
   collapsible?: boolean;

--- a/src/Form/type.ts
+++ b/src/Form/type.ts
@@ -1,10 +1,10 @@
-import { FlexboxProps } from '@lobehub/ui/Flex';
 import type { FormProps as AntFormProps, DividerProps, FormInstance } from 'antd';
 import { FormItemProps as AntdFormItemProps } from 'antd/es/form/FormItem';
 import { CSSProperties, ReactNode, Ref } from 'react';
 
 import type { ButtonProps } from '@/Button';
 import type { CollapseProps } from '@/Collapse';
+import { FlexboxProps } from '@/Flex';
 import type { IconProps } from '@/Icon';
 import type { TagProps } from '@/Tag';
 import type { DivProps } from '@/types';

--- a/src/FormModal/FormModal.tsx
+++ b/src/FormModal/FormModal.tsx
@@ -2,9 +2,9 @@
 
 import { useResponsive } from 'antd-style';
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import Button from '@/Button';
+import { Flexbox } from '@/Flex';
 import Form from '@/Form';
 import Modal from '@/Modal';
 

--- a/src/Grid/Grid.tsx
+++ b/src/Grid/Grid.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { useStyles } from './style';
 import type { GridProps } from './type';

--- a/src/Grid/type.ts
+++ b/src/Grid/type.ts
@@ -1,5 +1,5 @@
+import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { Ref } from 'react';
-import type { FlexboxProps } from 'react-layout-kit';
 
 export interface GridProps extends Omit<FlexboxProps, 'gap'> {
   gap?: string | number;

--- a/src/Grid/type.ts
+++ b/src/Grid/type.ts
@@ -1,5 +1,6 @@
-import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { Ref } from 'react';
+
+import type { FlexboxProps } from '@/Flex';
 
 export interface GridProps extends Omit<FlexboxProps, 'gap'> {
   gap?: string | number;

--- a/src/GroupAvatar/GroupAvatar.tsx
+++ b/src/GroupAvatar/GroupAvatar.tsx
@@ -17,8 +17,8 @@ const GroupAvatar = memo<GroupAvatarProps>(
     avatars = [],
     size = 32,
     grid = 2,
-    cornerShape = 'squircle',
-    avatarShape = 'circle',
+    cornerShape = 'square',
+    avatarShape = 'square',
     ...rest
   }) => {
     const { cx, styles } = useStyles();

--- a/src/GroupAvatar/demos/CornerShape.tsx
+++ b/src/GroupAvatar/demos/CornerShape.tsx
@@ -1,6 +1,6 @@
 import { Grid, GroupAvatar, Text } from '@lobehub/ui';
-import { Center } from 'react-layout-kit';
 
+import { Center } from '@/Flex';
 import { SMOOTH_CORNER_MASKS } from '@/utils/smoothCorners';
 
 const avatars = [

--- a/src/GroupAvatar/demos/index.tsx
+++ b/src/GroupAvatar/demos/index.tsx
@@ -1,6 +1,7 @@
 import { GroupAvatar, type GroupAvatarProps } from '@lobehub/ui';
 import { StoryBook, useControls, useCreateStore } from '@lobehub/ui/storybook';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   const store = useCreateStore();

--- a/src/GuideCard/GuideCard.tsx
+++ b/src/GuideCard/GuideCard.tsx
@@ -3,9 +3,9 @@
 import { cva } from 'class-variance-authority';
 import { X } from 'lucide-react';
 import { memo, useMemo, useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import ActionIcon from '@/ActionIcon';
+import { Flexbox } from '@/Flex';
 import Img from '@/Img';
 
 import { useStyles } from './style';

--- a/src/GuideCard/type.ts
+++ b/src/GuideCard/type.ts
@@ -1,8 +1,8 @@
-import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { ImageProps } from 'antd';
 import type { CSSProperties, ReactNode, Ref } from 'react';
 
 import type { ActionIconProps } from '@/ActionIcon';
+import type { FlexboxProps } from '@/Flex';
 import type { ImgProps } from '@/types';
 
 export interface GuideCardProps extends Omit<FlexboxProps, 'title'> {

--- a/src/GuideCard/type.ts
+++ b/src/GuideCard/type.ts
@@ -1,6 +1,6 @@
+import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { ImageProps } from 'antd';
 import type { CSSProperties, ReactNode, Ref } from 'react';
-import type { FlexboxProps } from 'react-layout-kit';
 
 import type { ActionIconProps } from '@/ActionIcon';
 import type { ImgProps } from '@/types';

--- a/src/Header/Header.tsx
+++ b/src/Header/Header.tsx
@@ -2,7 +2,8 @@
 
 import { useResponsive } from 'antd-style';
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { useStyles } from './style';
 import type { HeaderProps } from './type';

--- a/src/Header/type.ts
+++ b/src/Header/type.ts
@@ -1,5 +1,6 @@
-import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { CSSProperties, ReactNode, Ref } from 'react';
+
+import type { FlexboxProps } from '@/Flex';
 
 export interface HeaderProps extends FlexboxProps {
   actions?: ReactNode;

--- a/src/Header/type.ts
+++ b/src/Header/type.ts
@@ -1,5 +1,5 @@
+import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { CSSProperties, ReactNode, Ref } from 'react';
-import type { FlexboxProps } from 'react-layout-kit';
 
 export interface HeaderProps extends FlexboxProps {
   actions?: ReactNode;

--- a/src/Highlighter/FullFeatured.tsx
+++ b/src/Highlighter/FullFeatured.tsx
@@ -3,10 +3,10 @@
 import { cva } from 'class-variance-authority';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { ReactNode, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import ActionIcon from '@/ActionIcon';
 import CopyButton from '@/CopyButton';
+import { Flexbox } from '@/Flex';
 import { getCodeLanguageDisplayName, getCodeLanguageFilename } from '@/Highlighter/const';
 import MaterialFileTypeIcon from '@/MaterialFileTypeIcon';
 import Text from '@/Text';

--- a/src/Highlighter/FullFeatured.tsx
+++ b/src/Highlighter/FullFeatured.tsx
@@ -39,6 +39,9 @@ const HeaderLanguage = memo<HeaderLanguageProps>(
   }) => {
     if (!showLanguage) return null;
 
+    if (allowChangeLanguage && !fileName)
+      return <LangSelect onSelect={setLanguage} value={language.toLowerCase()} />;
+
     return (
       <Flexbox
         align={'center'}
@@ -46,26 +49,21 @@ const HeaderLanguage = memo<HeaderLanguageProps>(
         flex={1}
         gap={4}
         horizontal
-        justify={'center'}
+        justify={'flex-start'}
+        paddingInline={8}
       >
-        {allowChangeLanguage && !fileName ? (
-          <LangSelect onSelect={setLanguage} value={language.toLowerCase()} />
-        ) : (
-          <>
-            {icon || (
-              <MaterialFileTypeIcon
-                fallbackUnknownType={false}
-                filename={filetype}
-                size={18}
-                type={'file'}
-                variant={'raw'}
-              />
-            )}
-            <Text ellipsis fontSize={13}>
-              {displayName}
-            </Text>
-          </>
+        {icon || (
+          <MaterialFileTypeIcon
+            fallbackUnknownType={false}
+            filename={filetype}
+            size={18}
+            type={'file'}
+            variant={'raw'}
+          />
         )}
+        <Text ellipsis fontSize={13}>
+          {displayName}
+        </Text>
       </Flexbox>
     );
   },
@@ -226,13 +224,9 @@ export const HighlighterFullFeatured = memo<HighlighterFullFeaturedProps & { chi
           className={cx(headerVariants({ variant }), classNames?.header)}
           horizontal
           justify={'space-between'}
+          onClick={handleToggleExpand}
           style={customStyles?.header}
         >
-          <ActionIcon
-            icon={expand ? ChevronDown : ChevronRight}
-            onClick={handleToggleExpand}
-            size={'small'}
-          />
           <HeaderLanguage
             allowChangeLanguage={allowChangeLanguage}
             displayName={displayName}
@@ -243,8 +237,21 @@ export const HighlighterFullFeatured = memo<HighlighterFullFeaturedProps & { chi
             setLanguage={setLanguage}
             showLanguage={showLanguage}
           />
-          <Flexbox align={'center'} flex={'none'} gap={4} horizontal>
-            {actions}
+          <Flexbox
+            align={'center'}
+            flex={'none'}
+            gap={4}
+            horizontal
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Flexbox align={'center'} className={'panel-actions'} flex={'none'} gap={4} horizontal>
+              {actions}
+            </Flexbox>
+            <ActionIcon
+              icon={expand ? ChevronDown : ChevronRight}
+              onClick={handleToggleExpand}
+              size={'small'}
+            />
           </Flexbox>
         </Flexbox>
         <Flexbox

--- a/src/Highlighter/Highlighter.tsx
+++ b/src/Highlighter/Highlighter.tsx
@@ -90,7 +90,13 @@ export const Highlighter = memo<HighlighterProps>(
 
     const originalActions = useMemo(() => {
       if (!copyable) return null;
-      return <CopyButton content={getCopyContent} glass size={actionIconSize} />;
+      return (
+        <CopyButton
+          content={getCopyContent}
+          glass
+          size={actionIconSize || { blockSize: 28, size: 16 }}
+        />
+      );
     }, [actionIconSize, copyable, getCopyContent]);
 
     const actions = useMemo(() => {

--- a/src/Highlighter/Highlighter.tsx
+++ b/src/Highlighter/Highlighter.tsx
@@ -2,9 +2,9 @@
 
 import { cva } from 'class-variance-authority';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import CopyButton from '@/CopyButton';
+import { Flexbox } from '@/Flex';
 import { getCodeLanguageDisplayName } from '@/Highlighter/const';
 import Tag from '@/Tag';
 

--- a/src/Highlighter/LangSelect.tsx
+++ b/src/Highlighter/LangSelect.tsx
@@ -2,9 +2,9 @@
 
 import { Select, type SelectProps } from 'antd';
 import { memo, useMemo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 import { bundledLanguagesInfo } from 'shiki';
 
+import { Flexbox } from '@/Flex';
 import MaterialFileTypeIcon from '@/MaterialFileTypeIcon';
 import Text from '@/Text';
 

--- a/src/Highlighter/LangSelect.tsx
+++ b/src/Highlighter/LangSelect.tsx
@@ -8,11 +8,7 @@ import { Flexbox } from '@/Flex';
 import MaterialFileTypeIcon from '@/MaterialFileTypeIcon';
 import Text from '@/Text';
 
-import { useStyles } from './style';
-
 export const LangSelect = memo<Omit<SelectProps, 'options'>>(({ ...rest }) => {
-  const { styles } = useStyles();
-
   const options = useMemo(
     () => [
       {
@@ -61,10 +57,15 @@ export const LangSelect = memo<Omit<SelectProps, 'options'>>(({ ...rest }) => {
 
   return (
     <Select
-      className={styles.select}
+      className={'languageTitle'}
+      onClick={(e) => e.stopPropagation()}
       options={options}
       showSearch
       size={'small'}
+      style={{
+        maxWidth: 240,
+        width: '100%',
+      }}
       suffixIcon={false}
       variant={'borderless'}
       {...rest}

--- a/src/Highlighter/demos/index.tsx
+++ b/src/Highlighter/demos/index.tsx
@@ -30,7 +30,7 @@ export default () => {
 
   return (
     <StoryBook levaStore={store}>
-      <Highlighter style={{ height: 400 }} {...options} />
+      <Highlighter {...options} />
     </StoryBook>
   );
 };

--- a/src/Highlighter/style.ts
+++ b/src/Highlighter/style.ts
@@ -28,13 +28,18 @@ export const useStyles = createStyles(({ token, css, cx, prefixCls, stylish }) =
       transition: opacity 0.25s ${token.motionEaseOut};
     `,
     borderless: stylish.variantBorderlessWithoutHover,
-    filled: stylish.variantFilledWithoutHover,
+    filled: cx(
+      stylish.variantFilledWithoutHover,
+      css`
+        background: ${token.colorFillQuaternary};
+      `,
+    ),
     headerBorderless: css`
       padding-inline: 0;
     `,
 
     headerFilled: css`
-      background: ${token.colorFillQuaternary};
+      background: transparent;
     `,
 
     headerOutlined: css`
@@ -44,19 +49,9 @@ export const useStyles = createStyles(({ token, css, cx, prefixCls, stylish }) =
     `,
 
     headerRoot: css`
+      cursor: pointer;
       position: relative;
       padding: 4px;
-
-      .languageTitle {
-        opacity: 0.5;
-        transition: opacity 0.2s ${token.motionEaseInOut};
-      }
-
-      &:hover {
-        .languageTitle {
-          opacity: 1;
-        }
-      }
     `,
 
     lang: cx(
@@ -96,7 +91,29 @@ export const useStyles = createStyles(({ token, css, cx, prefixCls, stylish }) =
 
         transition: background-color 100ms ${token.motionEaseOut};
 
+        .languageTitle {
+          opacity: 0.5;
+          filter: grayscale(100%);
+          transition:
+            opacity,
+            grayscale 0.2s ${token.motionEaseInOut};
+        }
+
+        .panel-actions {
+          opacity: 0;
+          transition: opacity 0.2s ${token.motionEaseInOut};
+        }
+
         &:hover {
+          .languageTitle {
+            opacity: 1;
+            filter: grayscale(0%);
+          }
+
+          .panel-actions {
+            opacity: 1;
+          }
+
           .${actionsHoverCls} {
             opacity: 1;
           }
@@ -116,19 +133,6 @@ export const useStyles = createStyles(({ token, css, cx, prefixCls, stylish }) =
         }
       `,
     ),
-    select: css`
-      user-select: none;
-
-      position: absolute;
-      inset-inline-start: 50%;
-      transform: translateX(-50%);
-
-      min-width: 100px;
-
-      font-size: 14px;
-      color: ${token.colorTextDescription};
-      text-align: center;
-    `,
     shadow: stylish.shadow,
     wrap: css`
       pre,

--- a/src/Highlighter/type.ts
+++ b/src/Highlighter/type.ts
@@ -1,8 +1,8 @@
-import { FlexboxProps } from '@lobehub/ui/Flex';
 import { CSSProperties, ReactNode, type Ref } from 'react';
 import type { BuiltinTheme } from 'shiki';
 
 import type { ActionIconProps } from '@/ActionIcon';
+import { FlexboxProps } from '@/Flex';
 import { DivProps } from '@/types';
 
 export interface SyntaxHighlighterProps extends DivProps {

--- a/src/Highlighter/type.ts
+++ b/src/Highlighter/type.ts
@@ -1,5 +1,5 @@
+import { FlexboxProps } from '@lobehub/ui/Flex';
 import { CSSProperties, ReactNode, type Ref } from 'react';
-import { FlexboxProps } from 'react-layout-kit';
 import type { BuiltinTheme } from 'shiki';
 
 import type { ActionIconProps } from '@/ActionIcon';

--- a/src/Hotkey/Hotkey.tsx
+++ b/src/Hotkey/Hotkey.tsx
@@ -18,8 +18,8 @@ import {
   SpaceIcon,
 } from 'lucide-react';
 import { memo, useEffect, useMemo, useState } from 'react';
-import { Center, Flexbox } from 'react-layout-kit';
 
+import { Center, Flexbox } from '@/Flex';
 import Icon from '@/Icon';
 import LeftClickIcon from '@/icons/lucideExtra/LeftClickIcon';
 import LeftDoubleClickIcon from '@/icons/lucideExtra/LeftDoubleClickIcon';

--- a/src/Hotkey/demos/InverseTheme.tsx
+++ b/src/Hotkey/demos/InverseTheme.tsx
@@ -1,6 +1,7 @@
 import { Hotkey } from '@lobehub/ui';
 import { useTheme } from 'antd-style';
-import { Center } from 'react-layout-kit';
+
+import { Center } from '@/Flex';
 
 export default () => {
   const theme = useTheme();

--- a/src/Hotkey/demos/MacStyle.tsx
+++ b/src/Hotkey/demos/MacStyle.tsx
@@ -1,6 +1,7 @@
 import { Hotkey, type HotkeyProps } from '@lobehub/ui';
 import { StoryBook, useControls, useCreateStore } from '@lobehub/ui/storybook';
-import { Center } from 'react-layout-kit';
+
+import { Center } from '@/Flex';
 
 export default () => {
   const store = useCreateStore();

--- a/src/Hotkey/demos/Mouse.tsx
+++ b/src/Hotkey/demos/Mouse.tsx
@@ -1,5 +1,6 @@
 import { Hotkey, KeyMapEnum } from '@lobehub/ui';
-import { Center } from 'react-layout-kit';
+
+import { Center } from '@/Flex';
 
 export default () => {
   return (

--- a/src/Hotkey/type.ts
+++ b/src/Hotkey/type.ts
@@ -1,5 +1,6 @@
-import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { CSSProperties } from 'react';
+
+import type { FlexboxProps } from '@/Flex';
 
 export interface HotkeyProps extends Omit<FlexboxProps, 'children'> {
   classNames?: {

--- a/src/Hotkey/type.ts
+++ b/src/Hotkey/type.ts
@@ -1,5 +1,5 @@
+import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { CSSProperties } from 'react';
-import type { FlexboxProps } from 'react-layout-kit';
 
 export interface HotkeyProps extends Omit<FlexboxProps, 'children'> {
   classNames?: {

--- a/src/HotkeyInput/HotkeyInput.tsx
+++ b/src/HotkeyInput/HotkeyInput.tsx
@@ -15,10 +15,10 @@ import {
   useState,
 } from 'react';
 import { useHotkeys, useRecordHotkeys } from 'react-hotkeys-hook';
-import { Flexbox } from 'react-layout-kit';
 import useControlledState from 'use-merge-value';
 
 import ActionIcon from '@/ActionIcon';
+import { Flexbox } from '@/Flex';
 import Hotkey from '@/Hotkey';
 import { NORMATIVE_MODIFIER, checkIsAppleDevice, splitKeysByPlus } from '@/Hotkey/utils';
 

--- a/src/Image/Image.tsx
+++ b/src/Image/Image.tsx
@@ -3,7 +3,8 @@
 import { Image as AntImage, Skeleton } from 'antd';
 import { cva } from 'class-variance-authority';
 import { memo, useMemo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import usePreview from './components/usePreview';
 import { FALLBACK_DARK, FALLBACK_LIGHT, useStyles } from './style';

--- a/src/Image/components/Toolbar.tsx
+++ b/src/Image/components/Toolbar.tsx
@@ -23,12 +23,12 @@ const Toolbar = memo<ToolbarProps>(({ children, info, minScale, maxScale }) => {
 
   return (
     <Flexbox className={styles.toolbar} gap={4} horizontal>
-      <ActionIcon color={'#fff'} icon={FlipHorizontal} onClick={onFlipX} />
-      <ActionIcon color={'#fff'} icon={FlipVertical} onClick={onFlipY} />
-      <ActionIcon color={'#fff'} icon={RotateCcw} onClick={onRotateLeft} />
-      <ActionIcon color={'#fff'} icon={RotateCw} onClick={onRotateRight} />
-      <ActionIcon color={'#fff'} disabled={scale === minScale} icon={ZoomOut} onClick={onZoomOut} />
-      <ActionIcon color={'#fff'} disabled={scale === maxScale} icon={ZoomIn} onClick={onZoomIn} />
+      <ActionIcon icon={FlipHorizontal} onClick={onFlipX} />
+      <ActionIcon icon={FlipVertical} onClick={onFlipY} />
+      <ActionIcon icon={RotateCcw} onClick={onRotateLeft} />
+      <ActionIcon icon={RotateCw} onClick={onRotateRight} />
+      <ActionIcon disabled={scale === minScale} icon={ZoomOut} onClick={onZoomOut} />
+      <ActionIcon disabled={scale === maxScale} icon={ZoomIn} onClick={onZoomIn} />
       {children}
     </Flexbox>
   );

--- a/src/Image/components/Toolbar.tsx
+++ b/src/Image/components/Toolbar.tsx
@@ -1,9 +1,9 @@
 import { FlipHorizontal, FlipVertical, RotateCcw, RotateCw, ZoomIn, ZoomOut } from 'lucide-react';
 import type { ToolbarRenderInfoType } from 'rc-image/lib/Preview';
 import { type ReactNode, memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import ActionIcon from '@/ActionIcon';
+import { Flexbox } from '@/Flex';
 
 import { useStyles } from '../style';
 

--- a/src/Image/components/usePreview.tsx
+++ b/src/Image/components/usePreview.tsx
@@ -44,9 +44,6 @@ export const usePreview = (
           if (toolbarRender) return toolbarRender(originalNode, info);
           return originalNode;
         }),
-      classNames: {
-        root: cx(styles.preview, rootClassName),
-      },
       closeIcon: <Icon color={'#fff'} icon={X} />,
       imageRender: (originalNode, info) => {
         const node = <Preview visible={visible}>{originalNode}</Preview>;
@@ -62,6 +59,7 @@ export const usePreview = (
         // 向后兼容旧的 onVisibleChange
         onVisibleChange?.(open, !open);
       },
+      rootClassName: cx(styles.preview, rootClassName),
       styles: { mask: { backdropFilter: 'blur(8px)' } },
       ...rest,
     };

--- a/src/Image/demos/Gallery.tsx
+++ b/src/Image/demos/Gallery.tsx
@@ -1,5 +1,6 @@
 import { Image } from '@lobehub/ui';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   return (

--- a/src/Image/style.ts
+++ b/src/Image/style.ts
@@ -3,7 +3,7 @@ import { rgba } from 'polished';
 
 export const useStyles = createStyles(
   (
-    { cx, css, token, stylish },
+    { cx, css, token, stylish, prefixCls },
     {
       alwaysShowActions,
     }: {
@@ -41,6 +41,10 @@ export const useStyles = createStyles(
       ),
       outlined: stylish.variantOutlinedWithoutHover,
       preview: css`
+        .${prefixCls}-image-preview-mask {
+          background: ${rgba(token.colorBgLayout, 0.9)};
+        }
+
         img {
           width: 100%;
         }
@@ -58,6 +62,10 @@ export const useStyles = createStyles(
 
         line-height: 1;
 
+        .${prefixCls}-image-cover {
+          display: none !important;
+        }
+
         &:hover {
           .${actions} {
             opacity: 1;
@@ -71,7 +79,7 @@ export const useStyles = createStyles(
           padding: 4px;
           border-color: ${token.colorFillTertiary};
           border-radius: ${token.borderRadiusLG}px;
-          background: ${rgba(token.colorBgMask, 0.5)};
+          background: ${rgba(token.colorBgContainer, 0.5)};
         `,
       ),
 

--- a/src/ImageSelect/ImageSelect.tsx
+++ b/src/ImageSelect/ImageSelect.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 import useControlledState from 'use-merge-value';
 
+import { Flexbox } from '@/Flex';
 import Icon from '@/Icon';
 import Img from '@/Img';
 

--- a/src/ImageSelect/type.ts
+++ b/src/ImageSelect/type.ts
@@ -1,7 +1,7 @@
-import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { SelectProps } from 'antd';
 import type { CSSProperties, ReactNode, Ref } from 'react';
 
+import type { FlexboxProps } from '@/Flex';
 import type { IconProps } from '@/Icon';
 
 export interface ImageSelectItem {

--- a/src/ImageSelect/type.ts
+++ b/src/ImageSelect/type.ts
@@ -1,6 +1,6 @@
+import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { SelectProps } from 'antd';
 import type { CSSProperties, ReactNode, Ref } from 'react';
-import type { FlexboxProps } from 'react-layout-kit';
 
 import type { IconProps } from '@/Icon';
 

--- a/src/Layout/demos/index.tsx
+++ b/src/Layout/demos/index.tsx
@@ -1,6 +1,7 @@
 import { Layout } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 const useStyles = createStyles(({ css, token }) => ({
   footer: css`
@@ -9,8 +10,8 @@ const useStyles = createStyles(({ css, token }) => ({
   `,
   header: css`
     height: 100%;
-    background: ${token.cyan5A};
     border-block-end: 1px solid ${token.colorBorder};
+    background: ${token.cyan5A};
   `,
 }));
 

--- a/src/List/List.tsx
+++ b/src/List/List.tsx
@@ -2,7 +2,8 @@
 
 import { cx } from 'antd-style';
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import ListItem from './ListItem';
 import type { ListProps } from './type';

--- a/src/List/ListItem/index.tsx
+++ b/src/List/ListItem/index.tsx
@@ -2,8 +2,8 @@
 
 import { Loader2, MessageSquare } from 'lucide-react';
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
+import { Flexbox } from '@/Flex';
 import Icon from '@/Icon';
 import Text from '@/Text';
 

--- a/src/List/type.ts
+++ b/src/List/type.ts
@@ -1,5 +1,6 @@
-import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { CSSProperties, ReactNode, Ref } from 'react';
+
+import type { FlexboxProps } from '@/Flex';
 
 export interface ListItemProps extends Omit<FlexboxProps, 'title'> {
   actions?: ReactNode;

--- a/src/List/type.ts
+++ b/src/List/type.ts
@@ -1,5 +1,5 @@
+import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { CSSProperties, ReactNode, Ref } from 'react';
-import type { FlexboxProps } from 'react-layout-kit';
 
 export interface ListItemProps extends Omit<FlexboxProps, 'title'> {
   actions?: ReactNode;

--- a/src/Markdown/components/Footnotes.tsx
+++ b/src/Markdown/components/Footnotes.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { type ReactNode, memo, useMemo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import A from '@/A';
 import Block from '@/Block';
+import { Flexbox } from '@/Flex';
 import Text from '@/Text';
 
 import SearchResultCards from './SearchResultCards';

--- a/src/Markdown/components/SearchResultCards/SearchResultCard.tsx
+++ b/src/Markdown/components/SearchResultCards/SearchResultCard.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { Ref, memo, useMemo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import A from '@/A';
 import Block from '@/Block';
+import { Flexbox } from '@/Flex';
 import Img from '@/Img';
 import Text from '@/Text';
 import { AProps } from '@/types';

--- a/src/Markdown/components/SearchResultCards/index.tsx
+++ b/src/Markdown/components/SearchResultCards/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
+import { FlexboxProps } from '@lobehub/ui/Flex';
 import { Ref, memo } from 'react';
-import { FlexboxProps } from 'react-layout-kit';
 
 import ScrollShadow from '@/ScrollShadow';
 

--- a/src/Markdown/components/SearchResultCards/index.tsx
+++ b/src/Markdown/components/SearchResultCards/index.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { FlexboxProps } from '@lobehub/ui/Flex';
 import { Ref, memo } from 'react';
 
+import { FlexboxProps } from '@/Flex';
 import ScrollShadow from '@/ScrollShadow';
 
 import SearchResultCard from './SearchResultCard';

--- a/src/Markdown/demos/custom/citations/index.tsx
+++ b/src/Markdown/demos/custom/citations/index.tsx
@@ -1,6 +1,7 @@
 import { Block, Markdown, SearchResultCards, Tabs } from '@lobehub/ui';
 import { useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { normalizeThinkTags, remarkCaptureThink } from '../thinking/remarkPlugin';
 import { cases } from './cases';

--- a/src/Markdown/demos/custom/plugins/MarkdownElements/AntArtifact/Component.tsx
+++ b/src/Markdown/demos/custom/plugins/MarkdownElements/AntArtifact/Component.tsx
@@ -2,7 +2,8 @@ import { Icon } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import { SparkleIcon } from 'lucide-react';
 import { PropsWithChildren, memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 const useStyles = createStyles(({ css, token, isDarkMode }) => ({
   container: css`

--- a/src/Markdown/demos/custom/plugins/MarkdownElements/AntThinking/Component.tsx
+++ b/src/Markdown/demos/custom/plugins/MarkdownElements/AntThinking/Component.tsx
@@ -2,7 +2,8 @@ import { Icon } from '@lobehub/ui';
 import { createStyles } from 'antd-style';
 import { ChevronDown, ChevronRight, SparkleIcon } from 'lucide-react';
 import { PropsWithChildren, memo, useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 const useStyles = createStyles(({ css, token, isDarkMode }) => ({
   container: css`

--- a/src/Markdown/demos/custom/thinking/index.tsx
+++ b/src/Markdown/demos/custom/thinking/index.tsx
@@ -1,7 +1,8 @@
 import { Button, Markdown } from '@lobehub/ui';
 import { useTheme } from 'antd-style';
 import { PropsWithChildren, useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { fullThinking, inlineMode, ollama, partialThinking } from './content';
 import { normalizeThinkTags, remarkCaptureThink } from './remarkPlugin';

--- a/src/Markdown/demos/streaming.tsx
+++ b/src/Markdown/demos/streaming.tsx
@@ -1,7 +1,8 @@
 import { Button, Markdown } from '@lobehub/ui';
 import { StoryBook, useControls, useCreateStore } from '@lobehub/ui/storybook';
 import { useEffect, useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { markdownElements } from './custom/plugins/MarkdownElements';
 import { removeLineBreaksInAntArtifact } from './custom/plugins/utils';

--- a/src/MaskShadow/MaskShadow.tsx
+++ b/src/MaskShadow/MaskShadow.tsx
@@ -2,7 +2,8 @@
 
 import { cva } from 'class-variance-authority';
 import { memo, useMemo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { useStyles } from './style';
 import type { MaskShadowProps } from './type';

--- a/src/MaskShadow/type.ts
+++ b/src/MaskShadow/type.ts
@@ -1,4 +1,4 @@
-import type { FlexboxProps } from '@lobehub/ui/Flex';
+import type { FlexboxProps } from '@/Flex';
 
 export interface MaskShadowProps extends FlexboxProps {
   position?: 'top' | 'bottom' | 'left' | 'right';

--- a/src/MaskShadow/type.ts
+++ b/src/MaskShadow/type.ts
@@ -1,4 +1,4 @@
-import type { FlexboxProps } from 'react-layout-kit';
+import type { FlexboxProps } from '@lobehub/ui/Flex';
 
 export interface MaskShadowProps extends FlexboxProps {
   position?: 'top' | 'bottom' | 'left' | 'right';

--- a/src/MaterialFileTypeIcon/MaterialFileTypeIcon.tsx
+++ b/src/MaterialFileTypeIcon/MaterialFileTypeIcon.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { memo, useMemo } from 'react';
-import { Center } from 'react-layout-kit';
 
 import { useCdnFn } from '@/ConfigProvider';
 import FileTypeIcon from '@/FileTypeIcon';
+import { Center } from '@/Flex';
 import Img from '@/Img';
 
 import type { MaterialFileTypeIconProps } from './type';

--- a/src/Menu/demos/index.tsx
+++ b/src/Menu/demos/index.tsx
@@ -1,7 +1,8 @@
 import { Menu, type MenuProps } from '@lobehub/ui';
 import { StoryBook, useControls, useCreateStore } from '@lobehub/ui/storybook';
 import { useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { groupItems, items } from './data';
 

--- a/src/Mermaid/FullFeatured.tsx
+++ b/src/Mermaid/FullFeatured.tsx
@@ -32,7 +32,8 @@ const MermaidHeaderLanguage = memo(
         flex={1}
         gap={4}
         horizontal
-        justify={'center'}
+        justify={'flex-start'}
+        paddingInline={8}
       >
         <MaterialFileTypeIcon
           fallbackUnknownType={false}
@@ -176,20 +177,29 @@ export const MermaidFullFeatured = memo<MermaidFullFeaturedProps>(
           className={cx(headerVariants({ variant }), classNames?.header)}
           horizontal
           justify={'space-between'}
+          onClick={handleToggleExpand}
           style={customStyles?.header}
         >
-          <ActionIcon
-            icon={expand ? ChevronDown : ChevronRight}
-            onClick={handleToggleExpand}
-            size={'small'}
-          />
           <MermaidHeaderLanguage
             fileName={fileName}
             language={language}
             showLanguage={showLanguage}
           />
-          <Flexbox align={'center'} flex={'none'} gap={4} horizontal>
-            {actions}
+          <Flexbox
+            align={'center'}
+            flex={'none'}
+            gap={4}
+            horizontal
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Flexbox align={'center'} className={'panel-actions'} flex={'none'} gap={4} horizontal>
+              {actions}
+            </Flexbox>
+            <ActionIcon
+              icon={expand ? ChevronDown : ChevronRight}
+              onClick={handleToggleExpand}
+              size={'small'}
+            />
           </Flexbox>
         </Flexbox>
         <Flexbox

--- a/src/Mermaid/FullFeatured.tsx
+++ b/src/Mermaid/FullFeatured.tsx
@@ -3,10 +3,10 @@
 import { cva } from 'class-variance-authority';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { ReactNode, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import ActionIcon from '@/ActionIcon';
 import CopyButton from '@/CopyButton';
+import { Flexbox } from '@/Flex';
 import { useStyles } from '@/Highlighter/style';
 import MaterialFileTypeIcon from '@/MaterialFileTypeIcon';
 import Text from '@/Text';

--- a/src/Mermaid/Mermaid.tsx
+++ b/src/Mermaid/Mermaid.tsx
@@ -2,9 +2,9 @@
 
 import { cva } from 'class-variance-authority';
 import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import CopyButton from '@/CopyButton';
+import { Flexbox } from '@/Flex';
 import { useStyles } from '@/Highlighter/style';
 import Tag from '@/Tag';
 

--- a/src/Mermaid/Mermaid.tsx
+++ b/src/Mermaid/Mermaid.tsx
@@ -76,7 +76,9 @@ const Mermaid = memo<MermaidProps>(
 
     const originalActions = useMemo(() => {
       if (!copyable) return null;
-      return <CopyButton content={getCopyContent} size={actionIconSize} />;
+      return (
+        <CopyButton content={getCopyContent} size={actionIconSize || { blockSize: 28, size: 16 }} />
+      );
     }, [actionIconSize, copyable, getCopyContent]);
 
     const actions = useMemo(() => {

--- a/src/Mermaid/SyntaxMermaid/index.tsx
+++ b/src/Mermaid/SyntaxMermaid/index.tsx
@@ -10,7 +10,7 @@ import { mermaidThemes } from '../const';
 import type { SyntaxMermaidProps } from '../type';
 
 const SyntaxMermaid = memo<SyntaxMermaidProps>(
-  ({ ref, children, theme: customTheme, variant, enablePanZoom, className, style }) => {
+  ({ ref, children, theme: customTheme, variant, className, style }) => {
     const isDefaultTheme = customTheme === 'lobe-theme' || !customTheme;
 
     const background = useMemo(() => {
@@ -73,13 +73,6 @@ const SyntaxMermaid = memo<SyntaxMermaidProps>(
         maxHeight={480}
         minWidth={300}
         objectFit={'contain'}
-        preview={
-          enablePanZoom
-            ? {
-                mask: false,
-              }
-            : false
-        }
         ref={ref}
         src={blobUrl}
         style={{

--- a/src/ScrollShadow/ScrollShadow.tsx
+++ b/src/ScrollShadow/ScrollShadow.tsx
@@ -2,8 +2,9 @@
 
 import { cva } from 'class-variance-authority';
 import { memo, useMemo, useRef } from 'react';
-import { Flexbox } from 'react-layout-kit';
 import { mergeRefs } from 'react-merge-refs';
+
+import { Flexbox } from '@/Flex';
 
 import { useStyles } from './style';
 import type { ScrollShadowProps } from './type';

--- a/src/ScrollShadow/type.ts
+++ b/src/ScrollShadow/type.ts
@@ -1,5 +1,6 @@
-import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { Ref } from 'react';
+
+import type { FlexboxProps } from '@/Flex';
 
 export interface ScrollShadowProps extends FlexboxProps {
   hideScrollBar?: boolean;

--- a/src/ScrollShadow/type.ts
+++ b/src/ScrollShadow/type.ts
@@ -1,5 +1,5 @@
+import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { Ref } from 'react';
-import type { FlexboxProps } from 'react-layout-kit';
 
 export interface ScrollShadowProps extends FlexboxProps {
   hideScrollBar?: boolean;

--- a/src/SideNav/SideNav.tsx
+++ b/src/SideNav/SideNav.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { useStyles } from './style';
 import type { SideNavProps } from './type';

--- a/src/SideNav/type.ts
+++ b/src/SideNav/type.ts
@@ -1,5 +1,6 @@
-import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { ReactNode } from 'react';
+
+import type { FlexboxProps } from '@/Flex';
 
 export interface SideNavProps extends FlexboxProps {
   avatar?: ReactNode;

--- a/src/SideNav/type.ts
+++ b/src/SideNav/type.ts
@@ -1,5 +1,5 @@
+import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { ReactNode } from 'react';
-import type { FlexboxProps } from 'react-layout-kit';
 
 export interface SideNavProps extends FlexboxProps {
   avatar?: ReactNode;

--- a/src/Skeleton/Skeleton.tsx
+++ b/src/Skeleton/Skeleton.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import SkeletonAvatar from './SkeletonAvatar';
 import SkeletonParagraph from './SkeletonParagraph';

--- a/src/Skeleton/SkeletonParagraph.tsx
+++ b/src/Skeleton/SkeletonParagraph.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import SkeletonBlock from './SkeletonBlock';
 import type { SkeletonParagraphProps } from './type';

--- a/src/Skeleton/SkeletonTags.tsx
+++ b/src/Skeleton/SkeletonTags.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import SkeletonBlock from './SkeletonBlock';
 import { useStyles } from './style';

--- a/src/Skeleton/demos/Avatar.tsx
+++ b/src/Skeleton/demos/Avatar.tsx
@@ -1,5 +1,6 @@
 import { Avatar, Skeleton } from '@lobehub/ui';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => (
   <Flexbox gap={16}>

--- a/src/Skeleton/demos/Block.tsx
+++ b/src/Skeleton/demos/Block.tsx
@@ -1,5 +1,6 @@
 import { Skeleton } from '@lobehub/ui';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => (
   <Flexbox gap={16}>

--- a/src/Skeleton/demos/Button.tsx
+++ b/src/Skeleton/demos/Button.tsx
@@ -1,5 +1,6 @@
 import { Button, Skeleton } from '@lobehub/ui';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => (
   <Flexbox align="flex-start" gap={16}>

--- a/src/Skeleton/demos/Paragraph.tsx
+++ b/src/Skeleton/demos/Paragraph.tsx
@@ -1,5 +1,6 @@
 import { Skeleton, Text } from '@lobehub/ui';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => (
   <Flexbox gap={16}>

--- a/src/Skeleton/demos/Tags.tsx
+++ b/src/Skeleton/demos/Tags.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Skeleton, Tag } from '@lobehub/ui';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => (
   <Flexbox gap={16}>

--- a/src/Skeleton/demos/Title.tsx
+++ b/src/Skeleton/demos/Title.tsx
@@ -1,5 +1,6 @@
 import { Skeleton, Text } from '@lobehub/ui';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => (
   <Flexbox gap={16}>

--- a/src/SliderWithInput/SliderWithInput.tsx
+++ b/src/SliderWithInput/SliderWithInput.tsx
@@ -3,8 +3,8 @@
 import { Slider } from 'antd';
 import { isNull } from 'lodash-es';
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
+import { Flexbox } from '@/Flex';
 import InputNumber from '@/Input/InputNumber';
 
 import type { SliderWithInputProps } from './type';

--- a/src/SliderWithInput/type.ts
+++ b/src/SliderWithInput/type.ts
@@ -1,7 +1,7 @@
-import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { SliderSingleProps } from 'antd';
 import type { CSSProperties } from 'react';
 
+import type { FlexboxProps } from '@/Flex';
 import type { InputNumberProps } from '@/Input';
 
 export interface SliderWithInputProps extends Omit<SliderSingleProps, 'classNames' | 'styles'> {

--- a/src/SliderWithInput/type.ts
+++ b/src/SliderWithInput/type.ts
@@ -1,6 +1,6 @@
+import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { SliderSingleProps } from 'antd';
 import type { CSSProperties } from 'react';
-import type { FlexboxProps } from 'react-layout-kit';
 
 import type { InputNumberProps } from '@/Input';
 

--- a/src/Snippet/Snippet.tsx
+++ b/src/Snippet/Snippet.tsx
@@ -2,9 +2,9 @@
 
 import { cva } from 'class-variance-authority';
 import { memo, useMemo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import CopyButton from '@/CopyButton';
+import { Flexbox } from '@/Flex';
 import SyntaxHighlighter from '@/Highlighter/SyntaxHighlighter';
 import Spotlight from '@/awesome/Spotlight';
 

--- a/src/Snippet/type.ts
+++ b/src/Snippet/type.ts
@@ -1,5 +1,6 @@
-import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { Ref } from 'react';
+
+import type { FlexboxProps } from '@/Flex';
 
 export interface SnippetProps extends FlexboxProps {
   children: string;

--- a/src/Snippet/type.ts
+++ b/src/Snippet/type.ts
@@ -1,5 +1,5 @@
+import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { Ref } from 'react';
-import type { FlexboxProps } from 'react-layout-kit';
 
 export interface SnippetProps extends FlexboxProps {
   children: string;

--- a/src/SortableList/SortableList.tsx
+++ b/src/SortableList/SortableList.tsx
@@ -16,7 +16,8 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { Fragment, type ReactNode, memo, useMemo, useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import DragHandle from './components/DragHandle';
 import SortableItem from './components/SortableItem';

--- a/src/SortableList/components/SortableItem.tsx
+++ b/src/SortableList/components/SortableItem.tsx
@@ -3,9 +3,11 @@
 import type { DraggableSyntheticListeners } from '@dnd-kit/core';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { type FlexboxProps } from '@lobehub/ui/Flex';
 import { cva } from 'class-variance-authority';
 import { createContext, memo, useMemo } from 'react';
-import { Flexbox, type FlexboxProps } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { useStyles } from '../style';
 

--- a/src/SortableList/components/SortableItem.tsx
+++ b/src/SortableList/components/SortableItem.tsx
@@ -3,10 +3,10 @@
 import type { DraggableSyntheticListeners } from '@dnd-kit/core';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { type FlexboxProps } from '@lobehub/ui/Flex';
 import { cva } from 'class-variance-authority';
 import { createContext, memo, useMemo } from 'react';
 
+import { type FlexboxProps } from '@/Flex';
 import { Flexbox } from '@/Flex';
 
 import { useStyles } from '../style';

--- a/src/SortableList/type.ts
+++ b/src/SortableList/type.ts
@@ -1,5 +1,5 @@
+import type { FlexboxProps } from '@lobehub/ui/Flex';
 import { type ReactNode, Ref } from 'react';
-import type { FlexboxProps } from 'react-layout-kit';
 
 export interface SortableListItem {
   [key: string]: any;

--- a/src/SortableList/type.ts
+++ b/src/SortableList/type.ts
@@ -1,5 +1,6 @@
-import type { FlexboxProps } from '@lobehub/ui/Flex';
 import { type ReactNode, Ref } from 'react';
+
+import type { FlexboxProps } from '@/Flex';
 
 export interface SortableListItem {
   [key: string]: any;

--- a/src/Tag/demos/Color.tsx
+++ b/src/Tag/demos/Color.tsx
@@ -1,7 +1,8 @@
 import { Tag } from '@lobehub/ui';
 import { Badge } from 'antd';
 import { useTheme } from 'antd-style';
-import { Center } from 'react-layout-kit';
+
+import { Center } from '@/Flex';
 
 export default () => {
   const theme = useTheme();

--- a/src/ThemeProvider/demos/CustomFonts.tsx
+++ b/src/ThemeProvider/demos/CustomFonts.tsx
@@ -1,6 +1,7 @@
 import { ThemeProvider } from '@lobehub/ui';
 import { useTheme } from 'antd-style';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   const theme = useTheme();

--- a/src/ThemeSwitch/ThemeSwitch.tsx
+++ b/src/ThemeSwitch/ThemeSwitch.tsx
@@ -4,10 +4,10 @@ import { Select } from 'antd';
 import { ThemeMode } from 'antd-style';
 import { Monitor, Moon, Sun } from 'lucide-react';
 import { memo, useMemo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import ActionIcon from '@/ActionIcon';
 import Dropdown from '@/Dropdown';
+import { Flexbox } from '@/Flex';
 import Icon from '@/Icon';
 import type { MenuItemType } from '@/Menu';
 

--- a/src/Tooltip/TooltipFloating.tsx
+++ b/src/Tooltip/TooltipFloating.tsx
@@ -4,8 +4,8 @@ import type { FloatingContext, Placement } from '@floating-ui/react';
 import { FloatingArrow } from '@floating-ui/react';
 import type { CSSProperties, ReactNode, RefObject } from 'react';
 import React, { useLayoutEffect, useMemo, useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
+import { Flexbox } from '@/Flex';
 import Hotkey from '@/Hotkey';
 import { AnimatePresence, LazyMotion, m } from '@/motion';
 

--- a/src/Tooltip/demos/group.tsx
+++ b/src/Tooltip/demos/group.tsx
@@ -1,6 +1,7 @@
 import { Button, Tooltip, TooltipGroup } from '@lobehub/ui';
 import { StoryBook, useCreateStore } from '@lobehub/ui/storybook';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   const store = useCreateStore();

--- a/src/Video/index.tsx
+++ b/src/Video/index.tsx
@@ -1,13 +1,12 @@
 'use client';
 
-import { FlexboxProps } from '@lobehub/ui/Flex';
 import { Skeleton } from 'antd';
 import { cva } from 'class-variance-authority';
 import { PlayIcon } from 'lucide-react';
 import { type CSSProperties, type Ref, memo, useMemo, useState } from 'react';
 
 import ActionIcon from '@/ActionIcon';
-import { Flexbox } from '@/Flex';
+import { Flexbox, FlexboxProps } from '@/Flex';
 import type { VideoProps as VProps } from '@/types';
 
 import { useStyles } from './style';

--- a/src/Video/index.tsx
+++ b/src/Video/index.tsx
@@ -1,12 +1,13 @@
 'use client';
 
+import { FlexboxProps } from '@lobehub/ui/Flex';
 import { Skeleton } from 'antd';
 import { cva } from 'class-variance-authority';
 import { PlayIcon } from 'lucide-react';
 import { type CSSProperties, type Ref, memo, useMemo, useState } from 'react';
-import { Flexbox, FlexboxProps } from 'react-layout-kit';
 
 import ActionIcon from '@/ActionIcon';
+import { Flexbox } from '@/Flex';
 import type { VideoProps as VProps } from '@/types';
 
 import { useStyles } from './style';

--- a/src/awesome/AuroraBackground/AuroraBackground.tsx
+++ b/src/awesome/AuroraBackground/AuroraBackground.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { useStyles } from './style';
 import type { AuroraBackgroundProps } from './type';

--- a/src/awesome/AuroraBackground/type.ts
+++ b/src/awesome/AuroraBackground/type.ts
@@ -1,5 +1,6 @@
-import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { CSSProperties, Ref } from 'react';
+
+import type { FlexboxProps } from '@/Flex';
 
 export interface AuroraBackgroundProps extends FlexboxProps {
   classNames?: {

--- a/src/awesome/AuroraBackground/type.ts
+++ b/src/awesome/AuroraBackground/type.ts
@@ -1,5 +1,5 @@
+import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { CSSProperties, Ref } from 'react';
-import type { FlexboxProps } from 'react-layout-kit';
 
 export interface AuroraBackgroundProps extends FlexboxProps {
   classNames?: {

--- a/src/awesome/Features/FeatureItem.tsx
+++ b/src/awesome/Features/FeatureItem.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { CSSProperties, memo } from 'react';
-import { Center, Flexbox } from 'react-layout-kit';
 
 import A from '@/A';
+import { Center, Flexbox } from '@/Flex';
 import Icon from '@/Icon';
 import Img from '@/Img';
 import Text from '@/Text';

--- a/src/awesome/GridBackground/GridShowcase.tsx
+++ b/src/awesome/GridBackground/GridShowcase.tsx
@@ -3,7 +3,8 @@
 import { useTheme } from 'antd-style';
 import { rgba } from 'polished';
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import GridBackground from './GridBackground';
 import type { GridShowcaseProps } from './type';

--- a/src/awesome/GridBackground/type.ts
+++ b/src/awesome/GridBackground/type.ts
@@ -1,4 +1,4 @@
-import { FlexboxProps } from 'react-layout-kit';
+import { FlexboxProps } from '@lobehub/ui/Flex';
 
 import type { DivProps } from '@/types';
 

--- a/src/awesome/GridBackground/type.ts
+++ b/src/awesome/GridBackground/type.ts
@@ -1,5 +1,4 @@
-import { FlexboxProps } from '@lobehub/ui/Flex';
-
+import { FlexboxProps } from '@/Flex';
 import type { DivProps } from '@/types';
 
 export interface GridBackgroundProps extends DivProps {

--- a/src/awesome/Hero/Hero.tsx
+++ b/src/awesome/Hero/Hero.tsx
@@ -4,10 +4,10 @@ import { ConfigProvider } from 'antd';
 import { useResponsive } from 'antd-style';
 import { Github } from 'lucide-react';
 import { memo, useCallback } from 'react';
-import { Center, Flexbox } from 'react-layout-kit';
 
 import A from '@/A';
 import Button from '@/Button';
+import { Center, Flexbox } from '@/Flex';
 import AuroraBackground from '@/awesome/AuroraBackground';
 import GradientButton from '@/awesome/GradientButton';
 

--- a/src/awesome/SpotlightCard/SpotlightCardItem.tsx
+++ b/src/awesome/SpotlightCard/SpotlightCardItem.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { useStyles } from './style';
 import type { SpotlightCardItemProps } from './type';

--- a/src/awesome/SpotlightCard/demos/index.tsx
+++ b/src/awesome/SpotlightCard/demos/index.tsx
@@ -1,6 +1,7 @@
 import { SpotlightCard } from '@lobehub/ui/awesome';
 import { Avatar } from 'antd';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import data from './data';
 

--- a/src/awesome/TypewriterEffect/demos/advanced.tsx
+++ b/src/awesome/TypewriterEffect/demos/advanced.tsx
@@ -1,5 +1,6 @@
 import { TypewriterEffect } from '@lobehub/ui/awesome';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   return (

--- a/src/awesome/TypewriterEffect/demos/callback.tsx
+++ b/src/awesome/TypewriterEffect/demos/callback.tsx
@@ -1,6 +1,7 @@
 import { TypewriterEffect } from '@lobehub/ui/awesome';
 import { useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   const [count, setCount] = useState(0);

--- a/src/awesome/TypewriterEffect/demos/colors.tsx
+++ b/src/awesome/TypewriterEffect/demos/colors.tsx
@@ -1,5 +1,6 @@
 import { TypewriterEffect } from '@lobehub/ui/awesome';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   return (

--- a/src/awesome/TypewriterEffect/demos/cursorBehavior.tsx
+++ b/src/awesome/TypewriterEffect/demos/cursorBehavior.tsx
@@ -1,5 +1,6 @@
 import { TypewriterEffect } from '@lobehub/ui/awesome';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   return (

--- a/src/awesome/TypewriterEffect/demos/cursorStyles.tsx
+++ b/src/awesome/TypewriterEffect/demos/cursorStyles.tsx
@@ -1,6 +1,7 @@
 import { TypewriterEffect } from '@lobehub/ui/awesome';
 import { LoadingDots } from '@lobehub/ui/chat';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   const sentences = ['Different cursor styles'];

--- a/src/awesome/TypewriterEffect/demos/customSpeed.tsx
+++ b/src/awesome/TypewriterEffect/demos/customSpeed.tsx
@@ -1,5 +1,6 @@
 import { TypewriterEffect } from '@lobehub/ui/awesome';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   return (

--- a/src/awesome/TypewriterEffect/demos/emoji.tsx
+++ b/src/awesome/TypewriterEffect/demos/emoji.tsx
@@ -1,5 +1,6 @@
 import { TypewriterEffect } from '@lobehub/ui/awesome';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   return (

--- a/src/awesome/TypewriterEffect/demos/initialDelay.tsx
+++ b/src/awesome/TypewriterEffect/demos/initialDelay.tsx
@@ -1,5 +1,6 @@
 import { TypewriterEffect } from '@lobehub/ui/awesome';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   return (

--- a/src/awesome/TypewriterEffect/demos/segmentModes.tsx
+++ b/src/awesome/TypewriterEffect/demos/segmentModes.tsx
@@ -1,5 +1,6 @@
 import { TypewriterEffect } from '@lobehub/ui/awesome';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   return (

--- a/src/awesome/TypewriterEffect/demos/variableSpeed.tsx
+++ b/src/awesome/TypewriterEffect/demos/variableSpeed.tsx
@@ -1,5 +1,6 @@
 import { TypewriterEffect } from '@lobehub/ui/awesome';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   return (

--- a/src/brand/LobeChat/index.md
+++ b/src/brand/LobeChat/index.md
@@ -12,8 +12,8 @@ apiHeader:
 ## Example
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { LobeChat } from '@lobehub/ui/brand';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => (
   <Flexbox gap={16} align={'flex-start'}>

--- a/src/brand/LobeChat/index.md
+++ b/src/brand/LobeChat/index.md
@@ -12,8 +12,9 @@ apiHeader:
 ## Example
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { LobeChat } from '@lobehub/ui/brand';
+
+import { Flexbox } from '@/Flex';
 
 export default () => (
   <Flexbox gap={16} align={'flex-start'}>

--- a/src/brand/LobeChat/index.tsx
+++ b/src/brand/LobeChat/index.tsx
@@ -2,8 +2,8 @@
 
 import { useTheme } from 'antd-style';
 import { type ReactNode, memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
+import { Flexbox } from '@/Flex';
 import LogoText from '@/brand/LobeChatText';
 import { useStyles } from '@/brand/LobeHub/style';
 import Logo3d from '@/brand/Logo3d';

--- a/src/brand/LobeHub/index.md
+++ b/src/brand/LobeHub/index.md
@@ -12,8 +12,8 @@ apiHeader:
 ## Example
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { LobeHub } from '@lobehub/ui/brand';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => (
   <Flexbox gap={16} align={'flex-start'}>

--- a/src/brand/LobeHub/index.md
+++ b/src/brand/LobeHub/index.md
@@ -12,8 +12,9 @@ apiHeader:
 ## Example
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { LobeHub } from '@lobehub/ui/brand';
+
+import { Flexbox } from '@/Flex';
 
 export default () => (
   <Flexbox gap={16} align={'flex-start'}>

--- a/src/brand/LobeHub/index.tsx
+++ b/src/brand/LobeHub/index.tsx
@@ -2,8 +2,8 @@
 
 import { useTheme } from 'antd-style';
 import { type ReactNode, memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
+import { Flexbox } from '@/Flex';
 import LogoText from '@/brand/LobeHubText';
 import Logo3d from '@/brand/Logo3d';
 import LogoFlat from '@/brand/LogoFlat';

--- a/src/brand/LogoThree/Loading.tsx
+++ b/src/brand/LogoThree/Loading.tsx
@@ -1,7 +1,7 @@
 import { Loader2 } from 'lucide-react';
 import { memo } from 'react';
-import { Center } from 'react-layout-kit';
 
+import { Center } from '@/Flex';
 import Icon from '@/Icon';
 
 const Loading = memo<{ size?: number }>(({ size = 32 }) => {

--- a/src/brand/LogoThree/index.tsx
+++ b/src/brand/LogoThree/index.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { CSSProperties, memo, useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import { useCdnFn } from '@/ConfigProvider';
+import { Flexbox } from '@/Flex';
 import Img from '@/Img';
 import Spline, { type SplineProps } from '@/awesome/Spline';
 

--- a/src/chat/Bubble/Bubble.tsx
+++ b/src/chat/Bubble/Bubble.tsx
@@ -2,7 +2,8 @@
 
 import { cva } from 'class-variance-authority';
 import { memo, useMemo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { useStyles } from './style';
 import type { BubbleProps } from './type';

--- a/src/chat/Bubble/type.ts
+++ b/src/chat/Bubble/type.ts
@@ -1,5 +1,6 @@
-import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { Ref } from 'react';
+
+import type { FlexboxProps } from '@/Flex';
 
 export interface BubbleProps extends FlexboxProps {
   ref?: Ref<HTMLDivElement>;

--- a/src/chat/Bubble/type.ts
+++ b/src/chat/Bubble/type.ts
@@ -1,5 +1,5 @@
+import type { FlexboxProps } from '@lobehub/ui/Flex';
 import type { Ref } from 'react';
-import type { FlexboxProps } from 'react-layout-kit';
 
 export interface BubbleProps extends FlexboxProps {
   ref?: Ref<HTMLDivElement>;

--- a/src/chat/ChatHeader/ChatHeader.tsx
+++ b/src/chat/ChatHeader/ChatHeader.tsx
@@ -2,9 +2,9 @@
 
 import { ChevronLeft } from 'lucide-react';
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import ActionIcon from '@/ActionIcon';
+import { Flexbox } from '@/Flex';
 
 import { useStyles } from './style';
 import type { ChatHeaderProps } from './type';

--- a/src/chat/ChatHeader/ChatHeaderTitle.tsx
+++ b/src/chat/ChatHeader/ChatHeaderTitle.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { useTitleStyles as useStyles } from './style';
 import type { ChatHeaderTitleProps } from './type';

--- a/src/chat/ChatHeader/type.ts
+++ b/src/chat/ChatHeader/type.ts
@@ -1,5 +1,5 @@
+import { FlexboxProps } from '@lobehub/ui/Flex';
 import { CSSProperties, ReactNode } from 'react';
-import { FlexboxProps } from 'react-layout-kit';
 
 export interface ChatHeaderProps extends FlexboxProps {
   classNames?: {

--- a/src/chat/ChatHeader/type.ts
+++ b/src/chat/ChatHeader/type.ts
@@ -1,5 +1,6 @@
-import { FlexboxProps } from '@lobehub/ui/Flex';
 import { CSSProperties, ReactNode } from 'react';
+
+import { FlexboxProps } from '@/Flex';
 
 export interface ChatHeaderProps extends FlexboxProps {
   classNames?: {

--- a/src/chat/ChatInputArea/components/ChatInputActionBar.tsx
+++ b/src/chat/ChatInputArea/components/ChatInputActionBar.tsx
@@ -2,7 +2,8 @@
 
 import { useResponsive } from 'antd-style';
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { useActionBarStyles as useStyles } from '../style';
 import { ChatInputActionBarProps } from '../type';

--- a/src/chat/ChatInputArea/components/ChatSendButton.tsx
+++ b/src/chat/ChatInputArea/components/ChatSendButton.tsx
@@ -1,9 +1,9 @@
 import { useTheme } from 'antd-style';
 import { ArrowBigUp, CornerDownLeft, Loader2 } from 'lucide-react';
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import Button from '@/Button';
+import { Flexbox } from '@/Flex';
 import Icon from '@/Icon';
 
 import { ChatSendButtonProps } from '../type';

--- a/src/chat/ChatInputArea/demos/index.tsx
+++ b/src/chat/ChatInputArea/demos/index.tsx
@@ -1,7 +1,8 @@
 import { ActionIcon } from '@lobehub/ui';
 import { ChatInputActionBar, ChatInputArea, ChatSendButton, TokenTag } from '@lobehub/ui/chat';
 import { Eraser, Languages } from 'lucide-react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   return (

--- a/src/chat/ChatInputArea/type.ts
+++ b/src/chat/ChatInputArea/type.ts
@@ -1,8 +1,8 @@
-import { FlexboxProps } from '@lobehub/ui/Flex';
 import type { TextAreaRef } from 'antd/es/input/TextArea';
 import { CSSProperties, ReactNode, Ref } from 'react';
 
 import type { DraggablePanelProps } from '@/DraggablePanel';
+import { FlexboxProps } from '@/Flex';
 import type { TextAreaProps } from '@/Input';
 
 export interface ChatInputAreaProps extends Omit<ChatInputAreaInnerProps, 'classNames'> {

--- a/src/chat/ChatInputArea/type.ts
+++ b/src/chat/ChatInputArea/type.ts
@@ -1,6 +1,6 @@
+import { FlexboxProps } from '@lobehub/ui/Flex';
 import type { TextAreaRef } from 'antd/es/input/TextArea';
 import { CSSProperties, ReactNode, Ref } from 'react';
-import { FlexboxProps } from 'react-layout-kit';
 
 import type { DraggablePanelProps } from '@/DraggablePanel';
 import type { TextAreaProps } from '@/Input';

--- a/src/chat/ChatItem/ChatItem.tsx
+++ b/src/chat/ChatItem/ChatItem.tsx
@@ -2,7 +2,8 @@
 
 import { useResponsive } from 'antd-style';
 import { memo, useEffect, useRef, useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import Actions from './components/Actions';
 import Avatar from './components/Avatar';

--- a/src/chat/ChatItem/components/Actions.tsx
+++ b/src/chat/ChatItem/components/Actions.tsx
@@ -1,6 +1,6 @@
 import { type Ref, memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
+import { Flexbox } from '@/Flex';
 import { ChatItemProps } from '@/chat/ChatItem';
 
 import { useStyles } from '../style';

--- a/src/chat/ChatItem/components/Avatar.tsx
+++ b/src/chat/ChatItem/components/Avatar.tsx
@@ -1,7 +1,7 @@
 import { type CSSProperties, memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import A from '@/Avatar';
+import { Flexbox } from '@/Flex';
 
 import { useStyles } from '../style';
 import type { ChatItemProps } from '../type';

--- a/src/chat/ChatItem/components/ErrorContent.tsx
+++ b/src/chat/ChatItem/components/ErrorContent.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import Alert from '@/Alert';
+import { Flexbox } from '@/Flex';
 import { ChatItemProps } from '@/chat/ChatItem';
 
 import { useStyles } from '../style';

--- a/src/chat/ChatItem/components/Loading.tsx
+++ b/src/chat/ChatItem/components/Loading.tsx
@@ -1,7 +1,7 @@
 import { Loader2 } from 'lucide-react';
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
+import { Flexbox } from '@/Flex';
 import Icon from '@/Icon';
 import { ChatItemProps } from '@/chat/ChatItem';
 

--- a/src/chat/ChatItem/components/MessageContent.tsx
+++ b/src/chat/ChatItem/components/MessageContent.tsx
@@ -1,7 +1,7 @@
 import { useResponsive } from 'antd-style';
 import { type ReactNode, memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
+import { Flexbox } from '@/Flex';
 import type { MarkdownProps } from '@/Markdown';
 import { ChatItemProps } from '@/chat/ChatItem';
 import EditableMessage from '@/chat/EditableMessage';

--- a/src/chat/ChatItem/components/Title.tsx
+++ b/src/chat/ChatItem/components/Title.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
+import { Flexbox } from '@/Flex';
 import { ChatItemProps } from '@/chat/ChatItem';
 import { formatTime } from '@/utils/formatTime';
 

--- a/src/chat/ChatItem/type.ts
+++ b/src/chat/ChatItem/type.ts
@@ -1,5 +1,5 @@
+import { FlexboxProps } from '@lobehub/ui/Flex';
 import { ReactNode } from 'react';
-import { FlexboxProps } from 'react-layout-kit';
 
 import { AlertProps } from '@/Alert';
 import { AvatarProps } from '@/Avatar';

--- a/src/chat/ChatItem/type.ts
+++ b/src/chat/ChatItem/type.ts
@@ -1,8 +1,8 @@
-import { FlexboxProps } from '@lobehub/ui/Flex';
 import { ReactNode } from 'react';
 
 import { AlertProps } from '@/Alert';
 import { AvatarProps } from '@/Avatar';
+import { FlexboxProps } from '@/Flex';
 import type { MarkdownProps } from '@/Markdown';
 import type { EditableMessageProps } from '@/chat/EditableMessage';
 import type { MetaData } from '@/chat/types';

--- a/src/chat/EditableMessageList/EditableMessageList.tsx
+++ b/src/chat/EditableMessageList/EditableMessageList.tsx
@@ -3,11 +3,11 @@
 import isEqual from 'fast-deep-equal';
 import { Plus, Trash } from 'lucide-react';
 import { memo, useEffect, useReducer } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import ActionIcon from '@/ActionIcon';
 import Button from '@/Button';
 import ControlInput from '@/EditableText/ControlInput';
+import { Flexbox } from '@/Flex';
 import Select from '@/Select';
 
 import { messagesReducer } from './messageReducer';

--- a/src/chat/MessageInput/MessageInput.tsx
+++ b/src/chat/MessageInput/MessageInput.tsx
@@ -3,10 +3,10 @@
 import { useResponsive } from 'antd-style';
 import { memo, useState } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
-import { Flexbox } from 'react-layout-kit';
 
 import Button from '@/Button';
 import CodeEditor from '@/CodeEditor';
+import { Flexbox } from '@/Flex';
 import { KeyMapEnum } from '@/Hotkey/const';
 import { combineKeys } from '@/Hotkey/utils';
 import TextArea from '@/Input/TextArea';

--- a/src/chat/MessageInput/demos/index.tsx
+++ b/src/chat/MessageInput/demos/index.tsx
@@ -1,7 +1,8 @@
 import { MessageInput } from '@lobehub/ui/chat';
 import { Divider } from 'antd';
 import { useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   const [value, setValue] = useState('');

--- a/src/chat/MessageInput/type.ts
+++ b/src/chat/MessageInput/type.ts
@@ -1,5 +1,5 @@
+import { FlexboxProps } from '@lobehub/ui/Flex';
 import { CSSProperties } from 'react';
-import { FlexboxProps } from 'react-layout-kit';
 
 import type { ButtonProps } from '@/Button';
 import type { CodeEditorProps } from '@/CodeEditor';

--- a/src/chat/MessageInput/type.ts
+++ b/src/chat/MessageInput/type.ts
@@ -1,8 +1,8 @@
-import { FlexboxProps } from '@lobehub/ui/Flex';
 import { CSSProperties } from 'react';
 
 import type { ButtonProps } from '@/Button';
 import type { CodeEditorProps } from '@/CodeEditor';
+import { FlexboxProps } from '@/Flex';
 
 export interface MessageInputProps extends FlexboxProps {
   classNames?: CodeEditorProps['classNames'] & {

--- a/src/chat/MessageModal/MessageModal.tsx
+++ b/src/chat/MessageModal/MessageModal.tsx
@@ -2,11 +2,11 @@
 
 import { useResponsive } from 'antd-style';
 import { memo, useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
 import useControlledState from 'use-merge-value';
 
 import Button from '@/Button';
 import CodeEditor from '@/CodeEditor';
+import { Flexbox } from '@/Flex';
 import TextArea from '@/Input/TextArea';
 import Markdown from '@/Markdown';
 import Modal from '@/Modal';

--- a/src/color/ColorScales/ScaleRow.tsx
+++ b/src/color/ColorScales/ScaleRow.tsx
@@ -1,7 +1,7 @@
 import { Space, message } from 'antd';
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
+import { Flexbox } from '@/Flex';
 import { copyToClipboard } from '@/utils/copyToClipboard';
 
 import { alphaBg, useStyles } from './style';

--- a/src/color/ColorScales/index.tsx
+++ b/src/color/ColorScales/index.tsx
@@ -2,7 +2,8 @@
 
 import { Space } from 'antd';
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { ColorScaleItem } from '../types';
 import ScaleRow from './ScaleRow';

--- a/src/icons/Auth0/index.md
+++ b/src/icons/Auth0/index.md
@@ -11,8 +11,9 @@ apiHeader:
 ## Icons
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Auth0 } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => <Auth0 size={64} />;
 ```
@@ -20,8 +21,9 @@ export default () => <Auth0 size={64} />;
 ## Avatars
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Auth0 } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/Auth0/index.md
+++ b/src/icons/Auth0/index.md
@@ -11,8 +11,8 @@ apiHeader:
 ## Icons
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Auth0 } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => <Auth0 size={64} />;
 ```
@@ -20,8 +20,8 @@ export default () => <Auth0 size={64} />;
 ## Avatars
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Auth0 } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/Authelia/index.md
+++ b/src/icons/Authelia/index.md
@@ -11,8 +11,8 @@ apiHeader:
 ## Icons
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Authelia } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => <Authelia size={64} />;
 ```
@@ -20,8 +20,8 @@ export default () => <Authelia size={64} />;
 ## Color
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Authelia } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => <Authelia.Color size={64} />;
 ```
@@ -29,8 +29,8 @@ export default () => <Authelia.Color size={64} />;
 ## Avatars
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Authelia } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/Authelia/index.md
+++ b/src/icons/Authelia/index.md
@@ -11,8 +11,9 @@ apiHeader:
 ## Icons
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Authelia } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => <Authelia size={64} />;
 ```
@@ -20,8 +21,9 @@ export default () => <Authelia size={64} />;
 ## Color
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Authelia } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => <Authelia.Color size={64} />;
 ```
@@ -29,8 +31,9 @@ export default () => <Authelia.Color size={64} />;
 ## Avatars
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Authelia } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/Authentik/index.md
+++ b/src/icons/Authentik/index.md
@@ -11,8 +11,8 @@ apiHeader:
 ## Icons
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Authentik } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => <Authentik size={64} />;
 ```
@@ -20,8 +20,8 @@ export default () => <Authentik size={64} />;
 ## Color
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Authentik } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => <Authentik.Color size={64} />;
 ```
@@ -29,8 +29,8 @@ export default () => <Authentik.Color size={64} />;
 ## Avatars
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Authentik } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/Authentik/index.md
+++ b/src/icons/Authentik/index.md
@@ -11,8 +11,9 @@ apiHeader:
 ## Icons
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Authentik } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => <Authentik size={64} />;
 ```
@@ -20,8 +21,9 @@ export default () => <Authentik size={64} />;
 ## Color
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Authentik } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => <Authentik.Color size={64} />;
 ```
@@ -29,8 +31,9 @@ export default () => <Authentik.Color size={64} />;
 ## Avatars
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Authentik } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/Casdoor/index.md
+++ b/src/icons/Casdoor/index.md
@@ -11,8 +11,9 @@ apiHeader:
 ## Icons
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Casdoor } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => <Casdoor size={64} />;
 ```
@@ -20,8 +21,9 @@ export default () => <Casdoor size={64} />;
 ## Color
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Casdoor } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => <Casdoor.Color size={64} />;
 ```
@@ -29,8 +31,9 @@ export default () => <Casdoor.Color size={64} />;
 ## Avatars
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Casdoor } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/Casdoor/index.md
+++ b/src/icons/Casdoor/index.md
@@ -11,8 +11,8 @@ apiHeader:
 ## Icons
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Casdoor } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => <Casdoor size={64} />;
 ```
@@ -20,8 +20,8 @@ export default () => <Casdoor size={64} />;
 ## Color
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Casdoor } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => <Casdoor.Color size={64} />;
 ```
@@ -29,8 +29,8 @@ export default () => <Casdoor.Color size={64} />;
 ## Avatars
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Casdoor } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/Clerk/index.md
+++ b/src/icons/Clerk/index.md
@@ -11,8 +11,9 @@ apiHeader:
 ## Icons
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Clerk } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => <Clerk size={64} />;
 ```
@@ -20,8 +21,9 @@ export default () => <Clerk size={64} />;
 ## Color
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Clerk } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => <Clerk.Color size={64} />;
 ```
@@ -29,8 +31,9 @@ export default () => <Clerk.Color size={64} />;
 ## Avatars
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Clerk } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/Clerk/index.md
+++ b/src/icons/Clerk/index.md
@@ -11,8 +11,8 @@ apiHeader:
 ## Icons
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Clerk } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => <Clerk size={64} />;
 ```
@@ -20,8 +20,8 @@ export default () => <Clerk size={64} />;
 ## Color
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Clerk } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => <Clerk.Color size={64} />;
 ```
@@ -29,8 +29,8 @@ export default () => <Clerk.Color size={64} />;
 ## Avatars
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Clerk } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/Cloudflare/index.md
+++ b/src/icons/Cloudflare/index.md
@@ -11,8 +11,9 @@ apiHeader:
 ## Icons
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Cloudflare } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => <Cloudflare size={64} />;
 ```
@@ -20,8 +21,9 @@ export default () => <Cloudflare size={64} />;
 ## Avatars
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Cloudflare } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/Cloudflare/index.md
+++ b/src/icons/Cloudflare/index.md
@@ -11,8 +11,8 @@ apiHeader:
 ## Icons
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Cloudflare } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => <Cloudflare size={64} />;
 ```
@@ -20,8 +20,8 @@ export default () => <Cloudflare size={64} />;
 ## Avatars
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Cloudflare } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/Github/index.md
+++ b/src/icons/Github/index.md
@@ -11,8 +11,9 @@ apiHeader:
 ## Icons
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Github } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => <Github size={64} />;
 ```
@@ -20,8 +21,9 @@ export default () => <Github size={64} />;
 ## Avatars
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Github } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/Github/index.md
+++ b/src/icons/Github/index.md
@@ -11,8 +11,8 @@ apiHeader:
 ## Icons
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Github } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => <Github size={64} />;
 ```
@@ -20,8 +20,8 @@ export default () => <Github size={64} />;
 ## Avatars
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Github } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/Logto/index.md
+++ b/src/icons/Logto/index.md
@@ -11,8 +11,8 @@ apiHeader:
 ## Icons
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Logto } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => <Logto size={64} />;
 ```
@@ -20,8 +20,8 @@ export default () => <Logto size={64} />;
 ## Color
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Logto } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => <Logto.Color size={64} />;
 ```
@@ -29,8 +29,8 @@ export default () => <Logto.Color size={64} />;
 ## Avatars
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Logto } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/Logto/index.md
+++ b/src/icons/Logto/index.md
@@ -11,8 +11,9 @@ apiHeader:
 ## Icons
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Logto } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => <Logto size={64} />;
 ```
@@ -20,8 +21,9 @@ export default () => <Logto size={64} />;
 ## Color
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Logto } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => <Logto.Color size={64} />;
 ```
@@ -29,8 +31,9 @@ export default () => <Logto.Color size={64} />;
 ## Avatars
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Logto } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/MicrosoftEntra/index.md
+++ b/src/icons/MicrosoftEntra/index.md
@@ -11,8 +11,9 @@ apiHeader:
 ## Icons
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { MicrosoftEntra } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => <MicrosoftEntra size={64} />;
 ```
@@ -20,8 +21,9 @@ export default () => <MicrosoftEntra size={64} />;
 ## Color
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { MicrosoftEntra } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => <MicrosoftEntra.Color size={64} />;
 ```
@@ -29,8 +31,9 @@ export default () => <MicrosoftEntra.Color size={64} />;
 ## Avatars
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { MicrosoftEntra } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/MicrosoftEntra/index.md
+++ b/src/icons/MicrosoftEntra/index.md
@@ -11,8 +11,8 @@ apiHeader:
 ## Icons
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { MicrosoftEntra } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => <MicrosoftEntra size={64} />;
 ```
@@ -20,8 +20,8 @@ export default () => <MicrosoftEntra size={64} />;
 ## Color
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { MicrosoftEntra } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => <MicrosoftEntra.Color size={64} />;
 ```
@@ -29,8 +29,8 @@ export default () => <MicrosoftEntra.Color size={64} />;
 ## Avatars
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { MicrosoftEntra } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/NextAuth/index.md
+++ b/src/icons/NextAuth/index.md
@@ -11,8 +11,8 @@ apiHeader:
 ## Icons
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { NextAuth } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => <NextAuth size={64} />;
 ```
@@ -20,8 +20,8 @@ export default () => <NextAuth size={64} />;
 ## Color
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { NextAuth } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => <NextAuth.Color size={64} />;
 ```
@@ -29,8 +29,8 @@ export default () => <NextAuth.Color size={64} />;
 ## Avatars
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { NextAuth } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/NextAuth/index.md
+++ b/src/icons/NextAuth/index.md
@@ -11,8 +11,9 @@ apiHeader:
 ## Icons
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { NextAuth } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => <NextAuth size={64} />;
 ```
@@ -20,8 +21,9 @@ export default () => <NextAuth size={64} />;
 ## Color
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { NextAuth } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => <NextAuth.Color size={64} />;
 ```
@@ -29,8 +31,9 @@ export default () => <NextAuth.Color size={64} />;
 ## Avatars
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { NextAuth } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/Zitadel/index.md
+++ b/src/icons/Zitadel/index.md
@@ -11,8 +11,9 @@ apiHeader:
 ## Icons
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Zitadel } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => <Zitadel size={64} />;
 ```
@@ -20,8 +21,9 @@ export default () => <Zitadel size={64} />;
 ## Color
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Zitadel } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => <Zitadel.Color size={64} />;
 ```
@@ -29,8 +31,9 @@ export default () => <Zitadel.Color size={64} />;
 ## Avatars
 
 ```tsx
-import { Flexbox } from '@lobehub/ui/Flex';
 import { Zitadel } from '@lobehub/ui/icons';
+
+import { Flexbox } from '@/Flex';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/Zitadel/index.md
+++ b/src/icons/Zitadel/index.md
@@ -11,8 +11,8 @@ apiHeader:
 ## Icons
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Zitadel } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => <Zitadel size={64} />;
 ```
@@ -20,8 +20,8 @@ export default () => <Zitadel size={64} />;
 ## Color
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Zitadel } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => <Zitadel.Color size={64} />;
 ```
@@ -29,8 +29,8 @@ export default () => <Zitadel.Color size={64} />;
 ## Avatars
 
 ```tsx
+import { Flexbox } from '@lobehub/ui/Flex';
 import { Zitadel } from '@lobehub/ui/icons';
-import { Flexbox } from 'react-layout-kit';
 
 export default () => (
   <Flexbox gap={16} horizontal>

--- a/src/icons/lucideExtra/demos/index.tsx
+++ b/src/icons/lucideExtra/demos/index.tsx
@@ -1,6 +1,7 @@
 import { ActionIcon, copyToClipboard } from '@lobehub/ui';
 import { message } from 'antd';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import * as icons from '../index';
 

--- a/src/mdx/Callout/index.tsx
+++ b/src/mdx/Callout/index.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { FlexboxProps } from '@lobehub/ui/Flex';
 import { AlertOctagon, AlertTriangle, Info, Lightbulb, MessageSquareWarning } from 'lucide-react';
 import { FC, useMemo } from 'react';
 
-import { Flexbox } from '@/Flex';
+import { Flexbox, FlexboxProps } from '@/Flex';
 import Icon from '@/Icon';
 
 import { useStyles } from './style';

--- a/src/mdx/Callout/index.tsx
+++ b/src/mdx/Callout/index.tsx
@@ -1,9 +1,10 @@
 'use client';
 
+import { FlexboxProps } from '@lobehub/ui/Flex';
 import { AlertOctagon, AlertTriangle, Info, Lightbulb, MessageSquareWarning } from 'lucide-react';
 import { FC, useMemo } from 'react';
-import { Flexbox, FlexboxProps } from 'react-layout-kit';
 
+import { Flexbox } from '@/Flex';
 import Icon from '@/Icon';
 
 import { useStyles } from './style';

--- a/src/mdx/Cards/Card.tsx
+++ b/src/mdx/Cards/Card.tsx
@@ -2,10 +2,10 @@
 
 import { createStyles } from 'antd-style';
 import { FC } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import A from '@/A';
 import Block, { type BlockProps } from '@/Block';
+import { Flexbox } from '@/Flex';
 import Icon, { type IconProps } from '@/Icon';
 import Img from '@/Img';
 import Tag, { type TagProps } from '@/Tag';

--- a/src/mdx/FileTree/File.tsx
+++ b/src/mdx/FileTree/File.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { FlexboxProps } from '@lobehub/ui/Flex';
 import { FileIcon } from 'lucide-react';
 import { FC } from 'react';
 
-import { Flexbox } from '@/Flex';
+import { Flexbox, FlexboxProps } from '@/Flex';
 import Icon, { type IconProps } from '@/Icon';
 
 export interface FileProps extends Omit<FlexboxProps, 'children'> {

--- a/src/mdx/FileTree/File.tsx
+++ b/src/mdx/FileTree/File.tsx
@@ -1,9 +1,10 @@
 'use client';
 
+import { FlexboxProps } from '@lobehub/ui/Flex';
 import { FileIcon } from 'lucide-react';
 import { FC } from 'react';
-import { Flexbox, FlexboxProps } from 'react-layout-kit';
 
+import { Flexbox } from '@/Flex';
 import Icon, { type IconProps } from '@/Icon';
 
 export interface FileProps extends Omit<FlexboxProps, 'children'> {

--- a/src/mdx/FileTree/Folder.tsx
+++ b/src/mdx/FileTree/Folder.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { FlexboxProps } from '@lobehub/ui/Flex';
 import { createStyles } from 'antd-style';
 import { FolderIcon, FolderOpen } from 'lucide-react';
 import { FC, useState } from 'react';
 
-import { Flexbox } from '@/Flex';
+import { Flexbox, FlexboxProps } from '@/Flex';
 import Icon, { type IconProps } from '@/Icon';
 
 const useStyles = createStyles(({ css, token }) => {

--- a/src/mdx/FileTree/Folder.tsx
+++ b/src/mdx/FileTree/Folder.tsx
@@ -1,10 +1,11 @@
 'use client';
 
+import { FlexboxProps } from '@lobehub/ui/Flex';
 import { createStyles } from 'antd-style';
 import { FolderIcon, FolderOpen } from 'lucide-react';
 import { FC, useState } from 'react';
-import { Flexbox, FlexboxProps } from 'react-layout-kit';
 
+import { Flexbox } from '@/Flex';
 import Icon, { type IconProps } from '@/Icon';
 
 const useStyles = createStyles(({ css, token }) => {

--- a/src/mdx/Tabs/index.tsx
+++ b/src/mdx/Tabs/index.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { FlexboxProps } from '@lobehub/ui/Flex';
 import { FC, ReactNode, useState } from 'react';
 
-import { Flexbox } from '@/Flex';
+import { Flexbox, FlexboxProps } from '@/Flex';
 import { default as LobeTabs, type TabsProps as LobeTabsProps } from '@/Tabs';
 
 import { useStyles } from './style';

--- a/src/mdx/Tabs/index.tsx
+++ b/src/mdx/Tabs/index.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { FlexboxProps } from '@lobehub/ui/Flex';
 import { FC, ReactNode, useState } from 'react';
-import { Flexbox, FlexboxProps } from 'react-layout-kit';
 
+import { Flexbox } from '@/Flex';
 import { default as LobeTabs, type TabsProps as LobeTabsProps } from '@/Tabs';
 
 import { useStyles } from './style';

--- a/src/mdx/mdxComponents/Citation/PopoverPanel.tsx
+++ b/src/mdx/mdxComponents/Citation/PopoverPanel.tsx
@@ -4,8 +4,8 @@ import { Popover } from 'antd';
 import { createStyles } from 'antd-style';
 import { ArrowRightIcon } from 'lucide-react';
 import { type FC, type ReactNode, useMemo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
+import { Flexbox } from '@/Flex';
 import Icon from '@/Icon';
 
 const useStyles = createStyles(({ css, token }) => ({

--- a/src/mobile/ChatHeader/ChatHeader.tsx
+++ b/src/mobile/ChatHeader/ChatHeader.tsx
@@ -2,9 +2,9 @@
 
 import { ChevronLeft } from 'lucide-react';
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import ActionIcon from '@/ActionIcon';
+import { Flexbox } from '@/Flex';
 import MobileSafeArea from '@/mobile/SafeArea';
 
 import { useStyles } from './style';

--- a/src/mobile/ChatHeader/ChatHeaderTitle.tsx
+++ b/src/mobile/ChatHeader/ChatHeaderTitle.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 import { useTitleStyles as useStyles } from './style';
 import { ChatHeaderTitleProps } from './type';

--- a/src/mobile/ChatHeader/demos/index.tsx
+++ b/src/mobile/ChatHeader/demos/index.tsx
@@ -1,7 +1,8 @@
 import { ActionIcon, Tag } from '@lobehub/ui';
 import { ChatHeader } from '@lobehub/ui/mobile';
 import { MessageCircle } from 'lucide-react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   return (

--- a/src/mobile/ChatHeader/type.ts
+++ b/src/mobile/ChatHeader/type.ts
@@ -1,5 +1,6 @@
-import { FlexboxProps } from '@lobehub/ui/Flex';
 import { CSSProperties, ReactNode, Ref } from 'react';
+
+import { FlexboxProps } from '@/Flex';
 
 export interface ChatHeaderProps extends FlexboxProps {
   center?: ReactNode;

--- a/src/mobile/ChatHeader/type.ts
+++ b/src/mobile/ChatHeader/type.ts
@@ -1,5 +1,5 @@
+import { FlexboxProps } from '@lobehub/ui/Flex';
 import { CSSProperties, ReactNode, Ref } from 'react';
-import { FlexboxProps } from 'react-layout-kit';
 
 export interface ChatHeaderProps extends FlexboxProps {
   center?: ReactNode;

--- a/src/mobile/ChatInputArea/ChatInputArea.tsx
+++ b/src/mobile/ChatInputArea/ChatInputArea.tsx
@@ -12,9 +12,9 @@ import {
   useRef,
   useState,
 } from 'react';
-import { Flexbox } from 'react-layout-kit';
 
 import ActionIcon from '@/ActionIcon';
+import { Flexbox } from '@/Flex';
 import ChatInputAreaInner from '@/chat/ChatInputArea/components/ChatInputAreaInner';
 import SafeArea from '@/mobile/SafeArea';
 

--- a/src/mobile/ChatInputArea/demos/index.tsx
+++ b/src/mobile/ChatInputArea/demos/index.tsx
@@ -3,7 +3,8 @@ import { ChatInputActionBar, TokenTag } from '@lobehub/ui/chat';
 import { ChatInputArea } from '@lobehub/ui/mobile';
 import { Eraser, Languages } from 'lucide-react';
 import { useState } from 'react';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   const [expand, setExpand] = useState(false);

--- a/src/mobile/SafeArea/demos/index.tsx
+++ b/src/mobile/SafeArea/demos/index.tsx
@@ -1,5 +1,6 @@
 import { SafeArea } from '@lobehub/ui/mobile';
-import { Flexbox } from 'react-layout-kit';
+
+import { Flexbox } from '@/Flex';
 
 export default () => {
   return (

--- a/src/mobile/TabBar/TabBar.tsx
+++ b/src/mobile/TabBar/TabBar.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { memo } from 'react';
-import { Flexbox } from 'react-layout-kit';
 import useMergeState from 'use-merge-value';
 
+import { Flexbox } from '@/Flex';
 import SafeArea from '@/mobile/SafeArea';
 
 import { useStyles } from './style';

--- a/src/mobile/TabBar/type.ts
+++ b/src/mobile/TabBar/type.ts
@@ -1,5 +1,5 @@
+import { FlexboxProps } from '@lobehub/ui/Flex';
 import { ReactNode, Ref } from 'react';
-import { FlexboxProps } from 'react-layout-kit';
 
 export interface TabBarItemType {
   icon: ReactNode | ((active: boolean) => ReactNode);

--- a/src/mobile/TabBar/type.ts
+++ b/src/mobile/TabBar/type.ts
@@ -1,5 +1,6 @@
-import { FlexboxProps } from '@lobehub/ui/Flex';
 import { ReactNode, Ref } from 'react';
+
+import { FlexboxProps } from '@/Flex';
 
 export interface TabBarItemType {
   icon: ReactNode | ((active: boolean) => ReactNode);

--- a/src/storybook/StoryBook/index.tsx
+++ b/src/storybook/StoryBook/index.tsx
@@ -1,11 +1,12 @@
 'use client';
 
+import { FlexboxProps } from '@lobehub/ui/Flex';
 import { useResponsive } from 'antd-style';
 import { LevaPanel } from 'leva';
 import { Ref, memo } from 'react';
-import { Center, Flexbox, FlexboxProps } from 'react-layout-kit';
 
 import DraggablePanel from '@/DraggablePanel';
+import { Center, Flexbox } from '@/Flex';
 
 import { useStyles } from './style';
 

--- a/src/storybook/StoryBook/index.tsx
+++ b/src/storybook/StoryBook/index.tsx
@@ -1,12 +1,11 @@
 'use client';
 
-import { FlexboxProps } from '@lobehub/ui/Flex';
 import { useResponsive } from 'antd-style';
 import { LevaPanel } from 'leva';
 import { Ref, memo } from 'react';
 
 import DraggablePanel from '@/DraggablePanel';
-import { Center, Flexbox } from '@/Flex';
+import { Center, Flexbox, FlexboxProps } from '@/Flex';
 
 import { useStyles } from './style';
 


### PR DESCRIPTION
- Updated imports and styles across multiple components including Accordion, ActionIcon, Avatar, and more.
- Enhanced demo files for better presentation and functionality.
- Ensured consistent usage of types and props in components.

This commit improves the overall structure and maintainability of the codebase.

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

remove layout-kit
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Replace external layout-kit usage with the internal Flex/Flexbox system across components, demos, and docs, and adjust Flex defaults to avoid unintended CSS variable inheritance.

Enhancements:
- Set explicit CSS variable defaults on the Flex container and simplify usage by removing per-property fallbacks.
- Unify layout and spacing props by migrating component and type definitions from react-layout-kit FlexboxProps to @lobehub/ui/Flex FlexboxProps.
- Update UI components, mobile components, and chat components to rely on the shared Flex abstractions for layout.
- Refresh demos, MDX examples, and documentation snippets to import Flexbox/Center from the local Flex module or @lobehub/ui/Flex for consistency.

Build:
- Remove the react-layout-kit dependency from package.json now that layout is handled by the internal Flex system.