### PR TITLE
✨ feat(tooltip): Add layoutAnimation option and z-index to ContextMenu

### DIFF
--- a/src/ContextMenu/style.ts
+++ b/src/ContextMenu/style.ts
@@ -108,6 +108,8 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 
   popup: css`
+    z-index: 1000;
+
     min-width: 200px;
     padding: 4px;
     border-radius: ${cssVar.borderRadius};

--- a/src/Tooltip/TooltipFloating.tsx
+++ b/src/Tooltip/TooltipFloating.tsx
@@ -29,6 +29,12 @@ type TooltipFloatingProps = {
   hotkey?: TooltipProps['hotkey'];
   hotkeyProps?: TooltipProps['hotkeyProps'];
 
+  /**
+   * @description Whether to enable layout animation when switching between tooltips
+   * @default true
+   */
+  layoutAnimation?: boolean;
+
   open: boolean;
   placement?: Placement;
 
@@ -50,6 +56,7 @@ const TooltipFloating = ({
   context,
   hotkey,
   hotkeyProps,
+  layoutAnimation = true,
 
   className,
   classNames,
@@ -89,7 +96,7 @@ const TooltipFloating = ({
         <div
           className={cx(
             styles.tooltip,
-            hasTransform && styles.tooltipLayout,
+            layoutAnimation && hasTransform && styles.tooltipLayout,
             classNames?.container,
             classNames?.root,
             className,

--- a/src/Tooltip/TooltipGroup.tsx
+++ b/src/Tooltip/TooltipGroup.tsx
@@ -25,7 +25,11 @@ type TooltipGroupProps = TooltipGroupSharedProps & {
   children: ReactNode;
 };
 
-const TooltipGroup: FC<TooltipGroupProps> = ({ children, ...sharedProps }) => {
+const TooltipGroup: FC<TooltipGroupProps> = ({
+  children,
+  layoutAnimation = true,
+  ...sharedProps
+}) => {
   const arrowRef = useRef<SVGSVGElement | null>(null);
   const openTimerRef = useRef<number | null>(null);
   const closeTimerRef = useRef<number | null>(null);
@@ -195,6 +199,7 @@ const TooltipGroup: FC<TooltipGroupProps> = ({ children, ...sharedProps }) => {
       floatingStyles={floatingStyles}
       hotkey={active?.item.hotkey}
       hotkeyProps={active?.item.hotkeyProps}
+      layoutAnimation={layoutAnimation}
       open={open}
       placement={floatingPlacement}
       setFloating={refs.setFloating}

--- a/src/Tooltip/groupContext.ts
+++ b/src/Tooltip/groupContext.ts
@@ -7,7 +7,13 @@ export type TooltipGroupItem = Omit<TooltipProps, 'children' | 'open' | 'default
 export type TooltipGroupSharedProps = Omit<
   TooltipProps,
   'children' | 'defaultOpen' | 'open' | 'ref' | 'title'
->;
+> & {
+  /**
+   * @description Whether to enable layout animation when switching between tooltips
+   * @default true
+   */
+  layoutAnimation?: boolean;
+};
 
 export type TooltipGroupApi = {
   closeFromTrigger: (triggerEl: HTMLElement, item: TooltipGroupItem) => void;


### PR DESCRIPTION
## Summary

- Add `layoutAnimation` prop to `TooltipGroup` to control layout animation when switching between tooltips
- Add z-index to `ContextMenu` popup to ensure proper layering
- Default `layoutAnimation` to `true` to maintain existing behavior

## Changes

- `src/ContextMenu/style.ts`: Added `z-index: 1000` to popup styles
- `src/Tooltip/TooltipFloating.tsx`: Added `layoutAnimation` prop with default `true`
- `src/Tooltip/TooltipGroup.tsx`: Added `layoutAnimation` prop and passed it through
- `src/Tooltip/groupContext.ts`: Added `layoutAnimation` to `TooltipGroupSharedProps` type

## Test plan

- [x] Type check passes
- [x] Lint passes
- [x] No circular dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a configurable layout animation option to grouped tooltips and ensure the context menu popup renders above surrounding content.

New Features:
- Introduce an optional layoutAnimation prop on TooltipGroup and TooltipFloating to control animated layout transitions when switching between tooltips.

Enhancements:
- Default tooltip layoutAnimation to true to preserve existing animated behavior while allowing it to be disabled.
- Set a high z-index on the ContextMenu popup to improve layering over other UI elements.