### PR TITLE
🐛 fix(accordion): prevent text selection on title double-click

### DIFF
--- a/src/Accordion/AccordionItem.tsx
+++ b/src/Accordion/AccordionItem.tsx
@@ -279,6 +279,12 @@ const AccordionItem = memo<AccordionItemProps>(
       [allowExpand, disabled, handleToggle],
     );
 
+    const preventTitleTextSelection = useCallback((e: any) => {
+      // Prevent browser from creating a selection range on double/multi click,
+      // which can accidentally select the content region.
+      if (e?.detail > 1) e.preventDefault();
+    }, []);
+
     // Build indicator
     const indicator = useMemo(() => {
       if (!allowExpand || hideIndicatorFinal) return null;
@@ -392,9 +398,12 @@ const AccordionItem = memo<AccordionItemProps>(
             <>
               <Flexbox
                 align={'center'}
+                className={styles.titleWrapper}
                 flex={1}
                 gap={2}
                 horizontal
+                onDoubleClick={preventTitleTextSelection}
+                onMouseDown={preventTitleTextSelection}
                 style={{
                   overflow: 'hidden',
                 }}
@@ -410,9 +419,12 @@ const AccordionItem = memo<AccordionItemProps>(
             <>
               <Flexbox
                 align={'center'}
+                className={styles.titleWrapper}
                 flex={1}
                 gap={2}
                 horizontal
+                onDoubleClick={preventTitleTextSelection}
+                onMouseDown={preventTitleTextSelection}
                 style={{
                   overflow: 'hidden',
                 }}

--- a/src/Accordion/style.ts
+++ b/src/Accordion/style.ts
@@ -56,5 +56,8 @@ export const styles = createStaticStyles(({ css, cssVar }) => {
       display: flex;
       flex-direction: column;
     `,
+    titleWrapper: css`
+      user-select: none;
+    `,
   };
 });


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Prevent browser text selection when double-clicking or multi-clicking on `AccordionItem` title. Previously, rapid clicking could accidentally select text in the content region. Added `user-select: none` CSS and mouse event handlers to the title wrapper.

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Disable browser text selection on accordion item titles during double or multi-click interactions to avoid accidental content selection.