### PR TITLE
✨ feat: Update ThemeProvider and Tooltip components

### DIFF
--- a/src/ThemeProvider/ThemeProvider.tsx
+++ b/src/ThemeProvider/ThemeProvider.tsx
@@ -18,6 +18,7 @@ import { LobeCustomToken } from '@/types/customToken';
 
 import AntdConfigProvider from './ConfigProvider';
 import GlobalStyle from './GlobalStyle';
+import { LOBE_THEME_APP_ID } from './constants';
 import type { ThemeProviderProps } from './type';
 
 const ThemeProvider = memo<ThemeProviderProps>(
@@ -89,7 +90,9 @@ const ThemeProvider = memo<ThemeProviderProps>(
           <AntdConfigProvider>
             {enableGlobalStyle && <GlobalStyle />}
             <App className={className} style={{ minHeight: 'inherit', width: 'inherit', ...style }}>
-              {children}
+              <div id={LOBE_THEME_APP_ID} style={{ display: 'contents' }}>
+                {children}
+              </div>
             </App>
           </AntdConfigProvider>
         </AntdThemeProvider>

--- a/src/ThemeProvider/constants.ts
+++ b/src/ThemeProvider/constants.ts
@@ -1,0 +1,1 @@
+export const LOBE_THEME_APP_ID = 'lobe-ui-theme-app';

--- a/src/ThemeProvider/index.ts
+++ b/src/ThemeProvider/index.ts
@@ -1,3 +1,4 @@
+export * from './constants';
 export { default as Meta } from './Meta';
 export { default } from './ThemeProvider';
 export type * from './type';


### PR DESCRIPTION
## Summary

- Add `constants.ts` file to ThemeProvider for centralized constant management
- Update ThemeProvider implementation to use the new constants
- Improve TooltipPortal with container support and better root resolution logic
  - Portals now mount under `TooltipContainer` if provided
  - Falls back to ThemeProvider's App root
  - Falls back to `document.body` as final default

## Files changed

- `src/ThemeProvider/ThemeProvider.tsx` - Updated to use constants
- `src/ThemeProvider/constants.ts` - New file for centralized constants
- `src/ThemeProvider/index.ts` - Export constants
- `src/Tooltip/TooltipPortal.tsx` - Enhanced container resolution logic

## Summary by Sourcery

Centralize ThemeProvider app root configuration and enhance tooltip portal mounting behavior.

New Features:
- Introduce a shared ThemeProvider app root element identified by a constant ID for downstream consumers.
- Allow tooltips to resolve and mount into a dedicated tooltip container or the ThemeProvider app root before falling back to document.body.

Enhancements:
- Refine TooltipPortal to create its portal container after mount to avoid SSR and hydration side effects.
- Export ThemeProvider constants for reuse across components.