### PR TITLE
✨ feat: Add LobeSwitch component with BaseUI and motion animations

### DIFF
--- a/src/LobeSwitch/LobeSwitch.tsx
+++ b/src/LobeSwitch/LobeSwitch.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { cx } from 'antd-style';
+import { Loader2 } from 'lucide-react';
+import { memo } from 'react';
+
+import Icon from '@/Icon';
+
+import { LobeSwitchIcon, LobeSwitchRoot, LobeSwitchThumb } from './atoms';
+import { styles } from './style';
+import type { LobeSwitchProps } from './type';
+
+const LobeSwitch = memo<LobeSwitchProps>(
+  ({
+    autoFocus,
+    checked,
+    checkedChildren,
+    className,
+    classNames,
+    defaultChecked,
+    defaultValue,
+    disabled,
+    id,
+    loading,
+    name,
+    onChange,
+    onClick,
+    ref,
+    rootClassName,
+    size = 'default',
+    style,
+    styles: customStyles,
+    tabIndex,
+    title,
+    unCheckedChildren,
+    value,
+  }) => {
+    const isDisabled = disabled || loading;
+    const resolvedChecked = value ?? checked;
+    const resolvedDefaultChecked = defaultValue ?? defaultChecked;
+
+    return (
+      <LobeSwitchRoot
+        autoFocus={autoFocus}
+        checked={resolvedChecked}
+        className={cx(className, rootClassName, classNames?.root)}
+        defaultChecked={resolvedDefaultChecked}
+        disabled={isDisabled}
+        id={id}
+        name={name}
+        onCheckedChange={onChange}
+        onClick={onClick}
+        ref={ref}
+        size={size}
+        style={{ ...style, ...customStyles?.root }}
+        tabIndex={tabIndex}
+        title={title}
+      >
+        {checkedChildren && (
+          <LobeSwitchIcon
+            className={classNames?.content}
+            position="left"
+            size={size}
+            style={customStyles?.content}
+          >
+            {checkedChildren}
+          </LobeSwitchIcon>
+        )}
+        {unCheckedChildren && (
+          <LobeSwitchIcon
+            className={classNames?.content}
+            position="right"
+            size={size}
+            style={customStyles?.content}
+          >
+            {unCheckedChildren}
+          </LobeSwitchIcon>
+        )}
+        <LobeSwitchThumb className={classNames?.thumb} size={size} style={customStyles?.thumb}>
+          {loading && (
+            <Icon
+              className={styles.loading}
+              icon={Loader2}
+              size={size === 'small' ? 8 : 12}
+              style={{ color: 'var(--lobe-color-primary)' }}
+            />
+          )}
+        </LobeSwitchThumb>
+      </LobeSwitchRoot>
+    );
+  },
+);
+
+LobeSwitch.displayName = 'LobeSwitch';
+
+export default LobeSwitch;

