### PR TITLE
✨ feat(markdown): implement streaming animation for markdown blocks

### DIFF
--- a/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
+++ b/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
@@ -23,103 +23,97 @@ function countChars(text: string): number {
   return [...text].length;
 }
 
-const StreamdownBlock = memo<Options>(
-  ({ children, ...rest }) => {
-    return <Markdown {...rest}>{children}</Markdown>;
-  },
-  (prevProps, nextProps) => prevProps.children === nextProps.children,
-);
+const StreamdownBlock = memo<Options>(({ children, ...rest }) => {
+  return <Markdown {...rest}>{children}</Markdown>;
+});
 
 StreamdownBlock.displayName = 'StreamdownBlock';
 
-export const StreamdownRender = memo<Options>(
-  ({ children, ...rest }) => {
-    const escapedContent = useMarkdownContent(children || '');
-    const components = useMarkdownComponents();
-    const baseRehypePlugins = useMarkdownRehypePlugins();
-    const remarkPlugins = useMarkdownRemarkPlugins();
-    const generatedId = useId();
+export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
+  const escapedContent = useMarkdownContent(children || '');
+  const components = useMarkdownComponents();
+  const baseRehypePlugins = useMarkdownRehypePlugins();
+  const remarkPlugins = useMarkdownRemarkPlugins();
+  const generatedId = useId();
 
-    const processedContent = useMemo(() => {
-      const content = typeof escapedContent === 'string' ? escapedContent : '';
-      return remend(content);
-    }, [escapedContent]);
+  const processedContent = useMemo(() => {
+    const content = typeof escapedContent === 'string' ? escapedContent : '';
+    return remend(content);
+  }, [escapedContent]);
 
-    const blocks: BlockInfo[] = useMemo(() => {
-      const tokens = marked.lexer(processedContent);
-      let offset = 0;
-      return tokens.map((token) => {
-        const block = { content: token.raw, startOffset: offset };
-        offset += token.raw.length;
-        return block;
-      });
-    }, [processedContent]);
-
-    const { getBlockState, charDelay } = useStreamQueue(blocks);
-
-    const staggerPlugins: Pluggable[] = useMemo(
-      () => [...baseRehypePlugins, [rehypeStreamAnimated, { baseCharCount: 0, charDelay }]],
-      [baseRehypePlugins, charDelay],
-    );
-
-    // prevCharCount tracks the PREVIOUS render's streaming char count.
-    // Updated in useEffect (after render) to avoid stale reads during
-    // synchronous re-renders (e.g. useLayoutEffect auto-reveal).
-    const prevCharCountRef = useRef(0);
-    const prevStreamOffsetRef = useRef(-1);
-
-    useEffect(() => {
-      const tailIdx = blocks.length - 1;
-      if (tailIdx >= 0) {
-        const tail = blocks[tailIdx];
-        if (tail.startOffset !== prevStreamOffsetRef.current) {
-          prevStreamOffsetRef.current = tail.startOffset;
-          prevCharCountRef.current = 0;
-        }
-        prevCharCountRef.current = countChars(tail.content);
-      } else {
-        prevCharCountRef.current = 0;
-        prevStreamOffsetRef.current = -1;
-      }
+  const blocks: BlockInfo[] = useMemo(() => {
+    const tokens = marked.lexer(processedContent);
+    let offset = 0;
+    return tokens.map((token) => {
+      const block = { content: token.raw, startOffset: offset };
+      offset += token.raw.length;
+      return block;
     });
+  }, [processedContent]);
 
-    return (
-      <div className={styles.animated}>
-        {blocks.map((block, index) => {
-          const state = getBlockState(index);
-          if (state === 'queued') return null;
+  const { getBlockState, charDelay } = useStreamQueue(blocks);
 
-          let plugins: Pluggable[];
-          if (state === 'streaming') {
-            const baseCharCount =
-              block.startOffset === prevStreamOffsetRef.current ? prevCharCountRef.current : 0;
-            plugins = [
-              ...baseRehypePlugins,
-              [rehypeStreamAnimated, { baseCharCount, charDelay: STREAM_CHAR_DELAY }],
-            ];
-          } else if (state === 'animating') {
-            plugins = staggerPlugins;
-          } else {
-            plugins = baseRehypePlugins;
-          }
+  const staggerPlugins: Pluggable[] = useMemo(
+    () => [...baseRehypePlugins, [rehypeStreamAnimated, { baseCharCount: 0, charDelay }]],
+    [baseRehypePlugins, charDelay],
+  );
 
-          return (
-            <StreamdownBlock
-              {...rest}
-              components={components}
-              key={`${generatedId}-${block.startOffset}`}
-              rehypePlugins={plugins}
-              remarkPlugins={remarkPlugins}
-            >
-              {block.content}
-            </StreamdownBlock>
-          );
-        })}
-      </div>
-    );
-  },
-  (prevProps, nextProps) => prevProps.children === nextProps.children,
-);
+  // prevCharCount tracks the PREVIOUS render's streaming char count.
+  // Updated in useEffect (after render) to avoid stale reads during
+  // synchronous re-renders (e.g. useLayoutEffect auto-reveal).
+  const prevCharCountRef = useRef(0);
+  const prevStreamOffsetRef = useRef(-1);
+
+  useEffect(() => {
+    const tailIdx = blocks.length - 1;
+    if (tailIdx >= 0) {
+      const tail = blocks[tailIdx];
+      if (tail.startOffset !== prevStreamOffsetRef.current) {
+        prevStreamOffsetRef.current = tail.startOffset;
+        prevCharCountRef.current = 0;
+      }
+      prevCharCountRef.current = countChars(tail.content);
+    } else {
+      prevCharCountRef.current = 0;
+      prevStreamOffsetRef.current = -1;
+    }
+  }, [blocks]);
+
+  return (
+    <div className={styles.animated}>
+      {blocks.map((block, index) => {
+        const state = getBlockState(index);
+        if (state === 'queued') return null;
+
+        let plugins: Pluggable[];
+        if (state === 'streaming') {
+          const baseCharCount =
+            block.startOffset === prevStreamOffsetRef.current ? prevCharCountRef.current : 0;
+          plugins = [
+            ...baseRehypePlugins,
+            [rehypeStreamAnimated, { baseCharCount, charDelay: STREAM_CHAR_DELAY }],
+          ];
+        } else if (state === 'animating') {
+          plugins = staggerPlugins;
+        } else {
+          plugins = baseRehypePlugins;
+        }
+
+        return (
+          <StreamdownBlock
+            {...rest}
+            components={components}
+            key={`${generatedId}-${block.startOffset}`}
+            rehypePlugins={plugins}
+            remarkPlugins={remarkPlugins}
+          >
+            {block.content}
+          </StreamdownBlock>
+        );
+      })}
+    </div>
+  );
+});
 
 StreamdownRender.displayName = 'StreamdownRender';
 

