### PR TITLE
fix(Modal): replace deprecated maskClosable with mask.closable

### DIFF
--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -131,7 +131,7 @@ const Modal = memo<ModalProps>(
       >
         <AntModal
           closable
-          maskClosable
+          mask={{ closable: true }}
           cancelText={cancelText}
           className={cx(styles.content, className)}
           closeIcon={<Icon icon={X} size={20} />}

--- a/src/Modal/ModalStackItem.tsx
+++ b/src/Modal/ModalStackItem.tsx
@@ -25,7 +25,7 @@ export const ModalStackItem = memo(
     const stableOnCancel = useEventCallback(onCancel ?? noop);
     const close = useEventCallback(() => onClose(id));
     const setCanDismissByClickOutside = useEventCallback((value: boolean) =>
-      onUpdate(id, { maskClosable: value }),
+      onUpdate(id, { mask: { closable: value } }),
     );
     const stableContextValue = useMemo(
       () => ({ close, setCanDismissByClickOutside }),

--- a/src/Modal/RawModalStackItem.tsx
+++ b/src/Modal/RawModalStackItem.tsx
@@ -32,7 +32,7 @@ export const RawModalStackItem = memo(
     const close = useEventCallback(() => stableOnClose(id));
 
     const setCanDismissByClickOutside = useEventCallback((value: boolean) => {
-      onUpdate(id, { maskClosable: value });
+      onUpdate(id, { mask: { closable: value } });
     });
     const contextValue: ModalContextValue = useMemo(
       () => ({ close, setCanDismissByClickOutside }),

--- a/src/Modal/imperative.tsx
+++ b/src/Modal/imperative.tsx
@@ -232,7 +232,7 @@ export const createModal = (props: ImperativeModalProps): ModalInstance => {
   return {
     close: () => closeModal(id),
     destroy: () => destroyModal(id),
-    setCanDismissByClickOutside: (value) => updateModal(id, { maskClosable: value }),
+    setCanDismissByClickOutside: (value) => updateModal(id, { mask: { closable: value } }),
     update: (nextProps) => updateModal(id, nextProps),
   };
 };
@@ -271,7 +271,7 @@ export function createRawModal<P, OpenKey extends keyof P, CloseKey extends keyo
   return {
     close: () => closeModal(id),
     destroy: () => destroyModal(id),
-    setCanDismissByClickOutside: (value) => updateRawProps(id, { maskClosable: value }),
+    setCanDismissByClickOutside: (value) => updateRawProps(id, { mask: { closable: value } }),
     update: (nextProps) => updateRawProps(id, nextProps as Record<string, unknown>),
   };
 }


### PR DESCRIPTION
## Description

Replace deprecated `maskClosable` prop with `mask={{ closable: ... }}` to fix antd 6.x deprecation warning.

### Changes

- `src/Modal/Modal.tsx`: Replace `maskClosable` prop with `mask={{ closable: true }}`
- `src/Modal/RawModalStackItem.tsx`: Update onUpdate call to use new format
- `src/Modal/ModalStackItem.tsx`: Update onUpdate call to use new format  
- `src/Modal/imperative.tsx`: Update updateModal and updateRawProps calls

### Related Issue

Fixes #480

### Testing

- [x] Verified no more "maskClosable is deprecated" warnings in console
- [x] Modal click-outside-to-dismiss functionality still works

---

Thanks for maintaining this great library! 🙏