### PR TITLE
🐛 fix(select): correct list height overflow when search bar is present

### DIFF
--- a/src/LobeSelect/style.ts
+++ b/src/LobeSelect/style.ts
@@ -75,6 +75,9 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   itemText: css``,
   list: css`
     overflow-y: auto;
+    flex: 1;
+
+    min-height: 0;
     max-height: var(--lobe-select-available-height, var(--available-height));
     padding-block: 0;
   `,
@@ -93,7 +96,12 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     );
 
     transform-origin: var(--transform-origin);
+
+    display: flex;
+    flex-direction: column;
+
     box-sizing: border-box;
+
     transition:
       opacity 150ms ${cssVar.motionEaseOut},
       transform 150ms ${cssVar.motionEaseOut};
@@ -206,10 +214,10 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
 
     transition: all 150ms ${cssVar.motionEaseOut};
 
-    &:not([data-disabled]):not([data-readonly])[data-popup-open],
-    &:not([data-disabled]):not([data-readonly])[data-open],
-    &:not([data-disabled]):not([data-readonly])[data-state='open'],
-    &:not([data-disabled]):not([data-readonly])[aria-expanded='true'] {
+    &:not([data-disabled], [data-readonly])[data-popup-open],
+    &:not([data-disabled], [data-readonly])[data-open],
+    &:not([data-disabled], [data-readonly])[data-state='open'],
+    &:not([data-disabled], [data-readonly])[aria-expanded='true'] {
       background: var(--lobe-select-open-bg, ${cssVar.colorFillTertiary});
     }
 


### PR DESCRIPTION
## Summary
- Fix LobeSelect dropdown list overflowing when `showSearch` is enabled — the selected item rendered outside the scrollable viewport
- Apply `display: flex; flex-direction: column` to popup so the list takes remaining space after the search bar
- Add `flex: 1; min-height: 0` to the list to properly constrain within the popup's `maxHeight`

## Test plan
- [x] Open a LobeSelect with `showSearch` enabled and many options
- [x] Verify the selected item stays within the scrollable area
- [x] Verify scrolling works correctly with and without search bar

## Summary by Sourcery

Adjust LobeSelect popup layout to prevent dropdown list overflow when the search bar is shown and ensure correct open-state background styling.

Bug Fixes:
- Prevent the LobeSelect dropdown list from overflowing its popup when the search bar is enabled, keeping the selected item within the scrollable area.

Enhancements:
- Make the select popup content use a column flex layout so the options list occupies remaining space below the search bar.
- Refine selector syntax for open-state styles on non-disabled, non-readonly triggers.