--- a/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
+++ b/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { marked } from 'marked';
-import { memo, useId, useMemo } from 'react';
+import { memo, useEffect, useId, useMemo, useRef } from 'react';
 import Markdown, { type Options } from 'react-markdown';
 import remend from 'remend';
+import type { Pluggable } from 'unified';
 
 import {
   useMarkdownComponents,
@@ -11,13 +12,16 @@ import {
   useMarkdownRehypePlugins,
   useMarkdownRemarkPlugins,
 } from '@/hooks/useMarkdown';
+import { rehypeStreamAnimated } from '@/Markdown/plugins/rehypeStreamAnimated';
 
 import { styles } from './style';
+import { type BlockInfo, useStreamQueue } from './useStreamQueue';
 
-const parseMarkdownIntoBlocks = (markdown: string): string[] => {
-  const tokens = marked.lexer(markdown);
-  return tokens.map((token) => token.raw);
-};
+const STREAM_CHAR_DELAY = 15;
+
+function countChars(text: string): number {
+  return [...text].length;
+}
 
 const StreamdownBlock = memo<Options>(
   ({ children, ...rest }) => {
@@ -32,34 +36,91 @@ export const StreamdownRender = memo<Options>(
   ({ children, ...rest }) => {
     const escapedContent = useMarkdownContent(children || '');
     const components = useMarkdownComponents();
-    const rehypePluginsList = useMarkdownRehypePlugins();
-    const remarkPluginsList = useMarkdownRemarkPlugins();
+    const baseRehypePlugins = useMarkdownRehypePlugins();
+    const remarkPlugins = useMarkdownRemarkPlugins();
     const generatedId = useId();
+
     const processedContent = useMemo(() => {
       const content = typeof escapedContent === 'string' ? escapedContent : '';
       return remend(content);
     }, [escapedContent]);
 
-    const blocks = useMemo(() => parseMarkdownIntoBlocks(processedContent), [processedContent]);
+    const blocks: BlockInfo[] = useMemo(() => {
+      const tokens = marked.lexer(processedContent);
+      let offset = 0;
+      return tokens.map((token) => {
+        const block = { content: token.raw, startOffset: offset };
+        offset += token.raw.length;
+        return block;
+      });
+    }, [processedContent]);
+
+    const { getBlockState, charDelay } = useStreamQueue(blocks);
+
+    const staggerPlugins: Pluggable[] = useMemo(
+      () => [...baseRehypePlugins, [rehypeStreamAnimated, { baseCharCount: 0, charDelay }]],
+      [baseRehypePlugins, charDelay],
+    );
+
+    // prevCharCount tracks the PREVIOUS render's streaming char count.
+    // Updated in useEffect (after render) to avoid stale reads during
+    // synchronous re-renders (e.g. useLayoutEffect auto-reveal).
+    const prevCharCountRef = useRef(0);
+    const prevStreamOffsetRef = useRef(-1);
+
+    useEffect(() => {
+      const tailIdx = blocks.length - 1;
+      if (tailIdx >= 0) {
+        const tail = blocks[tailIdx];
+        if (tail.startOffset !== prevStreamOffsetRef.current) {
+          prevStreamOffsetRef.current = tail.startOffset;
+          prevCharCountRef.current = 0;
+        }
+        prevCharCountRef.current = countChars(tail.content);
+      } else {
+        prevCharCountRef.current = 0;
+        prevStreamOffsetRef.current = -1;
+      }
+    });
 
     return (
       <div className={styles.animated}>
-        {blocks.map((block, index) => (
-          <StreamdownBlock
-            {...rest}
-            components={components}
-            key={`${generatedId}-block_${index}`}
-            rehypePlugins={rehypePluginsList}
-            remarkPlugins={remarkPluginsList}
-          >
-            {block}
-          </StreamdownBlock>
-        ))}
+        {blocks.map((block, index) => {
+          const state = getBlockState(index);
+          if (state === 'queued') return null;
+
+          let plugins: Pluggable[];
+          if (state === 'streaming') {
+            const baseCharCount =
+              block.startOffset === prevStreamOffsetRef.current ? prevCharCountRef.current : 0;
+            plugins = [
+              ...baseRehypePlugins,
+              [rehypeStreamAnimated, { baseCharCount, charDelay: STREAM_CHAR_DELAY }],
+            ];
+          } else if (state === 'animating') {
+            plugins = staggerPlugins;
+          } else {
+            plugins = baseRehypePlugins;
+          }
+
+          return (
+            <StreamdownBlock
+              {...rest}
+              components={components}
+              key={`${generatedId}-${block.startOffset}`}
+              rehypePlugins={plugins}
+              remarkPlugins={remarkPlugins}
+            >
+              {block.content}
+            </StreamdownBlock>
+          );
+        })}
       </div>
     );
   },
   (prevProps, nextProps) => prevProps.children === nextProps.children,
 );
+
 StreamdownRender.displayName = 'StreamdownRender';
 
 export default StreamdownRender;

--- a/src/Markdown/SyntaxMarkdown/style.ts
+++ b/src/Markdown/SyntaxMarkdown/style.ts
@@ -14,6 +14,11 @@ export const styles = createStaticStyles(({ css }) => {
         animation-fill-mode: forwards;
       }
 
+      .stream-char-revealed {
+        opacity: 1;
+        animation: none;
+      }
+
       .katex-display .katex-html span {
         mask: none !important;
         animation: none !important;

--- a/src/Markdown/SyntaxMarkdown/style.ts
+++ b/src/Markdown/SyntaxMarkdown/style.ts
@@ -5,15 +5,15 @@ import { fadeIn } from '@/styles/animations';
 export const styles = createStaticStyles(({ css }) => {
   return {
     animated: css`
-      .animate-fade-in,
-      .katex-html > .base,
-      span.line > span,
-      code:not(:has(span.line)) {
-        opacity: 1;
-        animation: ${fadeIn} 1s ease-in-out;
+      .stream-char {
+        opacity: 0;
+
+        animation-name: ${fadeIn};
+        animation-duration: 150ms;
+        animation-timing-function: ease-out;
+        animation-fill-mode: forwards;
       }
 
-      /* 只对 .base 级别的 span 应用流式动画，不要穿透到内部 */
       .katex-display .katex-html span {
         mask: none !important;
         animation: none !important;

--- a/src/Markdown/SyntaxMarkdown/useStreamQueue.ts
+++ b/src/Markdown/SyntaxMarkdown/useStreamQueue.ts
@@ -1,0 +1,118 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface BlockInfo {
+  content: string;
+  startOffset: number;
+}
+
+export type BlockState = 'revealed' | 'animating' | 'streaming' | 'queued';
+
+const BASE_DELAY = 20;
+const ACCELERATION_FACTOR = 0.3;
+const MAX_BLOCK_DURATION = 3000;
+const FADE_DURATION = 150;
+
+function countChars(text: string): number {
+  return [...text].length;
+}
+
+function computeCharDelay(queueLength: number, charCount: number): number {
+  const acceleration = 1 + queueLength * ACCELERATION_FACTOR;
+  let delay = BASE_DELAY / acceleration;
+  delay = Math.min(delay, MAX_BLOCK_DURATION / Math.max(charCount, 1));
+  return delay;
+}
+
+export interface UseStreamQueueReturn {
+  charDelay: number;
+  getBlockState: (index: number) => BlockState;
+  queueLength: number;
+}
+
+export function useStreamQueue(blocks: BlockInfo[]): UseStreamQueueReturn {
+  const [revealedCount, setRevealedCount] = useState(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevBlocksLenRef = useRef(0);
+  const minRevealedRef = useRef(0);
+
+  // Synchronous auto-reveal during render.
+  // When blocks grow, the previous tail (streaming block) is instantly
+  // promoted to revealed — its chars are already visible via stream-mode
+  // animation. This runs during render (not in effect) so there is NO
+  // intermediate frame where the old streaming block enters 'animating'
+  // state and gets stagger plugins that would restart its animations.
+  if (blocks.length === 0 && prevBlocksLenRef.current !== 0) {
+    minRevealedRef.current = 0;
+  }
+  if (blocks.length > prevBlocksLenRef.current && prevBlocksLenRef.current > 0) {
+    const prevTail = prevBlocksLenRef.current - 1;
+    minRevealedRef.current = Math.max(minRevealedRef.current, prevTail + 1);
+  }
+  prevBlocksLenRef.current = blocks.length;
+
+  // State reset when stream restarts (blocks empty)
+  useEffect(() => {
+    if (blocks.length === 0) {
+      setRevealedCount(0);
+      minRevealedRef.current = 0;
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    }
+  }, [blocks.length]);
+
+  const effectiveRevealedCount = Math.max(revealedCount, minRevealedRef.current);
+  const tailIndex = blocks.length - 1;
+
+  const getBlockState = useCallback(
+    (index: number): BlockState => {
+      if (index < effectiveRevealedCount) return 'revealed';
+      if (index === effectiveRevealedCount && index < tailIndex) return 'animating';
+      if (index === effectiveRevealedCount && index === tailIndex) return 'streaming';
+      return 'queued';
+    },
+    [effectiveRevealedCount, tailIndex],
+  );
+
+  const queueLength = Math.max(0, tailIndex - effectiveRevealedCount - 1);
+
+  const animatingIndex = effectiveRevealedCount < tailIndex ? effectiveRevealedCount : -1;
+  const animatingCharCount =
+    animatingIndex >= 0 ? countChars(blocks[animatingIndex]?.content ?? '') : 0;
+
+  // Freeze charDelay when a new block starts animating
+  const frozenRef = useRef({ delay: BASE_DELAY, index: -1 });
+  if (animatingIndex >= 0 && animatingIndex !== frozenRef.current.index) {
+    frozenRef.current = {
+      delay: computeCharDelay(queueLength, animatingCharCount),
+      index: animatingIndex,
+    };
+  }
+  const charDelay = animatingIndex >= 0 ? frozenRef.current.delay : BASE_DELAY;
+
+  const onAnimationDone = useCallback(() => {
+    setRevealedCount(effectiveRevealedCount + 1);
+  }, [effectiveRevealedCount]);
+
+  useEffect(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+
+    if (animatingIndex < 0) return;
+
+    const totalTime = Math.max(0, (animatingCharCount - 1) * charDelay) + FADE_DURATION;
+    timerRef.current = setTimeout(onAnimationDone, totalTime);
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [animatingIndex, animatingCharCount, charDelay, onAnimationDone]);
+
+  return { charDelay, getBlockState, queueLength };
+}

--- a/src/Markdown/demos/content.ts
+++ b/src/Markdown/demos/content.ts
@@ -1,4 +1,5 @@
-export const fullContent = `# Complete Markdown Integration Example
+export const fullContent = `Complete Markdown Integration Example
+--
 
 This demonstrates a comprehensive real-world example of how different markdown features work together in a cohesive document.
 

--- a/src/Markdown/plugins/rehypeStreamAnimated.ts
+++ b/src/Markdown/plugins/rehypeStreamAnimated.ts
@@ -5,6 +5,7 @@ import { visit } from 'unist-util-visit';
 export interface StreamAnimatedOptions {
   baseCharCount?: number;
   charDelay?: number;
+  revealed?: boolean;
 }
 
 const BLOCK_TAGS = new Set(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li']);
@@ -18,7 +19,7 @@ function hasClass(node: Element, cls: string): boolean {
 }
 
 export const rehypeStreamAnimated = (options: StreamAnimatedOptions = {}) => {
-  const { charDelay = 20, baseCharCount = 0 } = options;
+  const { charDelay = 20, baseCharCount = 0, revealed = false } = options;
 
   return (tree: Root) => {
     let globalCharIndex = 0;
@@ -32,13 +33,15 @@ export const rehypeStreamAnimated = (options: StreamAnimatedOptions = {}) => {
       for (const child of node.children) {
         if (child.type === 'text') {
           for (const char of child.value) {
-            const relativeIndex = Math.max(0, globalCharIndex - baseCharCount);
-            const delay = relativeIndex * charDelay;
             const properties: Record<string, any> = {
-              className: 'stream-char',
+              className: revealed ? 'stream-char stream-char-revealed' : 'stream-char',
             };
-            if (delay > 0) {
-              properties.style = `animation-delay:${delay}ms`;
+            if (!revealed) {
+              const relativeIndex = Math.max(0, globalCharIndex - baseCharCount);
+              const delay = relativeIndex * charDelay;
+              if (delay > 0) {
+                properties.style = `animation-delay:${delay}ms`;
+              }
             }
             newChildren.push({
               children: [{ type: 'text', value: char }],

--- a/src/Markdown/plugins/rehypeStreamAnimated.ts
+++ b/src/Markdown/plugins/rehypeStreamAnimated.ts
@@ -1,37 +1,70 @@
-// Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
-// SPDX-License-Identifier: MIT
 import { type Element, type ElementContent, type Root } from 'hast';
 import { type BuildVisitor } from 'unist-util-visit';
 import { visit } from 'unist-util-visit';
 
-export const rehypeStreamAnimated = () => {
+export interface StreamAnimatedOptions {
+  baseCharCount?: number;
+  charDelay?: number;
+}
+
+const BLOCK_TAGS = new Set(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li']);
+const SKIP_TAGS = new Set(['pre', 'code', 'table', 'svg']);
+
+function hasClass(node: Element, cls: string): boolean {
+  const cn = node.properties?.className;
+  if (Array.isArray(cn)) return cn.some((c) => String(c).includes(cls));
+  if (typeof cn === 'string') return cn.includes(cls);
+  return false;
+}
+
+export const rehypeStreamAnimated = (options: StreamAnimatedOptions = {}) => {
+  const { charDelay = 20, baseCharCount = 0 } = options;
+
   return (tree: Root) => {
-    visit(tree, 'element', ((node: Element) => {
-      if (
-        ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'strong'].includes(node.tagName) &&
-        node.children
-      ) {
-        const newChildren: Array<ElementContent> = [];
-        for (const child of node.children) {
-          if (child.type === 'text') {
-            const segmenter = new Intl.Segmenter('zh', { granularity: 'word' });
-            const segments = segmenter.segment(child.value);
-            const words = [...segments].map((segment) => segment.segment).filter(Boolean);
-            words.forEach((word: string) => {
-              newChildren.push({
-                children: [{ type: 'text', value: word }],
-                properties: {
-                  className: 'animate-fade-in',
-                },
-                tagName: 'span',
-                type: 'element',
-              });
+    let globalCharIndex = 0;
+
+    const shouldSkip = (node: Element): boolean => {
+      return SKIP_TAGS.has(node.tagName) || hasClass(node, 'katex');
+    };
+
+    const wrapText = (node: Element) => {
+      const newChildren: ElementContent[] = [];
+      for (const child of node.children) {
+        if (child.type === 'text') {
+          for (const char of child.value) {
+            const relativeIndex = Math.max(0, globalCharIndex - baseCharCount);
+            const delay = relativeIndex * charDelay;
+            const properties: Record<string, any> = {
+              className: 'stream-char',
+            };
+            if (delay > 0) {
+              properties.style = `animation-delay:${delay}ms`;
+            }
+            newChildren.push({
+              children: [{ type: 'text', value: char }],
+              properties,
+              tagName: 'span',
+              type: 'element',
             });
-          } else {
-            newChildren.push(child);
+            globalCharIndex++;
           }
+        } else if (child.type === 'element') {
+          if (!shouldSkip(child)) {
+            wrapText(child);
+          }
+          newChildren.push(child);
+        } else {
+          newChildren.push(child);
         }
-        node.children = newChildren;
+      }
+      node.children = newChildren;
+    };
+
+    visit(tree, 'element', ((node: Element) => {
+      if (shouldSkip(node)) return 'skip';
+      if (BLOCK_TAGS.has(node.tagName)) {
+        wrapText(node);
+        return 'skip';
       }
     }) as BuildVisitor<Root, 'element'>);
   };

--- a/src/hooks/useMarkdown/useMarkdownRehypePlugins.ts
+++ b/src/hooks/useMarkdown/useMarkdownRehypePlugins.ts
@@ -9,11 +9,9 @@ import type { Pluggable } from 'unified';
 import { useMarkdownContext } from '@/Markdown/components/MarkdownProvider';
 import { rehypeCustomFootnotes } from '@/Markdown/plugins/rehypeCustomFootnotes';
 import { rehypeKatexDir } from '@/Markdown/plugins/rehypeKatexDir';
-import { rehypeStreamAnimated } from '@/Markdown/plugins/rehypeStreamAnimated';
 
 export const useMarkdownRehypePlugins = (): Pluggable[] => {
   const {
-    animated,
     enableLatex,
     enableCustomFootnotes,
     enableGithubAlert,
@@ -30,9 +28,8 @@ export const useMarkdownRehypePlugins = (): Pluggable[] => {
         enableLatex && rehypeKatex,
         enableLatex && rehypeKatexDir,
         enableCustomFootnotes && rehypeCustomFootnotes,
-        animated && rehypeStreamAnimated,
       ].filter(Boolean) as Pluggable[],
-    [animated, enableLatex, enableGithubAlert, enableCustomFootnotes, allowHtml],
+    [enableLatex, enableGithubAlert, enableCustomFootnotes, allowHtml],
   );
 
   return useMemo(


### PR DESCRIPTION
## Summary

- Implement streaming animation for markdown blocks with smooth reveal effects
- Simplify StreamdownBlock and StreamdownRender components for better maintainability

## Commits

- `86812c94` ✨ feat(markdown): implement streaming animation for markdown blocks
- `d6ed6e0e` ♻️ refactor(markdown): simplify StreamdownBlock and StreamdownRender components

## Test plan

- [ ] Verify markdown streaming animation displays correctly
- [ ] Check that StreamdownBlock and StreamdownRender components render properly
- [ ] Ensure no visual regressions in existing markdown rendering

## Summary by Sourcery

Add per-block streaming animation for markdown rendering with dynamic timing and simplified components.

New Features:
- Introduce character-level streaming animation for markdown blocks using a dedicated rehype plugin and queue logic.

Enhancements:
- Refactor StreamdownRender to operate on structured markdown blocks with state-driven animation phases.
- Simplify StreamdownBlock memoization and decouple streaming animation from the global markdown rehype plugin list.
- Add a useStreamQueue hook to manage block reveal order, timing, and streaming states for markdown content.
- Adjust markdown animation styles to use a dedicated .stream-char class and shorter fade timing for smoother reveals.