### PR TITLE
✨ feat(hotkey-input): add clear button support & improve markdown streaming

### DIFF
--- a/src/HotkeyInput/HotkeyInput.tsx
+++ b/src/HotkeyInput/HotkeyInput.tsx
@@ -3,7 +3,7 @@
 import { type InputRef } from 'antd';
 import { cx, useThemeMode } from 'antd-style';
 import { isEqual } from 'es-toolkit/compat';
-import { Undo2Icon } from 'lucide-react';
+import { Undo2Icon, XIcon } from 'lucide-react';
 import {
   type FocusEvent,
   memo,
@@ -33,10 +33,12 @@ const HotkeyInput = memo<HotkeyInputProps>(
     defaultValue = '',
     resetValue = '',
     onChange,
+    onClear,
     onConflict,
     placeholder,
     disabled,
     shadow,
+    allowClear,
     allowReset = true,
     style,
     className,
@@ -184,6 +186,18 @@ const HotkeyInput = memo<HotkeyInputProps>(
       onBlur?.(e);
     };
 
+    const handleClear = (e: MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setHotkeyValue?.('');
+      resetKeys();
+      setHasConflict(false);
+      setHasInvalidCombination(false);
+      setIsFocused(false);
+      stop();
+      onClear?.(hotkeyValue);
+    };
+
     // 重置功能
     const handleReset = (e: MouseEvent) => {
       e.preventDefault();
@@ -206,6 +220,7 @@ const HotkeyInput = memo<HotkeyInputProps>(
 
     const placeholderText = placeholder ?? t('hotkey.placeholder');
     const resetTitle = texts?.reset ?? t('hotkey.reset');
+    const clearTitle = texts?.clear ?? t('hotkey.clear');
     const conflictText = texts?.conflicts ?? t('hotkey.conflict');
     const invalidText = texts?.invalidCombination ?? t('hotkey.invalidCombination');
 
@@ -263,6 +278,15 @@ const HotkeyInput = memo<HotkeyInputProps>(
               title={resetTitle}
               variant={'filled'}
               onClick={handleReset}
+            />
+          )}
+          {!isFocused && allowClear && hotkeyValue && !disabled && (
+            <ActionIcon
+              icon={XIcon}
+              size={'small'}
+              title={clearTitle}
+              variant={'filled'}
+              onClick={handleClear}
             />
           )}
         </Flexbox>

--- a/src/HotkeyInput/HotkeyInput.tsx
+++ b/src/HotkeyInput/HotkeyInput.tsx
@@ -271,23 +271,27 @@ const HotkeyInput = memo<HotkeyInputProps>(
             onFocus={handleFocus}
           />
 
-          {!isFocused && allowReset && hotkeyValue && hotkeyValue !== resetValue && !disabled && (
-            <ActionIcon
-              icon={Undo2Icon}
-              size={'small'}
-              title={resetTitle}
-              variant={'filled'}
-              onClick={handleReset}
-            />
-          )}
-          {!isFocused && allowClear && hotkeyValue && !disabled && (
-            <ActionIcon
-              icon={XIcon}
-              size={'small'}
-              title={clearTitle}
-              variant={'filled'}
-              onClick={handleClear}
-            />
+          {!isFocused && hotkeyValue && !disabled && (allowReset || allowClear) && (
+            <Flexbox horizontal gap={4}>
+              {allowReset && hotkeyValue !== resetValue && (
+                <ActionIcon
+                  icon={Undo2Icon}
+                  size={'small'}
+                  title={resetTitle}
+                  variant={'filled'}
+                  onClick={handleReset}
+                />
+              )}
+              {allowClear && (
+                <ActionIcon
+                  icon={XIcon}
+                  size={'small'}
+                  title={clearTitle}
+                  variant={'filled'}
+                  onClick={handleClear}
+                />
+              )}
+            </Flexbox>
           )}
         </Flexbox>
         {hasConflict && <div className={styles.errorText}>{conflictText}</div>}

--- a/src/HotkeyInput/demos/index.tsx
+++ b/src/HotkeyInput/demos/index.tsx
@@ -10,6 +10,7 @@ export default () => {
 
   const controls = useControls(
     {
+      allowClear: false,
       allowReset: true,
       defaultValue: DEFAULT_VALUE,
       disabled: false,
@@ -33,6 +34,9 @@ export default () => {
         onChange={(value) => {
           setShortcut(value);
           console.log(value);
+        }}
+        onClear={(currentValue) => {
+          console.log('Cleared:', currentValue);
         }}
         {...controls}
       />

--- a/src/HotkeyInput/type.ts
+++ b/src/HotkeyInput/type.ts
@@ -2,6 +2,7 @@ import type { InputProps } from 'antd';
 import type { CSSProperties } from 'react';
 
 export interface HotkeyInputProps {
+  allowClear?: boolean;
   allowReset?: boolean;
   className?: string;
   defaultValue?: string;
@@ -10,6 +11,7 @@ export interface HotkeyInputProps {
   isApple?: boolean;
   onBlur?: InputProps['onBlur'];
   onChange?: (value: string) => void;
+  onClear?: (currentValue: string) => void;
   onConflict?: (conflictKey: string) => void;
   onFocus?: InputProps['onFocus'];
   onReset?: (currentValue: string, resetValue: string) => void;
@@ -18,6 +20,7 @@ export interface HotkeyInputProps {
   shadow?: boolean;
   style?: CSSProperties;
   texts?: {
+    clear?: string;
     conflicts?: string;
     invalidCombination?: string;
     reset?: string;

--- a/src/Markdown/Markdown.tsx
+++ b/src/Markdown/Markdown.tsx
@@ -43,6 +43,7 @@ const Markdown = memo<MarkdownProps>((props) => {
     components = {},
     customRender,
     showFootnotes = true,
+    streamSmoothingPreset,
     citations,
     ...rest
   } = props;
@@ -93,6 +94,7 @@ const Markdown = memo<MarkdownProps>((props) => {
           remarkPlugins={remarkPlugins}
           remarkPluginsAhead={remarkPluginsAhead}
           showFootnotes={showFootnotes}
+          streamSmoothingPreset={streamSmoothingPreset}
           variant={variant}
         >
           <Render

--- a/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
+++ b/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
@@ -12,12 +12,14 @@ import {
   useMarkdownRehypePlugins,
   useMarkdownRemarkPlugins,
 } from '@/hooks/useMarkdown';
+import { useMarkdownContext } from '@/Markdown/components/MarkdownProvider';
 import { rehypeStreamAnimated } from '@/Markdown/plugins/rehypeStreamAnimated';
 
 import { styles } from './style';
+import { useSmoothStreamContent } from './useSmoothStreamContent';
 import { type BlockInfo, useStreamQueue } from './useStreamQueue';
 
-const STREAM_CHAR_DELAY = 15;
+const STREAM_FADE_DURATION = 280;
 
 function countChars(text: string): number {
   return [...text].length;
@@ -100,16 +102,20 @@ const StreamdownBlock = memo<Options>(
 StreamdownBlock.displayName = 'StreamdownBlock';
 
 export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
+  const { streamSmoothingPreset = 'balanced' } = useMarkdownContext();
   const escapedContent = useMarkdownContent(children || '');
   const components = useMarkdownComponents();
   const baseRehypePlugins = useStablePlugins(useMarkdownRehypePlugins());
   const remarkPlugins = useStablePlugins(useMarkdownRemarkPlugins());
   const generatedId = useId();
+  const smoothedContent = useSmoothStreamContent(
+    typeof escapedContent === 'string' ? escapedContent : '',
+    { preset: streamSmoothingPreset },
+  );
 
   const processedContent = useMemo(() => {
-    const content = typeof escapedContent === 'string' ? escapedContent : '';
-    return remend(content);
-  }, [escapedContent]);
+    return remend(smoothedContent);
+  }, [smoothedContent]);
 
   const blocks: BlockInfo[] = useMemo(() => {
     const tokens = marked.lexer(processedContent);
@@ -122,56 +128,87 @@ export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
   }, [processedContent]);
 
   const { getBlockState, charDelay } = useStreamQueue(blocks);
+  const prevBlockCharCountRef = useRef<Map<number, number>>(new Map());
+  const blockTimelineRef = useRef<Map<number, number>>(new Map());
+  const lastRenderTsRef = useRef<number | null>(null);
 
-  const staggerPlugins: Pluggable[] = useMemo(
-    () => [...baseRehypePlugins, [rehypeStreamAnimated, { baseCharCount: 0, charDelay }]],
-    [baseRehypePlugins, charDelay],
-  );
+  const renderTs = typeof performance === 'undefined' ? Date.now() : performance.now();
+  const frameDt =
+    lastRenderTsRef.current === null
+      ? 0
+      : Math.max(0, Math.min(renderTs - lastRenderTsRef.current, 120));
 
-  const revealedPlugins: Pluggable[] = useMemo(
-    () => [...baseRehypePlugins, [rehypeStreamAnimated, { revealed: true }]],
-    [baseRehypePlugins],
-  );
+  const timelineForRender = useMemo(() => {
+    const next = new Map<number, number>();
+    const prevTimeline = blockTimelineRef.current;
+    const prevCharCounts = prevBlockCharCountRef.current;
 
-  // prevCharCount tracks the PREVIOUS render's streaming char count.
-  // Updated in useEffect (after render) to avoid stale reads during
-  // synchronous re-renders (e.g. useLayoutEffect auto-reveal).
-  const prevCharCountRef = useRef(0);
-  const prevStreamOffsetRef = useRef(-1);
+    for (const block of blocks) {
+      const blockCharCount = countChars(block.content);
+      const prevCharCount = prevCharCounts.get(block.startOffset) ?? 0;
+      const prevElapsed = prevTimeline.get(block.startOffset);
+      const latestCharStart = Math.max(0, (blockCharCount - 1) * charDelay);
+
+      if (prevElapsed === undefined || blockCharCount < prevCharCount) {
+        next.set(block.startOffset, latestCharStart);
+        continue;
+      }
+
+      const elapsedByTime = prevElapsed + frameDt;
+      // Avoid huge hidden backlog when stream updates in bursts.
+      const minElapsed = Math.max(0, latestCharStart - charDelay * 2);
+      next.set(block.startOffset, Math.max(elapsedByTime, minElapsed));
+    }
+
+    return next;
+  }, [blocks, charDelay, frameDt]);
 
   useEffect(() => {
-    const tailIdx = blocks.length - 1;
-    if (tailIdx >= 0) {
-      const tail = blocks[tailIdx];
-      if (tail.startOffset !== prevStreamOffsetRef.current) {
-        prevStreamOffsetRef.current = tail.startOffset;
-        prevCharCountRef.current = 0;
-      }
-      prevCharCountRef.current = countChars(tail.content);
-    } else {
-      prevCharCountRef.current = 0;
-      prevStreamOffsetRef.current = -1;
+    const nextCharCount = new Map<number, number>();
+    for (const block of blocks) {
+      nextCharCount.set(block.startOffset, countChars(block.content));
     }
-  }, [blocks]);
+    prevBlockCharCountRef.current = nextCharCount;
+    blockTimelineRef.current = timelineForRender;
+    lastRenderTsRef.current = typeof performance === 'undefined' ? Date.now() : performance.now();
+  }, [blocks, timelineForRender]);
 
   return (
     <div className={styles.animated}>
       {blocks.map((block, index) => {
         const state = getBlockState(index);
         if (state === 'queued') return null;
+        const timelineElapsedMs = timelineForRender.get(block.startOffset) ?? 0;
 
         let plugins: Pluggable[];
         if (state === 'streaming') {
-          const baseCharCount =
-            block.startOffset === prevStreamOffsetRef.current ? prevCharCountRef.current : 0;
           plugins = [
             ...baseRehypePlugins,
-            [rehypeStreamAnimated, { baseCharCount, charDelay: STREAM_CHAR_DELAY }],
+            [
+              rehypeStreamAnimated,
+              { charDelay, fadeDuration: STREAM_FADE_DURATION, timelineElapsedMs },
+            ],
           ];
         } else if (state === 'animating') {
-          plugins = staggerPlugins;
+          // Continue from previously rendered progress instead of restarting
+          // or force-switching to fully revealed.
+          plugins = [
+            ...baseRehypePlugins,
+            [
+              rehypeStreamAnimated,
+              { charDelay, fadeDuration: STREAM_FADE_DURATION, timelineElapsedMs },
+            ],
+          ];
         } else {
-          plugins = revealedPlugins;
+          // Keep fade continuity for just-finished chars; avoid instant class
+          // switch to stream-char-revealed that would cancel in-flight fades.
+          plugins = [
+            ...baseRehypePlugins,
+            [
+              rehypeStreamAnimated,
+              { charDelay, fadeDuration: STREAM_FADE_DURATION, timelineElapsedMs },
+            ],
+          ];
         }
 
         return (

--- a/src/Markdown/SyntaxMarkdown/style.ts
+++ b/src/Markdown/SyntaxMarkdown/style.ts
@@ -9,8 +9,8 @@ export const styles = createStaticStyles(({ css }) => {
         opacity: 0;
 
         animation-name: ${fadeIn};
-        animation-duration: 150ms;
-        animation-timing-function: ease-out;
+        animation-duration: 280ms;
+        animation-timing-function: cubic-bezier(0.33, 0, 0.67, 1);
         animation-fill-mode: forwards;
       }
 

--- a/src/Markdown/SyntaxMarkdown/useSmoothStreamContent.ts
+++ b/src/Markdown/SyntaxMarkdown/useSmoothStreamContent.ts
@@ -1,0 +1,323 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { type StreamSmoothingPreset } from '@/Markdown/type';
+
+interface StreamSmoothingPresetConfig {
+  activeInputWindowMs: number;
+  defaultCps: number;
+  emaAlpha: number;
+  flushCps: number;
+  largeAppendChars: number;
+  maxActiveCps: number;
+  maxCps: number;
+  maxFlushCps: number;
+  minCps: number;
+  settleAfterMs: number;
+  settleDrainMaxMs: number;
+  settleDrainMinMs: number;
+  targetBufferMs: number;
+}
+
+const PRESET_CONFIG: Record<StreamSmoothingPreset, StreamSmoothingPresetConfig> = {
+  balanced: {
+    activeInputWindowMs: 220,
+    defaultCps: 38,
+    emaAlpha: 0.2,
+    flushCps: 120,
+    largeAppendChars: 120,
+    maxActiveCps: 132,
+    maxCps: 72,
+    maxFlushCps: 280,
+    minCps: 18,
+    settleAfterMs: 360,
+    settleDrainMaxMs: 520,
+    settleDrainMinMs: 180,
+    targetBufferMs: 120,
+  },
+  realtime: {
+    activeInputWindowMs: 140,
+    defaultCps: 50,
+    emaAlpha: 0.3,
+    flushCps: 170,
+    largeAppendChars: 180,
+    maxActiveCps: 180,
+    maxCps: 96,
+    maxFlushCps: 360,
+    minCps: 24,
+    settleAfterMs: 260,
+    settleDrainMaxMs: 360,
+    settleDrainMinMs: 140,
+    targetBufferMs: 40,
+  },
+  silky: {
+    activeInputWindowMs: 320,
+    defaultCps: 28,
+    emaAlpha: 0.14,
+    flushCps: 96,
+    largeAppendChars: 100,
+    maxActiveCps: 102,
+    maxCps: 56,
+    maxFlushCps: 220,
+    minCps: 14,
+    settleAfterMs: 460,
+    settleDrainMaxMs: 680,
+    settleDrainMinMs: 240,
+    targetBufferMs: 170,
+  },
+};
+
+const clamp = (value: number, min: number, max: number): number => {
+  return Math.min(max, Math.max(min, value));
+};
+
+export const countChars = (text: string): number => {
+  return [...text].length;
+};
+
+interface UseSmoothStreamContentOptions {
+  enabled?: boolean;
+  preset?: StreamSmoothingPreset;
+}
+
+export const useSmoothStreamContent = (
+  content: string,
+  { enabled = true, preset = 'balanced' }: UseSmoothStreamContentOptions = {},
+): string => {
+  const config = PRESET_CONFIG[preset];
+  const [displayedContent, setDisplayedContent] = useState(content);
+
+  const displayedContentRef = useRef(content);
+  const displayedCountRef = useRef(countChars(content));
+
+  const targetContentRef = useRef(content);
+  const targetCharsRef = useRef([...content]);
+  const targetCountRef = useRef(targetCharsRef.current.length);
+
+  const emaCpsRef = useRef(config.defaultCps);
+  const lastInputTsRef = useRef(0);
+  const lastInputCountRef = useRef(targetCountRef.current);
+  const chunkSizeEmaRef = useRef(1);
+  const arrivalCpsEmaRef = useRef(config.defaultCps);
+
+  const rafRef = useRef<number | null>(null);
+  const lastFrameTsRef = useRef<number | null>(null);
+
+  const stopFrameLoop = useCallback(() => {
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    lastFrameTsRef.current = null;
+  }, []);
+
+  const syncImmediate = useCallback(
+    (nextContent: string) => {
+      stopFrameLoop();
+
+      const chars = [...nextContent];
+      const now = performance.now();
+
+      targetContentRef.current = nextContent;
+      targetCharsRef.current = chars;
+      targetCountRef.current = chars.length;
+
+      displayedContentRef.current = nextContent;
+      displayedCountRef.current = chars.length;
+      setDisplayedContent(nextContent);
+
+      emaCpsRef.current = config.defaultCps;
+      chunkSizeEmaRef.current = 1;
+      arrivalCpsEmaRef.current = config.defaultCps;
+      lastInputTsRef.current = now;
+      lastInputCountRef.current = chars.length;
+    },
+    [config.defaultCps, stopFrameLoop],
+  );
+
+  const startFrameLoop = useCallback(() => {
+    if (rafRef.current !== null) return;
+
+    const tick = (ts: number) => {
+      if (lastFrameTsRef.current === null) {
+        lastFrameTsRef.current = ts;
+        rafRef.current = requestAnimationFrame(tick);
+        return;
+      }
+
+      const dtSeconds = Math.max(0.001, Math.min((ts - lastFrameTsRef.current) / 1000, 0.05));
+      lastFrameTsRef.current = ts;
+
+      const targetCount = targetCountRef.current;
+      const displayedCount = displayedCountRef.current;
+      const backlog = targetCount - displayedCount;
+
+      if (backlog <= 0) {
+        stopFrameLoop();
+        return;
+      }
+
+      const now = performance.now();
+      const idleMs = now - lastInputTsRef.current;
+      const inputActive = idleMs <= config.activeInputWindowMs;
+      const settling = !inputActive && idleMs >= config.settleAfterMs;
+
+      const baseCps = clamp(emaCpsRef.current, config.minCps, config.maxCps);
+      const baseLagChars = Math.max(1, Math.round((baseCps * config.targetBufferMs) / 1000));
+      const lagUpperBound = Math.max(baseLagChars + 2, baseLagChars * 3);
+      const targetLagChars = inputActive
+        ? Math.round(
+            clamp(baseLagChars + chunkSizeEmaRef.current * 0.35, baseLagChars, lagUpperBound),
+          )
+        : 0;
+      const desiredDisplayed = Math.max(0, targetCount - targetLagChars);
+
+      let currentCps: number;
+      if (inputActive) {
+        const backlogPressure = targetLagChars > 0 ? backlog / targetLagChars : 1;
+        const chunkPressure = targetLagChars > 0 ? chunkSizeEmaRef.current / targetLagChars : 1;
+        const arrivalPressure = arrivalCpsEmaRef.current / Math.max(baseCps, 1);
+        const combinedPressure = clamp(
+          backlogPressure * 0.6 + chunkPressure * 0.25 + arrivalPressure * 0.15,
+          1,
+          4.5,
+        );
+        const activeCap = clamp(
+          config.maxActiveCps + chunkSizeEmaRef.current * 6,
+          config.maxActiveCps,
+          config.maxFlushCps,
+        );
+        currentCps = clamp(baseCps * combinedPressure, config.minCps, activeCap);
+      } else if (settling) {
+        // If upstream likely ended, cap the remaining tail duration so
+        // we do not keep replaying old backlog for seconds.
+        const drainTargetMs = clamp(backlog * 8, config.settleDrainMinMs, config.settleDrainMaxMs);
+        const settleCps = (backlog * 1000) / drainTargetMs;
+        currentCps = clamp(settleCps, config.flushCps, config.maxFlushCps);
+      } else {
+        const idleFlushCps = Math.max(
+          config.flushCps,
+          baseCps * 1.8,
+          arrivalCpsEmaRef.current * 0.8,
+        );
+        currentCps = clamp(idleFlushCps, config.flushCps, config.maxFlushCps);
+      }
+
+      const urgentBacklog = inputActive && targetLagChars > 0 && backlog > targetLagChars * 2.2;
+      const burstyInput = inputActive && chunkSizeEmaRef.current >= targetLagChars * 0.9;
+      const minRevealChars = inputActive ? (urgentBacklog || burstyInput ? 2 : 1) : 2;
+      let revealChars = Math.max(minRevealChars, Math.round(currentCps * dtSeconds));
+
+      if (inputActive) {
+        const shortfall = desiredDisplayed - displayedCount;
+        if (shortfall <= 0) {
+          rafRef.current = requestAnimationFrame(tick);
+          return;
+        }
+        revealChars = Math.min(revealChars, shortfall, backlog);
+      } else {
+        revealChars = Math.min(revealChars, backlog);
+      }
+
+      const nextCount = displayedCount + revealChars;
+      const segment = targetCharsRef.current.slice(displayedCount, nextCount).join('');
+
+      if (segment) {
+        const nextDisplayed = displayedContentRef.current + segment;
+        displayedContentRef.current = nextDisplayed;
+        displayedCountRef.current = nextCount;
+        setDisplayedContent(nextDisplayed);
+      } else {
+        displayedContentRef.current = targetContentRef.current;
+        displayedCountRef.current = targetCount;
+        setDisplayedContent(targetContentRef.current);
+      }
+
+      rafRef.current = requestAnimationFrame(tick);
+    };
+
+    rafRef.current = requestAnimationFrame(tick);
+  }, [
+    config.activeInputWindowMs,
+    config.flushCps,
+    config.maxActiveCps,
+    config.maxCps,
+    config.maxFlushCps,
+    config.minCps,
+    config.settleAfterMs,
+    config.settleDrainMaxMs,
+    config.settleDrainMinMs,
+    config.targetBufferMs,
+    stopFrameLoop,
+  ]);
+
+  useEffect(() => {
+    if (!enabled) {
+      syncImmediate(content);
+      return;
+    }
+
+    const prevTargetContent = targetContentRef.current;
+    if (content === prevTargetContent) return;
+
+    const now = performance.now();
+    const appendOnly = content.startsWith(prevTargetContent);
+
+    if (!appendOnly) {
+      syncImmediate(content);
+      return;
+    }
+
+    const appended = content.slice(prevTargetContent.length);
+    const appendedChars = [...appended];
+    const appendedCount = appendedChars.length;
+
+    if (appendedCount > config.largeAppendChars) {
+      syncImmediate(content);
+      return;
+    }
+
+    targetContentRef.current = content;
+    targetCharsRef.current = [...targetCharsRef.current, ...appendedChars];
+    targetCountRef.current += appendedCount;
+
+    const deltaChars = targetCountRef.current - lastInputCountRef.current;
+    const deltaMs = Math.max(1, now - lastInputTsRef.current);
+
+    if (deltaChars > 0) {
+      const instantCps = (deltaChars * 1000) / deltaMs;
+      const normalizedInstantCps = clamp(instantCps, config.minCps, config.maxFlushCps * 2);
+      const chunkEmaAlpha = 0.35;
+      chunkSizeEmaRef.current =
+        chunkSizeEmaRef.current * (1 - chunkEmaAlpha) + appendedCount * chunkEmaAlpha;
+      arrivalCpsEmaRef.current =
+        arrivalCpsEmaRef.current * (1 - chunkEmaAlpha) + normalizedInstantCps * chunkEmaAlpha;
+
+      const clampedCps = clamp(instantCps, config.minCps, config.maxActiveCps);
+      emaCpsRef.current = emaCpsRef.current * (1 - config.emaAlpha) + clampedCps * config.emaAlpha;
+    }
+
+    lastInputTsRef.current = now;
+    lastInputCountRef.current = targetCountRef.current;
+
+    startFrameLoop();
+  }, [
+    config.emaAlpha,
+    config.largeAppendChars,
+    config.maxActiveCps,
+    config.maxCps,
+    config.maxFlushCps,
+    config.minCps,
+    content,
+    enabled,
+    startFrameLoop,
+    syncImmediate,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      stopFrameLoop();
+    };
+  }, [stopFrameLoop]);
+
+  return displayedContent;
+};

--- a/src/Markdown/SyntaxMarkdown/useStreamQueue.ts
+++ b/src/Markdown/SyntaxMarkdown/useStreamQueue.ts
@@ -7,10 +7,10 @@ export interface BlockInfo {
 
 export type BlockState = 'revealed' | 'animating' | 'streaming' | 'queued';
 
-const BASE_DELAY = 20;
+const BASE_DELAY = 18;
 const ACCELERATION_FACTOR = 0.3;
 const MAX_BLOCK_DURATION = 3000;
-const FADE_DURATION = 150;
+const FADE_DURATION = 280;
 
 function countChars(text: string): number {
   return [...text].length;
@@ -81,15 +81,19 @@ export function useStreamQueue(blocks: BlockInfo[]): UseStreamQueueReturn {
   const animatingCharCount =
     animatingIndex >= 0 ? countChars(blocks[animatingIndex]?.content ?? '') : 0;
 
-  // Freeze charDelay when a new block starts animating
+  const streamingIndex = animatingIndex < 0 && tailIndex >= effectiveRevealedCount ? tailIndex : -1;
+  const activeIndex = animatingIndex >= 0 ? animatingIndex : streamingIndex;
+  const activeCharCount = activeIndex >= 0 ? countChars(blocks[activeIndex]?.content ?? '') : 0;
+
+  // Freeze charDelay when entering a new active block (animating or streaming)
   const frozenRef = useRef({ delay: BASE_DELAY, index: -1 });
-  if (animatingIndex >= 0 && animatingIndex !== frozenRef.current.index) {
+  if (activeIndex >= 0 && activeIndex !== frozenRef.current.index) {
     frozenRef.current = {
-      delay: computeCharDelay(queueLength, animatingCharCount),
-      index: animatingIndex,
+      delay: computeCharDelay(queueLength, activeCharCount),
+      index: activeIndex,
     };
   }
-  const charDelay = animatingIndex >= 0 ? frozenRef.current.delay : BASE_DELAY;
+  const charDelay = activeIndex >= 0 ? frozenRef.current.delay : BASE_DELAY;
 
   const onAnimationDone = useCallback(() => {
     setRevealedCount(effectiveRevealedCount + 1);

--- a/src/Markdown/demos/streaming.tsx
+++ b/src/Markdown/demos/streaming.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Flexbox } from '@/Flex';
 
+import { type StreamSmoothingPreset } from '../type';
 import { fullContent, fullContentCN } from './content';
 import { type ChunkInfo, createLocalStream } from './createLocalStream';
 import { markdownElements } from './custom/plugins/MarkdownElements';
@@ -27,6 +28,7 @@ export default () => {
     chunkDelayMin,
     chunkDelayMax,
     language,
+    streamSmoothingPreset,
 
     streamDebug,
     ...rest
@@ -57,7 +59,11 @@ export default () => {
         value: 25,
       },
       useReadableStream: {
-        value: false,
+        value: true,
+      },
+      streamSmoothingPreset: {
+        options: ['realtime', 'balanced', 'silky'],
+        value: 'balanced',
       },
       ReadableStream: folder(
         {
@@ -65,25 +71,25 @@ export default () => {
             max: 5000,
             min: 10,
             step: 10,
-            value: 1000,
+            value: 120,
           },
           chunkDelayMin: {
             max: 1000,
             min: 5,
             step: 5,
-            value: 20,
+            value: 35,
           },
           chunkSizeMax: {
             max: 200,
             min: 1,
             step: 1,
-            value: 50,
+            value: 8,
           },
           chunkSizeMin: {
             max: 100,
             min: 1,
             step: 1,
-            value: 3,
+            value: 2,
           },
         },
         { render: (get) => get('useReadableStream') },
@@ -104,6 +110,12 @@ export default () => {
   }, [streamDebug]);
 
   const safeChildren = typeof children === 'string' ? children : '';
+  const safeSmoothingPreset: StreamSmoothingPreset =
+    streamSmoothingPreset === 'realtime' ||
+    streamSmoothingPreset === 'balanced' ||
+    streamSmoothingPreset === 'silky'
+      ? streamSmoothingPreset
+      : 'balanced';
 
   const [streamedContent, setStreamedContent] = useState(safeChildren);
   const [isStreaming, setIsStreaming] = useState(false);
@@ -277,6 +289,7 @@ export default () => {
           components={components}
           fullFeaturedCodeBlock={rest.fullFeaturedCodeBlock}
           rehypePlugins={rehypePlugins}
+          streamSmoothingPreset={safeSmoothingPreset}
           variant="chat"
         >
           {removeLineBreaksInAntArtifact(renderedContent)}

--- a/src/Markdown/plugins/rehypeStreamAnimated.ts
+++ b/src/Markdown/plugins/rehypeStreamAnimated.ts
@@ -5,7 +5,9 @@ import { visit } from 'unist-util-visit';
 export interface StreamAnimatedOptions {
   baseCharCount?: number;
   charDelay?: number;
+  fadeDuration?: number;
   revealed?: boolean;
+  timelineElapsedMs?: number;
 }
 
 const BLOCK_TAGS = new Set(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li']);
@@ -19,7 +21,14 @@ function hasClass(node: Element, cls: string): boolean {
 }
 
 export const rehypeStreamAnimated = (options: StreamAnimatedOptions = {}) => {
-  const { charDelay = 20, baseCharCount = 0, revealed = false } = options;
+  const {
+    charDelay = 20,
+    fadeDuration = 150,
+    baseCharCount = 0,
+    revealed = false,
+    timelineElapsedMs,
+  } = options;
+  const hasTimeline = typeof timelineElapsedMs === 'number' && Number.isFinite(timelineElapsedMs);
 
   return (tree: Root) => {
     let globalCharIndex = 0;
@@ -33,15 +42,38 @@ export const rehypeStreamAnimated = (options: StreamAnimatedOptions = {}) => {
       for (const child of node.children) {
         if (child.type === 'text') {
           for (const char of child.value) {
-            const properties: Record<string, any> = {
-              className: revealed ? 'stream-char stream-char-revealed' : 'stream-char',
-            };
-            if (!revealed) {
-              const relativeIndex = Math.max(0, globalCharIndex - baseCharCount);
-              const delay = relativeIndex * charDelay;
-              if (delay > 0) {
-                properties.style = `animation-delay:${delay}ms`;
+            const relativeIndex = globalCharIndex - baseCharCount;
+            let className = 'stream-char';
+            let delay: number | undefined;
+
+            if (revealed) {
+              className = 'stream-char stream-char-revealed';
+            } else if (hasTimeline) {
+              const progress = (timelineElapsedMs as number) - globalCharIndex * charDelay;
+              if (progress >= fadeDuration) {
+                className = 'stream-char stream-char-revealed';
+              } else {
+                // Positive delay means "not started yet", negative keeps
+                // the current in-flight progress on rerender.
+                delay = -progress;
               }
+            } else if (relativeIndex >= 0) {
+              // Newly appended chars start with staggered positive delay.
+              delay = relativeIndex * charDelay;
+            } else {
+              // Previously started chars continue fading with negative delay
+              // instead of being immediately switched to revealed.
+              const elapsed = -relativeIndex * charDelay;
+              if (elapsed >= fadeDuration) {
+                className = 'stream-char stream-char-revealed';
+              } else {
+                delay = -elapsed;
+              }
+            }
+
+            const properties: Record<string, any> = { className };
+            if (delay !== undefined && delay !== 0) {
+              properties.style = `animation-delay:${delay}ms`;
             }
             newChildren.push({
               children: [{ type: 'text', value: char }],

--- a/src/Markdown/type.ts
+++ b/src/Markdown/type.ts
@@ -18,6 +18,8 @@ export interface TypographyProps extends DivProps {
   ref?: Ref<HTMLDivElement>;
 }
 
+export type StreamSmoothingPreset = 'realtime' | 'balanced' | 'silky';
+
 export interface SyntaxMarkdownProps {
   allowHtml?: boolean;
   allowHtmlList?: ElementType[];
@@ -48,6 +50,7 @@ export interface SyntaxMarkdownProps {
   remarkPlugins?: Pluggable[];
   remarkPluginsAhead?: Pluggable[];
   showFootnotes?: boolean;
+  streamSmoothingPreset?: StreamSmoothingPreset;
   variant?: 'default' | 'chat';
 }
 

--- a/src/i18n/index.md
+++ b/src/i18n/index.md
@@ -108,6 +108,7 @@ type TranslationResourcesInput = TranslationResourcesMap | Promise<TranslationRe
 
 | Key                         | English                                                                           | 简体中文                                                     |
 | --------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `hotkey.clear`              | Clear binding                                                                     | 清除绑定                                                     |
 | `hotkey.placeholder`        | Press keys to record shortcut                                                     | 按键录制快捷键                                               |
 | `hotkey.reset`              | Reset to default                                                                  | 重置为默认                                                   |
 | `hotkey.conflict`           | This shortcut conflicts with an existing one.                                     | 此快捷键与现有快捷键冲突。                                   |

--- a/src/i18n/resources/en/hotkey.ts
+++ b/src/i18n/resources/en/hotkey.ts
@@ -1,4 +1,5 @@
 export default {
+  'hotkey.clear': 'Clear binding',
   'hotkey.conflict': 'This shortcut conflicts with an existing one.',
   'hotkey.invalidCombination':
     'Shortcut must include a modifier key (Ctrl, Alt, Shift) and only one regular key.',

--- a/src/i18n/resources/zhCn/hotkey.ts
+++ b/src/i18n/resources/zhCn/hotkey.ts
@@ -1,4 +1,5 @@
 export default {
+  'hotkey.clear': '清除绑定',
   'hotkey.conflict': '此快捷键与现有快捷键冲突。',
   'hotkey.invalidCombination': '快捷键必须包含修饰键（Ctrl、Alt、Shift）且只能有一个常规键。',
   'hotkey.placeholder': '按键录制快捷键',


### PR DESCRIPTION
## Summary

- Add `allowClear` and `onClear` props to `HotkeyInput` component with clear button (XIcon)
- Add `useSmoothStreamContent` hook for smooth markdown streaming animation
- Improve `rehypeStreamAnimated` plugin with better cursor handling and stream state management
- Add i18n support for hotkey clear text (en/zh-CN)

## Test plan

- [x] Verify HotkeyInput clear button appears when `allowClear` is set and value exists
- [x] Verify `onClear` callback fires correctly
- [x] Verify markdown streaming animation renders smoothly
- [x] Verify i18n translations for hotkey clear text

## Summary by Sourcery

Add configurable hotkey clear support and introduce smoother, preset-based markdown streaming animations.

New Features:
- Expose an allowClear option and onClear callback on HotkeyInput, with a clear-action icon and i18n text.
- Add a useSmoothStreamContent hook with stream smoothing presets that control markdown streaming behaviour.
- Allow SyntaxMarkdown/Markdown consumers to configure stream smoothing via a streamSmoothingPreset prop and demo controls.

Enhancements:
- Refine the markdown streaming animation pipeline to use timeline-based character fade, longer easing, and adaptive char delays for more natural playback.
- Improve streaming queue timing and fade constants for better continuity between streaming, animating, and revealed states.

Documentation:
- Extend i18n resources and reference docs with a hotkey.clear translation key for English and Simplified Chinese.