--- a/src/LobeSwitch/atoms.tsx
+++ b/src/LobeSwitch/atoms.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { Switch } from '@base-ui/react/switch';
+import { cx } from 'antd-style';
+import type { KeyboardEvent, MouseEvent } from 'react';
+import { createContext, useContext, useMemo, useRef, useState } from 'react';
+import useControlledState from 'use-merge-value';
+
+import { useMotionComponent } from '@/MotionProvider';
+
+import { rootVariants, styles, thumbVariants } from './style';
+import type {
+  LobeSwitchChangeEventHandler,
+  LobeSwitchContextType,
+  LobeSwitchIconPosition,
+  LobeSwitchIconProps,
+  LobeSwitchRootProps,
+  LobeSwitchThumbProps,
+} from './type';
+
+const LobeSwitchContext = createContext<LobeSwitchContextType | null>(null);
+
+export const useLobeSwitchContext = () => {
+  const context = useContext(LobeSwitchContext);
+  if (!context) {
+    throw new Error('useLobeSwitchContext must be used within a LobeSwitchRoot');
+  }
+  return context;
+};
+
+type LobeSwitchRootInternalProps = Omit<LobeSwitchRootProps, 'onCheckedChange' | 'onClick'> & {
+  onCheckedChange?: LobeSwitchChangeEventHandler;
+  onClick?: LobeSwitchChangeEventHandler;
+};
+
+export const LobeSwitchRoot = ({
+  checked,
+  className,
+  defaultChecked,
+  onCheckedChange,
+  onClick,
+  size = 'default',
+  children,
+  disabled,
+  readOnly,
+  required,
+  inputRef,
+  id,
+  name,
+  ...rest
+}: LobeSwitchRootInternalProps) => {
+  const Motion = useMotionComponent();
+  const [isPressed, setIsPressed] = useState(false);
+  const lastEventRef = useRef<MouseEvent<HTMLButtonElement> | KeyboardEvent<HTMLButtonElement>>(
+    null,
+  );
+
+  const [isChecked, setIsChecked] = useControlledState(defaultChecked ?? false, {
+    defaultValue: defaultChecked,
+    onChange: (value: boolean) => {
+      if (lastEventRef.current) {
+        onCheckedChange?.(value, lastEventRef.current);
+      }
+    },
+    value: checked,
+  });
+
+  const baseClassName = rootVariants({ size });
+
+  const contextValue = useMemo(
+    () => ({
+      isChecked: Boolean(isChecked),
+      isPressed,
+      setIsChecked: (value: boolean) => setIsChecked(value),
+      setIsPressed,
+    }),
+    [isChecked, isPressed, setIsChecked],
+  );
+
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    lastEventRef.current = event;
+    onClick?.(!isChecked, event);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      lastEventRef.current = event;
+    }
+    (rest as any).onKeyDown?.(event);
+  };
+
+  return (
+    <LobeSwitchContext.Provider value={contextValue}>
+      <Switch.Root
+        checked={isChecked}
+        defaultChecked={defaultChecked}
+        disabled={disabled}
+        id={id}
+        inputRef={inputRef}
+        name={name}
+        onCheckedChange={setIsChecked}
+        readOnly={readOnly}
+        render={
+          <Motion.button
+            {...rest}
+            className={cx(baseClassName, className)}
+            initial={false}
+            onClick={handleClick}
+            onKeyDown={handleKeyDown}
+            onTap={() => setIsPressed(false)}
+            onTapCancel={() => setIsPressed(false)}
+            onTapStart={() => setIsPressed(true)}
+            whileTap="tap"
+          />
+        }
+        required={required}
+      >
+        {children}
+      </Switch.Root>
+    </LobeSwitchContext.Provider>
+  );
+};
+
+LobeSwitchRoot.displayName = 'LobeSwitchRoot';
+
+export const LobeSwitchThumb = ({
+  className,
+  pressedAnimation,
+  size = 'default',
+  transition = { damping: 25, stiffness: 300, type: 'spring' },
+  children,
+  ...rest
+}: LobeSwitchThumbProps) => {
+  const Motion = useMotionComponent();
+  const { isPressed } = useLobeSwitchContext();
+  const baseClassName = thumbVariants({ size });
+
+  const defaultPressedAnimation = {
+    width: size === 'small' ? 16 : 22,
+  };
+
+  return (
+    <Switch.Thumb
+      render={
+        <Motion.span
+          animate={isPressed ? pressedAnimation || defaultPressedAnimation : undefined}
+          className={cx(baseClassName, className)}
+          layout
+          transition={transition}
+          {...rest}
+        >
+          {children}
+        </Motion.span>
+      }
+    />
+  );
+};
+
+LobeSwitchThumb.displayName = 'LobeSwitchThumb';
+
+const getIconPositionClass = (position: LobeSwitchIconPosition, size: 'default' | 'small') => {
+  if (position === 'thumb') return styles.iconThumb;
+  if (position === 'left') return size === 'small' ? styles.iconLeftSmall : styles.iconLeft;
+  return size === 'small' ? styles.iconRightSmall : styles.iconRight;
+};
+
+export const LobeSwitchIcon = ({
+  children,
+  className,
+  position,
+  transition = { bounce: 0, type: 'spring' },
+  ...rest
+}: LobeSwitchIconProps & { children?: React.ReactNode; size?: 'default' | 'small' }) => {
+  const Motion = useMotionComponent();
+  const { isChecked } = useLobeSwitchContext();
+  const size = (rest as any).size || 'default';
+
+  const isAnimated = useMemo(() => {
+    if (position === 'right') return !isChecked;
+    if (position === 'left') return isChecked;
+    if (position === 'thumb') return true;
+    return false;
+  }, [position, isChecked]);
+
+  const positionClass = getIconPositionClass(position, size);
+
+  return (
+    <Motion.span
+      animate={isAnimated ? { opacity: 1, scale: 1 } : { opacity: 0, scale: 0 }}
+      className={cx(styles.icon, positionClass, className)}
+      transition={transition}
+      {...rest}
+    >
+      {children}
+    </Motion.span>
+  );
+};
+
+LobeSwitchIcon.displayName = 'LobeSwitchIcon';
+
+export { styles as lobeSwitchStyles } from './style';

