### PR TITLE
🐛 fix(popover): prevent infinite positioning loop in inset mode

### DIFF
--- a/src/Popover/PopoverGroup.tsx
+++ b/src/Popover/PopoverGroup.tsx
@@ -84,22 +84,16 @@ const PopoverGroup: FC<PopoverGroupProps> = ({
             const placementConfig = placementMap[placement] ?? placementMap.top;
             const baseSideOffset = arrow ? 10 : 6;
             const resolvedSideOffset = item.inset
-              ? ({
-                  side,
-                  positioner,
-                }: {
-                  positioner: { height: number; width: number };
-                  side: Side;
-                }) => {
+              ? ({ side, anchor }: { anchor: { height: number; width: number }; side: Side }) => {
                   if (
                     side === 'left' ||
                     side === 'right' ||
                     side === 'inline-start' ||
                     side === 'inline-end'
                   ) {
-                    return -positioner.width;
+                    return -anchor.width;
                   }
-                  return -positioner.height;
+                  return -anchor.height;
                 }
               : baseSideOffset;
 

--- a/src/Popover/PopoverStandalone.tsx
+++ b/src/Popover/PopoverStandalone.tsx
@@ -92,22 +92,16 @@ export const PopoverStandalone = memo<PopoverProps>(
     const baseSideOffset = arrow ? 10 : 6;
     const resolvedSideOffset = useMemo(() => {
       if (!inset) return baseSideOffset;
-      return ({
-        side,
-        positioner,
-      }: {
-        positioner: { height: number; width: number };
-        side: Side;
-      }) => {
+      return ({ side, anchor }: { anchor: { height: number; width: number }; side: Side }) => {
         if (
           side === 'left' ||
           side === 'right' ||
           side === 'inline-start' ||
           side === 'inline-end'
         ) {
-          return -positioner.width;
+          return -anchor.width;
         }
-        return -positioner.height;
+        return -anchor.height;
       };
     }, [baseSideOffset, inset]);
 


### PR DESCRIPTION
## Summary
- Popover inset mode used `positioner` (floating element) dimensions for `sideOffset` calculation, which can change during positioning cycles due to viewport constraints and collision avoidance
- This created a feedback loop: offset change → reposition → ResizeObserver detects size change → autoUpdate → recompute offset → repeat
- Switched to `anchor` (trigger element) dimensions, which remain stable throughout the positioning lifecycle

## Test plan
- [ ] Verify inset popover opens without infinite position recalculation
- [ ] Test inset popover near viewport edges (where collision avoidance triggers)
- [ ] Confirm inset behavior visually correct for all placement directions (top, bottom, left, right)
- [ ] Test both standalone and grouped popover with `inset` prop

## Summary by Sourcery

Bug Fixes:
- Fix infinite positioning loop when using inset popovers by decoupling offset calculations from changing positioner size in both standalone and grouped popovers.