### PR TITLE
chore: Update @base-ui/react to version 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
   },
   "dependencies": {
     "@ant-design/cssinjs": "^2.0.1",
-    "@base-ui/react": "1.0.0",
+    "@base-ui/react": "1.1.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",

--- a/src/Popover/style.ts
+++ b/src/Popover/style.ts
@@ -108,7 +108,8 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
 
     z-index: 1100;
 
-    width: min(var(--positioner-width), var(--available-width));
+    width: var(--positioner-width);
+    max-width: var(--available-width);
     height: var(--positioner-height);
 
     transition-timing-function: var(--lobe-popover-animation-ease-out);


### PR DESCRIPTION
## Summary
- Update @base-ui/react from 1.0.0 to 1.1.0
- Adjust Popover styles to accommodate new version changes

## Changes
- `package.json`: Bump @base-ui/react version
- `src/Popover/style.ts`: Update Popover styling

## Summary by Sourcery

Update the Base UI React dependency and adjust Popover layout styling to align with the new version.

Enhancements:
- Adjust Popover dimensions to respect the available width while using the computed positioner width.

Build:
- Bump @base-ui/react dependency from 1.0.0 to 1.1.0.