--- a/src/LobeSwitch/demos/atoms.tsx
+++ b/src/LobeSwitch/demos/atoms.tsx
@@ -1,0 +1,42 @@
+import { Flexbox, LobeSwitchIcon, LobeSwitchRoot, LobeSwitchThumb } from '@lobehub/ui';
+import { CheckIcon, XIcon } from 'lucide-react';
+
+export default () => {
+  return (
+    <Flexbox gap={16}>
+      <Flexbox align="center" gap={8} horizontal>
+        <span>Basic:</span>
+        <LobeSwitchRoot defaultChecked>
+          <LobeSwitchThumb />
+        </LobeSwitchRoot>
+      </Flexbox>
+      <Flexbox align="center" gap={8} horizontal>
+        <span>Small:</span>
+        <LobeSwitchRoot defaultChecked size="small">
+          <LobeSwitchThumb size="small" />
+        </LobeSwitchRoot>
+      </Flexbox>
+      <Flexbox align="center" gap={8} horizontal>
+        <span>With Icons:</span>
+        <LobeSwitchRoot defaultChecked>
+          <LobeSwitchIcon position="left" size="default">
+            <CheckIcon size={12} />
+          </LobeSwitchIcon>
+          <LobeSwitchIcon position="right" size="default">
+            <XIcon size={12} />
+          </LobeSwitchIcon>
+          <LobeSwitchThumb />
+        </LobeSwitchRoot>
+      </Flexbox>
+      <Flexbox align="center" gap={8} horizontal>
+        <span>Custom Thumb:</span>
+        <LobeSwitchRoot defaultChecked>
+          <LobeSwitchThumb
+            pressedAnimation={{ scale: 1.1, width: 24 }}
+            transition={{ damping: 20, stiffness: 400, type: 'spring' }}
+          />
+        </LobeSwitchRoot>
+      </Flexbox>
+    </Flexbox>
+  );
+};

--- a/src/LobeSwitch/demos/index.tsx
+++ b/src/LobeSwitch/demos/index.tsx
@@ -1,0 +1,45 @@
+import { Flexbox, LobeSwitch } from '@lobehub/ui';
+import { CheckIcon, XIcon } from 'lucide-react';
+import { useState } from 'react';
+
+export default () => {
+  const [checked, setChecked] = useState(false);
+
+  return (
+    <Flexbox gap={16}>
+      <Flexbox align="center" gap={8} horizontal>
+        <span>Default:</span>
+        <LobeSwitch checked={checked} onChange={setChecked} />
+      </Flexbox>
+      <Flexbox align="center" gap={8} horizontal>
+        <span>Small:</span>
+        <LobeSwitch checked={checked} onChange={setChecked} size="small" />
+      </Flexbox>
+      <Flexbox align="center" gap={8} horizontal>
+        <span>With Icons:</span>
+        <LobeSwitch
+          checked={checked}
+          checkedChildren={<CheckIcon size={12} />}
+          onChange={setChecked}
+          unCheckedChildren={<XIcon size={12} />}
+        />
+      </Flexbox>
+      <Flexbox align="center" gap={8} horizontal>
+        <span>Disabled:</span>
+        <LobeSwitch disabled />
+      </Flexbox>
+      <Flexbox align="center" gap={8} horizontal>
+        <span>Disabled Checked:</span>
+        <LobeSwitch defaultChecked disabled />
+      </Flexbox>
+      <Flexbox align="center" gap={8} horizontal>
+        <span>Loading:</span>
+        <LobeSwitch loading />
+      </Flexbox>
+      <Flexbox align="center" gap={8} horizontal>
+        <span>Loading Small:</span>
+        <LobeSwitch loading size="small" />
+      </Flexbox>
+    </Flexbox>
+  );
+};

--- a/src/LobeSwitch/index.md
+++ b/src/LobeSwitch/index.md
@@ -1,0 +1,14 @@
+---
+nav: Components
+group: Data Entry
+title: LobeSwitch
+description: Base UI-powered Switch component with Lobe UI styling.
+---
+
+## Default
+
+<code src="./demos/index.tsx" nopadding></code>
+
+## Atom Components
+
+<code src="./demos/atoms.tsx" nopadding></code>

--- a/src/LobeSwitch/index.ts
+++ b/src/LobeSwitch/index.ts
@@ -1,0 +1,21 @@
+export {
+  LobeSwitchIcon,
+  LobeSwitchRoot,
+  lobeSwitchStyles,
+  LobeSwitchThumb,
+  useLobeSwitchContext,
+} from './atoms';
+export { default } from './LobeSwitch';
+export type {
+  LobeSwitchChangeEventHandler,
+  LobeSwitchClassNames,
+  LobeSwitchClickEventHandler,
+  LobeSwitchContextType,
+  LobeSwitchIconPosition,
+  LobeSwitchIconProps,
+  LobeSwitchProps,
+  LobeSwitchRootProps,
+  LobeSwitchSize,
+  LobeSwitchStyles,
+  LobeSwitchThumbProps,
+} from './type';

--- a/src/LobeSwitch/style.ts
+++ b/src/LobeSwitch/style.ts
@@ -1,0 +1,151 @@
+import { createStaticStyles } from 'antd-style';
+import { cva } from 'class-variance-authority';
+
+export const styles = createStaticStyles(({ css, cssVar }) => ({
+  icon: css`
+    pointer-events: none;
+
+    position: absolute;
+    inset-block: 0 0;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    color: ${cssVar.colorTextLightSolid};
+  `,
+  iconLeft: css`
+    inset-inline-start: 5px;
+  `,
+  iconLeftSmall: css`
+    inset-inline-start: 4px;
+  `,
+  iconRight: css`
+    inset-inline-end: 5px;
+  `,
+  iconRightSmall: css`
+    inset-inline-end: 4px;
+  `,
+  iconThumb: css`
+    position: relative;
+    inset: unset;
+    transform: none;
+    color: ${cssVar.colorPrimary};
+  `,
+  loading: css`
+    @keyframes lobe-switch-loading {
+      0% {
+        transform: rotate(0deg);
+      }
+
+      100% {
+        transform: rotate(360deg);
+      }
+    }
+
+    animation: lobe-switch-loading 1s linear infinite;
+  `,
+  root: css`
+    cursor: pointer;
+    user-select: none;
+
+    position: relative;
+
+    overflow: hidden;
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-start;
+
+    box-sizing: border-box;
+    padding: 2px;
+    border: 0;
+    border-radius: 100px;
+
+    background: ${cssVar.colorTextQuaternary};
+    outline: none;
+
+    transition: background 150ms ${cssVar.motionEaseOut};
+
+    &:focus-visible {
+      outline: 2px solid ${cssVar.colorPrimaryBorder};
+      outline-offset: 1px;
+    }
+
+    &:hover:not([data-disabled]) {
+      background: ${cssVar.colorTextTertiary};
+    }
+
+    &[data-checked] {
+      justify-content: flex-end;
+      background: ${cssVar.colorPrimary};
+
+      &:hover:not([data-disabled]) {
+        background: ${cssVar.colorPrimaryHover};
+      }
+    }
+
+    &[data-disabled] {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+  `,
+  rootDefault: css`
+    width: 44px;
+    min-width: 44px;
+    height: 22px;
+  `,
+  rootSmall: css`
+    width: 28px;
+    min-width: 28px;
+    height: 16px;
+  `,
+  thumb: css`
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+
+    border-radius: 50%;
+
+    background: ${cssVar.colorBgContainer};
+    box-shadow:
+      0 2px 4px 0 rgba(0, 35, 11, 20%),
+      0 1px 2px 0 rgba(0, 0, 0, 8%);
+
+    [data-disabled] > & {
+      box-shadow: none;
+    }
+  `,
+  thumbDefault: css`
+    width: 18px;
+    height: 18px;
+  `,
+  thumbSmall: css`
+    width: 12px;
+    height: 12px;
+  `,
+}));
+
+export const rootVariants = cva(styles.root, {
+  defaultVariants: {
+    size: 'default',
+  },
+  variants: {
+    size: {
+      default: styles.rootDefault,
+      small: styles.rootSmall,
+    },
+  },
+});
+
+export const thumbVariants = cva(styles.thumb, {
+  defaultVariants: {
+    size: 'default',
+  },
+  variants: {
+    size: {
+      default: styles.thumbDefault,
+      small: styles.thumbSmall,
+    },
+  },
+});

--- a/src/LobeSwitch/type.ts
+++ b/src/LobeSwitch/type.ts
@@ -1,0 +1,149 @@
+import type { Switch } from '@base-ui/react/switch';
+import type { HTMLMotionProps, TargetAndTransition, Transition } from 'motion/react';
+import type {
+  CSSProperties,
+  ComponentProps,
+  KeyboardEvent,
+  MouseEvent,
+  ReactNode,
+  Ref,
+} from 'react';
+
+export type LobeSwitchSize = 'default' | 'small';
+
+export type LobeSwitchChangeEventHandler = (
+  checked: boolean,
+  event: MouseEvent<HTMLButtonElement> | KeyboardEvent<HTMLButtonElement>,
+) => void;
+
+export type LobeSwitchClickEventHandler = LobeSwitchChangeEventHandler;
+
+export interface LobeSwitchClassNames {
+  content?: string;
+  root?: string;
+  thumb?: string;
+}
+
+export interface LobeSwitchStyles {
+  content?: CSSProperties;
+  root?: CSSProperties;
+  thumb?: CSSProperties;
+}
+
+export interface LobeSwitchContextType {
+  isChecked: boolean;
+  isPressed: boolean;
+  setIsChecked: (checked: boolean) => void;
+  setIsPressed: (pressed: boolean) => void;
+}
+
+export type LobeSwitchRootProps = Omit<ComponentProps<typeof Switch.Root>, 'render'> &
+  HTMLMotionProps<'button'> & {
+    size?: LobeSwitchSize;
+  };
+
+export type LobeSwitchThumbProps = Omit<ComponentProps<typeof Switch.Thumb>, 'render'> &
+  HTMLMotionProps<'span'> & {
+    pressedAnimation?: TargetAndTransition | boolean;
+    size?: LobeSwitchSize;
+    transition?: Transition;
+  };
+
+export type LobeSwitchIconPosition = 'left' | 'right' | 'thumb';
+
+export type LobeSwitchIconProps = HTMLMotionProps<'span'> & {
+  position: LobeSwitchIconPosition;
+  transition?: Transition;
+};
+
+export interface LobeSwitchProps {
+  /**
+   * Whether to set focus automatically when mounted
+   */
+  autoFocus?: boolean;
+  /**
+   * Whether the switch is checked
+   */
+  checked?: boolean;
+  /**
+   * Icon to show when checked (left position)
+   */
+  checkedChildren?: ReactNode;
+  /**
+   * Custom class name
+   */
+  className?: string;
+  /**
+   * Custom class names for each part
+   */
+  classNames?: LobeSwitchClassNames;
+  /**
+   * Initial checked state (uncontrolled)
+   */
+  defaultChecked?: boolean;
+  /**
+   * Alias for `defaultChecked`
+   */
+  defaultValue?: boolean;
+  /**
+   * Whether the switch is disabled
+   */
+  disabled?: boolean;
+  /**
+   * Element id
+   */
+  id?: string;
+  /**
+   * Show loading indicator
+   */
+  loading?: boolean;
+  /**
+   * Name attribute for form submission
+   */
+  name?: string;
+  /**
+   * Callback when the switch state changes
+   */
+  onChange?: LobeSwitchChangeEventHandler;
+  /**
+   * Callback when clicking the switch
+   */
+  onClick?: LobeSwitchClickEventHandler;
+  /**
+   * Reference to the root element
+   */
+  ref?: Ref<HTMLButtonElement>;
+  /**
+   * Additional class name for root element
+   */
+  rootClassName?: string;
+  /**
+   * Size of the switch
+   * @default 'default'
+   */
+  size?: LobeSwitchSize;
+  /**
+   * Custom inline style
+   */
+  style?: CSSProperties;
+  /**
+   * Custom styles for each part
+   */
+  styles?: LobeSwitchStyles;
+  /**
+   * Tab index for keyboard navigation
+   */
+  tabIndex?: number;
+  /**
+   * Native title attribute
+   */
+  title?: string;
+  /**
+   * Icon to show when unchecked (right position)
+   */
+  unCheckedChildren?: ReactNode;
+  /**
+   * Alias for `checked`
+   */
+  value?: boolean;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -224,6 +224,25 @@ export {
   type LobeSelectValueProps,
 } from './LobeSelect';
 export {
+  default as LobeSwitch,
+  type LobeSwitchChangeEventHandler,
+  type LobeSwitchClassNames,
+  type LobeSwitchClickEventHandler,
+  type LobeSwitchContextType,
+  LobeSwitchIcon,
+  type LobeSwitchIconPosition,
+  type LobeSwitchIconProps,
+  type LobeSwitchProps,
+  LobeSwitchRoot,
+  type LobeSwitchRootProps,
+  type LobeSwitchSize,
+  type LobeSwitchStyles,
+  lobeSwitchStyles,
+  LobeSwitchThumb,
+  type LobeSwitchThumbProps,
+  useLobeSwitchContext,
+} from './LobeSwitch';
+export {
   default as Markdown,
   type MarkdownProps,
   Typography,


### PR DESCRIPTION
## Summary
- Add new LobeSwitch component based on `@base-ui/react/switch` with full API compatibility with antd Switch
- Export atomic components (LobeSwitchRoot, LobeSwitchThumb, LobeSwitchIcon) for flexible composition
- Use MotionProvider context for animations (Motion.button/Motion.span) instead of direct motion import
- Support all antd Switch props including value/defaultValue aliases, onChange with event parameter, loading state, size variants

## Test plan
- [ ] Verify LobeSwitch renders correctly in default and small sizes
- [ ] Test controlled and uncontrolled modes (checked/value, defaultChecked/defaultValue)
- [ ] Verify onChange callback receives both checked state and event
- [ ] Test loading state with spinner animation
- [ ] Verify checkedChildren and unCheckedChildren icons display correctly
- [ ] Test disabled state styling and interaction blocking
- [ ] Verify atomic components can be used independently
- [ ] Test press animation on thumb

## Summary by Sourcery

Add a new animated LobeSwitch component and expose its atomic subcomponents for flexible composition, matching antd Switch behavior and styling.

New Features:
- Introduce LobeSwitch component built on @base-ui/react/switch with antd-compatible props including loading, size variants, and value/checked aliases.
- Export atomic switch primitives (LobeSwitchRoot, LobeSwitchThumb, LobeSwitchIcon) plus context and styles for custom compositions.
- Add motion-based press and icon animations via MotionProvider integration for the switch root, thumb, and icons.

Documentation:
- Add LobeSwitch documentation page with usage examples for the composite component and atomic primitives.