### PR TITLE
:sparkles: feat(markdown): refine Streamdown streaming animation meta and rehype plugin

### DIFF
--- a/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
+++ b/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
@@ -160,46 +160,57 @@ export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
   const blocks: BlockInfo[] = blocksResult.value;
 
   const { getBlockState, charDelay } = useStreamQueue(blocks);
-  const prevBlockCharCountRef = useRef<Map<number, number>>(new Map());
   const blockCharDelayRef = useRef<Map<number, number>>(new Map());
-  const blockTimelineRef = useRef<Map<number, number>>(new Map());
-  const lastRenderTsRef = useRef<number | null>(null);
+  const blockBirthsRef = useRef<Map<number, number[]>>(new Map());
 
-  const renderTs = getNow();
-  const frameDt =
-    lastRenderTsRef.current === null
-      ? 0
-      : Math.max(0, Math.min(renderTs - lastRenderTsRef.current, 120));
+  const renderNow = getNow();
 
-  const timelineResult = useMemo(() => {
+  const birthsResult = useMemo(() => {
     const start = profiler ? getNow() : 0;
-    const next = new Map<number, number>();
-    const prevTimeline = blockTimelineRef.current;
-    const prevCharCounts = prevBlockCharCountRef.current;
+    const nextBirths = new Map<number, number[]>();
+    const prevBirths = blockBirthsRef.current;
 
-    for (const block of blocks) {
+    for (const [index, block] of blocks.entries()) {
+      const state = getBlockState(index);
+      // Queued blocks are not rendered. Defer birth assignment so that
+      // when the block later transitions to animating/streaming, its
+      // chars start fading from that moment instead of having already
+      // "aged out" of the fade window.
+      if (state === 'queued') continue;
+
       const blockCharCount = countChars(block.content);
-      const prevCharCount = prevCharCounts.get(block.startOffset) ?? 0;
-      const prevElapsed = prevTimeline.get(block.startOffset);
-      const latestCharStart = Math.max(0, (blockCharCount - 1) * charDelay);
+      const prev = prevBirths.get(block.startOffset);
+      let arr: number[];
 
-      if (prevElapsed === undefined || blockCharCount < prevCharCount) {
-        next.set(block.startOffset, latestCharStart);
-        continue;
+      if (prev && prev.length === blockCharCount) {
+        arr = prev;
+      } else if (prev && prev.length > blockCharCount) {
+        // Block content shrunk (stream restart or upstream rewrite).
+        arr = prev.slice(0, blockCharCount);
+      } else {
+        arr = prev ? prev.slice() : [];
+        const startIdx = arr.length;
+        // Chain each new char monotonically after the previous one so fades
+        // never race out of order. Cap how far the fade queue can run ahead
+        // of renderNow to prevent stream-faster-than-fade producing seconds
+        // of invisible backlog at the tail.
+        const cap = renderNow + STREAM_FADE_DURATION;
+        for (let i = startIdx; i < blockCharCount; i++) {
+          const prevBirth = i > 0 ? (arr[i - 1] as number) : renderNow - charDelay;
+          const chained = prevBirth + charDelay;
+          arr.push(Math.min(cap, Math.max(chained, renderNow)));
+        }
       }
 
-      const elapsedByTime = prevElapsed + frameDt;
-      // Avoid huge hidden backlog when stream updates in bursts.
-      const minElapsed = Math.max(0, latestCharStart - charDelay * 2);
-      next.set(block.startOffset, Math.max(elapsedByTime, minElapsed));
+      nextBirths.set(block.startOffset, arr);
     }
 
     return {
       durationMs: profiler ? getNow() - start : 0,
-      value: next,
+      value: nextBirths,
     };
-  }, [blocks, charDelay, frameDt, profiler]);
-  const timelineForRender = timelineResult.value;
+  }, [blocks, charDelay, getBlockState, profiler, renderNow]);
+  const birthsForRender = birthsResult.value;
 
   useEffect(() => {
     if (!profiler) return;
@@ -226,12 +237,12 @@ export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
     if (!profiler) return;
 
     profiler.recordCalculation({
-      durationMs: timelineResult.durationMs,
+      durationMs: birthsResult.durationMs,
       itemCount: blocks.length,
-      name: 'block-timeline',
+      name: 'block-births',
       textLength: processedContent.length,
     });
-  }, [blocks.length, processedContent.length, profiler, timelineResult.durationMs]);
+  }, [birthsResult.durationMs, blocks.length, processedContent.length, profiler]);
 
   const blockAnimationMetaResult = useMemo(() => {
     const nextBlockCharDelay = new Map<number, number>();
@@ -239,14 +250,15 @@ export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
 
     for (const [index, block] of blocks.entries()) {
       const state = getBlockState(index);
-      const timelineElapsedMs = timelineForRender.get(block.startOffset) ?? 0;
+      const births = birthsForRender.get(block.startOffset);
+      const lastBirthTs = births && births.length > 0 ? (births.at(-1) ?? renderNow) : renderNow;
+      const lastElapsedMs = renderNow - lastBirthTs;
       const animationMeta = resolveBlockAnimationMeta({
-        blockCharCount: countChars(block.content),
         currentCharDelay: charDelay,
         fadeDuration: STREAM_FADE_DURATION,
+        lastElapsedMs,
         previousCharDelay: blockCharDelayRef.current.get(block.startOffset),
         state,
-        timelineElapsedMs,
       });
 
       nextBlockCharDelay.set(block.startOffset, animationMeta.charDelay);
@@ -257,18 +269,12 @@ export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
       blockAnimationMeta,
       blockCharDelay: nextBlockCharDelay,
     };
-  }, [blocks, charDelay, getBlockState, timelineForRender]);
+  }, [birthsForRender, blocks, charDelay, getBlockState, renderNow]);
 
   useEffect(() => {
-    const nextCharCount = new Map<number, number>();
-    for (const block of blocks) {
-      nextCharCount.set(block.startOffset, countChars(block.content));
-    }
     blockCharDelayRef.current = blockAnimationMetaResult.blockCharDelay;
-    prevBlockCharCountRef.current = nextCharCount;
-    blockTimelineRef.current = timelineForRender;
-    lastRenderTsRef.current = getNow();
-  }, [blockAnimationMetaResult.blockCharDelay, blocks, timelineForRender]);
+    blockBirthsRef.current = birthsForRender;
+  }, [birthsForRender, blockAnimationMetaResult.blockCharDelay]);
 
   const handleRootRender = useCallback<ProfilerOnRenderCallback>(
     (_, phase, actualDuration, baseDuration) => {
@@ -316,6 +322,7 @@ export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
         const animationMeta = blockAnimationMetaResult.blockAnimationMeta.get(block.startOffset);
         if (!animationMeta) return null;
 
+        const births = birthsForRender.get(block.startOffset);
         const plugins: Pluggable[] = animationMeta.settled
           ? [...baseRehypePlugins, REVEALED_STREAM_PLUGIN]
           : [
@@ -323,9 +330,9 @@ export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
               [
                 rehypeStreamAnimated,
                 {
-                  charDelay: animationMeta.charDelay,
+                  births,
                   fadeDuration: STREAM_FADE_DURATION,
-                  timelineElapsedMs: animationMeta.timelineElapsedMs,
+                  nowMs: renderNow,
                 },
               ],
             ];

--- a/src/Markdown/SyntaxMarkdown/streamAnimationMeta.test.ts
+++ b/src/Markdown/SyntaxMarkdown/streamAnimationMeta.test.ts
@@ -5,46 +5,40 @@ import { resolveBlockAnimationMeta } from './streamAnimationMeta';
 describe('resolveBlockAnimationMeta', () => {
   it('keeps the current charDelay for active blocks', () => {
     const result = resolveBlockAnimationMeta({
-      blockCharCount: 8,
       currentCharDelay: 18,
       fadeDuration: 280,
+      lastElapsedMs: 64,
       previousCharDelay: 12,
       state: 'streaming',
-      timelineElapsedMs: 64,
     });
 
     expect(result.charDelay).toBe(18);
     expect(result.settled).toBe(false);
-    expect(result.timelineElapsedMs).toBe(64);
   });
 
   it('preserves the previous charDelay for revealed blocks still fading', () => {
     const result = resolveBlockAnimationMeta({
-      blockCharCount: 5,
       currentCharDelay: 10,
       fadeDuration: 280,
+      lastElapsedMs: 200,
       previousCharDelay: 20,
       state: 'revealed',
-      timelineElapsedMs: 320,
     });
 
     expect(result.charDelay).toBe(20);
     expect(result.settled).toBe(false);
-    expect(result.timelineElapsedMs).toBe(320);
   });
 
-  it('freezes revealed blocks after the fade window completes', () => {
+  it('settles revealed blocks after the fade window completes', () => {
     const result = resolveBlockAnimationMeta({
-      blockCharCount: 5,
       currentCharDelay: 10,
       fadeDuration: 280,
+      lastElapsedMs: 320,
       previousCharDelay: 20,
       state: 'revealed',
-      timelineElapsedMs: 480,
     });
 
     expect(result.charDelay).toBe(20);
     expect(result.settled).toBe(true);
-    expect(result.timelineElapsedMs).toBe(360);
   });
 });

--- a/src/Markdown/SyntaxMarkdown/streamAnimationMeta.ts
+++ b/src/Markdown/SyntaxMarkdown/streamAnimationMeta.ts
@@ -1,18 +1,16 @@
 import { type BlockState } from './useStreamQueue';
 
 export interface ResolveBlockAnimationMetaOptions {
-  blockCharCount: number;
   currentCharDelay: number;
   fadeDuration: number;
+  lastElapsedMs: number;
   previousCharDelay?: number;
   state: BlockState;
-  timelineElapsedMs: number;
 }
 
 export interface BlockAnimationMeta {
   charDelay: number;
   settled: boolean;
-  timelineElapsedMs: number;
 }
 
 const isActiveBlock = (state: BlockState) => {
@@ -20,22 +18,19 @@ const isActiveBlock = (state: BlockState) => {
 };
 
 export const resolveBlockAnimationMeta = ({
-  blockCharCount,
   currentCharDelay,
   fadeDuration,
+  lastElapsedMs,
   previousCharDelay,
   state,
-  timelineElapsedMs,
 }: ResolveBlockAnimationMetaOptions): BlockAnimationMeta => {
   const charDelay = isActiveBlock(state)
     ? currentCharDelay
     : (previousCharDelay ?? currentCharDelay);
-  const latestCharStart = Math.max(0, (blockCharCount - 1) * charDelay);
-  const settled = state === 'revealed' && timelineElapsedMs >= latestCharStart + fadeDuration;
+  const settled = state === 'revealed' && lastElapsedMs >= fadeDuration;
 
   return {
     charDelay,
     settled,
-    timelineElapsedMs: settled ? latestCharStart + fadeDuration : timelineElapsedMs,
   };
 };

--- a/src/Markdown/demos/streamingAnimationRepro.tsx
+++ b/src/Markdown/demos/streamingAnimationRepro.tsx
@@ -1,0 +1,364 @@
+'use client';
+
+import { Button, Markdown } from '@lobehub/ui';
+import { type CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
+
+import { Flexbox } from '@/Flex';
+
+import { type StreamSmoothingPreset } from '../type';
+
+type Scenario =
+  | 'largeAppend'
+  | 'blockBurstSync'
+  | 'blockBurstViaSmoother'
+  | 'fastSmallChunks'
+  | 'ultraFast250tps'
+  | 'slow20tps';
+
+interface ScenarioConfig {
+  description: string;
+  hypothesis: string;
+  label: string;
+  run: (push: (chunk: string) => void, done: () => void) => () => void;
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const ALPHA = 'abcdefghijklmnopqrstuvwxyz ';
+const repeat = (n: number) => Array.from({ length: n }, (_, i) => ALPHA[i % ALPHA.length]).join('');
+
+const SCENARIOS: Record<Scenario, ScenarioConfig> = {
+  blockBurstSync: {
+    description:
+      'Push the whole multi-paragraph payload in one setState. Forces syncImmediate unconditionally — every new block gets timeline seeded to latestCharStart at once.',
+    hypothesis: 'If timeline seeding is the cause, skipped count should dominate (>50% miss rate).',
+    label: 'B. Multi-paragraph in one shot',
+    run: (push, done) => {
+      const payload = [
+        '# Heading B',
+        '',
+        repeat(90) + '.',
+        '',
+        repeat(90) + '.',
+        '',
+        repeat(90) + '.',
+        '',
+      ].join('\n');
+      let cancelled = false;
+      const t = setTimeout(() => {
+        if (cancelled) return;
+        push(payload);
+        done();
+      }, 50);
+      return () => {
+        cancelled = true;
+        clearTimeout(t);
+      };
+    },
+  },
+  blockBurstViaSmoother: {
+    description:
+      'Each paragraph is ~90 chars (below largeAppendChars=120 for `balanced`), pushed in one append per 500ms. Smoother paces char-by-char, but each newline boundary births a new block mid-stream.',
+    hypothesis:
+      'If smoother always grows blocks 1 char at a time, timeline seeds at 0 and we should see NO skipped chars from this path.',
+    label: 'B2. Paragraphs via smoother (<120 each)',
+    run: (push, done) => {
+      const paragraphs = [
+        '# Heading B2\n\n',
+        repeat(80) + '.\n\n',
+        repeat(80) + '.\n\n',
+        repeat(80) + '.\n',
+      ];
+      let cancelled = false;
+      let i = 0;
+      (async () => {
+        while (!cancelled && i < paragraphs.length) {
+          push(paragraphs[i++]);
+          await sleep(500);
+        }
+        if (!cancelled) done();
+      })();
+      return () => {
+        cancelled = true;
+      };
+    },
+  },
+  fastSmallChunks: {
+    description:
+      '100 chars/sec, 4-char chunks every 40ms. No chunk exceeds largeAppendChars. Stress the smoother while constantly crossing paragraph boundaries.',
+    hypothesis:
+      'If backlog pressure causes the smoother to flush many chars per frame across a newline, timeline seeding may still miss animations.',
+    label: 'D. Fast small chunks, 100 cps',
+    run: (push, done) => {
+      const text =
+        '# Heading D\n\n' + repeat(160) + '.\n\n' + repeat(160) + '.\n\n' + repeat(160) + '.\n';
+      let cancelled = false;
+      let pos = 0;
+      (async () => {
+        while (!cancelled && pos < text.length) {
+          const size = Math.min(4, text.length - pos);
+          push(text.slice(pos, pos + size));
+          pos += size;
+          await sleep(40);
+        }
+        if (!cancelled) done();
+      })();
+      return () => {
+        cancelled = true;
+      };
+    },
+  },
+  ultraFast250tps: {
+    description:
+      '~260 chars/sec, 13-char chunks every 50ms. Sustained high-pressure stream. Each chunk stays under largeAppendChars but smoother backlog runs hot for the whole duration.',
+    hypothesis:
+      'With fix: no chunk should skip its fade regardless of how many chars RAF batches per commit.',
+    label: 'E. Ultra-fast stream (~260 cps)',
+    run: (push, done) => {
+      const text =
+        '# Heading E\n\n' + repeat(240) + '.\n\n' + repeat(240) + '.\n\n' + repeat(240) + '.\n';
+      let cancelled = false;
+      let pos = 0;
+      (async () => {
+        while (!cancelled && pos < text.length) {
+          const size = Math.min(13, text.length - pos);
+          push(text.slice(pos, pos + size));
+          pos += size;
+          await sleep(50);
+        }
+        if (!cancelled) done();
+      })();
+      return () => {
+        cancelled = true;
+      };
+    },
+  },
+  largeAppend: {
+    description:
+      'One append of 200+ chars. Exceeds largeAppendChars=120 for `balanced`, forcing syncImmediate. All content flushes in one setState with zero per-char pacing.',
+    hypothesis:
+      'If syncImmediate + timeline seeding is the cause, we should see heavy skipped counts here.',
+    label: 'A. Single chunk > 120',
+    run: (push, done) => {
+      const payload = `# Heading A\n\n${repeat(200)}.\n`;
+      let cancelled = false;
+      const t = setTimeout(() => {
+        if (cancelled) return;
+        push(payload);
+        done();
+      }, 50);
+      return () => {
+        cancelled = true;
+        clearTimeout(t);
+      };
+    },
+  },
+  slow20tps: {
+    description: '20 chars/sec, 2-char chunks. Steady slow stream with paragraph boundaries.',
+    hypothesis: 'Baseline — should animate cleanly if nothing is broken.',
+    label: 'C. 20 TPS baseline',
+    run: (push, done) => {
+      const text =
+        '# Heading C\n\n' +
+        'Short paragraph one with a few words here.\n\n' +
+        'Short paragraph two also with a few words.\n\n' +
+        'Short paragraph three closes the story.\n';
+      let cancelled = false;
+      let pos = 0;
+      (async () => {
+        while (!cancelled && pos < text.length) {
+          const size = Math.min(2, text.length - pos);
+          push(text.slice(pos, pos + size));
+          pos += size;
+          await sleep(100);
+        }
+        if (!cancelled) done();
+      })();
+      return () => {
+        cancelled = true;
+      };
+    },
+  },
+};
+
+const SLOW_MOTION_CSS = `
+[data-repro-slow='1'] .stream-char {
+  animation-duration: 2000ms !important;
+}
+[data-repro-slow='1'] .stream-char-revealed {
+  outline: 1px solid rgba(255, 80, 80, 0.45) !important;
+  background: rgba(255, 80, 80, 0.1) !important;
+}
+`;
+
+const panelStyle: CSSProperties = {
+  background: 'rgba(127, 127, 127, 0.08)',
+  border: '1px solid rgba(127, 127, 127, 0.16)',
+  borderRadius: 8,
+  fontSize: 12,
+  lineHeight: 1.6,
+  padding: 12,
+};
+
+const counterStyle: CSSProperties = {
+  ...panelStyle,
+  display: 'grid',
+  fontFamily: 'monospace',
+  gap: 8,
+  gridTemplateColumns: 'repeat(5, minmax(120px, 1fr))',
+};
+
+export default () => {
+  const [content, setContent] = useState('');
+  const [scenario, setScenario] = useState<Scenario>('largeAppend');
+  const [preset, setPreset] = useState<StreamSmoothingPreset>('balanced');
+  const [slowMotion, setSlowMotion] = useState(true);
+  const [running, setRunning] = useState(false);
+  const [stats, setStats] = useState({
+    animated: 0,
+    revealedLive: 0,
+    skipped: 0,
+    totalLive: 0,
+  });
+  const rootRef = useRef<HTMLDivElement>(null);
+  const cancelRef = useRef<(() => void) | null>(null);
+  const seenRef = useRef<WeakSet<Element>>(new WeakSet());
+  const liveTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const tallyAtBirth = (el: Element) => {
+      if (seenRef.current.has(el)) return;
+      if (!el.classList?.contains('stream-char')) return;
+      seenRef.current.add(el);
+      const skipped = el.classList.contains('stream-char-revealed');
+      setStats((prev) =>
+        skipped ? { ...prev, skipped: prev.skipped + 1 } : { ...prev, animated: prev.animated + 1 },
+      );
+    };
+
+    const observer = new MutationObserver((mutations) => {
+      for (const m of mutations) {
+        for (const node of m.addedNodes) {
+          if (node.nodeType !== 1) continue;
+          const el = node as Element;
+          tallyAtBirth(el);
+          el.querySelectorAll?.('.stream-char').forEach(tallyAtBirth);
+        }
+      }
+    });
+
+    observer.observe(root, { childList: true, subtree: true });
+
+    liveTimerRef.current = setInterval(() => {
+      if (!rootRef.current) return;
+      const total = rootRef.current.querySelectorAll('.stream-char').length;
+      const revealed = rootRef.current.querySelectorAll('.stream-char-revealed').length;
+      setStats((prev) => ({ ...prev, revealedLive: revealed, totalLive: total }));
+    }, 150);
+
+    return () => {
+      observer.disconnect();
+      if (liveTimerRef.current) clearInterval(liveTimerRef.current);
+    };
+  }, []);
+
+  const stop = useCallback(() => {
+    cancelRef.current?.();
+    cancelRef.current = null;
+    setRunning(false);
+  }, []);
+
+  const start = useCallback(() => {
+    stop();
+    seenRef.current = new WeakSet();
+    setStats({ animated: 0, revealedLive: 0, skipped: 0, totalLive: 0 });
+    setContent('');
+    setRunning(true);
+
+    const bootstrap = setTimeout(() => {
+      const push = (chunk: string) => {
+        setContent((prev) => prev + chunk);
+      };
+      const done = () => setRunning(false);
+      cancelRef.current = SCENARIOS[scenario].run(push, done);
+    }, 32);
+
+    cancelRef.current = () => clearTimeout(bootstrap);
+  }, [scenario, stop]);
+
+  useEffect(() => () => cancelRef.current?.(), []);
+
+  const config = SCENARIOS[scenario];
+  const totalAtBirth = stats.animated + stats.skipped;
+  const missRate =
+    totalAtBirth === 0 ? '—' : `${Math.round((stats.skipped / totalAtBirth) * 100)}%`;
+
+  return (
+    <Flexbox gap={12} style={{ padding: 16 }}>
+      <style>{SLOW_MOTION_CSS}</style>
+
+      <Flexbox direction="horizontal" gap={8} wrap="wrap">
+        {(Object.keys(SCENARIOS) as Scenario[]).map((key) => (
+          <Button
+            disabled={running}
+            key={key}
+            type={scenario === key ? 'primary' : 'default'}
+            onClick={() => setScenario(key)}
+          >
+            {SCENARIOS[key].label}
+          </Button>
+        ))}
+      </Flexbox>
+
+      <Flexbox direction="horizontal" gap={8} wrap="wrap">
+        {(['realtime', 'balanced', 'silky'] as StreamSmoothingPreset[]).map((p) => (
+          <Button
+            disabled={running}
+            key={p}
+            type={preset === p ? 'primary' : 'default'}
+            onClick={() => setPreset(p)}
+          >
+            preset: {p}
+          </Button>
+        ))}
+        <Button type={slowMotion ? 'primary' : 'default'} onClick={() => setSlowMotion((v) => !v)}>
+          slow-mo fade {slowMotion ? 'ON' : 'OFF'}
+        </Button>
+        <Button type="primary" onClick={running ? stop : start}>
+          {running ? 'Stop' : 'Reproduce'}
+        </Button>
+      </Flexbox>
+
+      <div style={panelStyle}>
+        <div>
+          <strong>{config.label}</strong>
+        </div>
+        <div style={{ marginTop: 4 }}>{config.description}</div>
+        <div style={{ marginTop: 4, opacity: 0.75 }}>{config.hypothesis}</div>
+        <div style={{ marginTop: 8, opacity: 0.65 }}>
+          Slow-mo mode extends the fadeIn animation to 2000ms and outlines any
+          `.stream-char-revealed` span in red, so chars that skipped the fade are visually obvious.
+        </div>
+      </div>
+
+      <div style={counterStyle}>
+        <span>birth total: {totalAtBirth}</span>
+        <span style={{ color: 'rgb(82, 196, 26)' }}>animated@birth: {stats.animated}</span>
+        <span style={{ color: 'rgb(255, 77, 79)' }}>skipped@birth: {stats.skipped}</span>
+        <span>miss rate: {missRate}</span>
+        <span>
+          live revealed/total: {stats.revealedLive}/{stats.totalLive}
+        </span>
+      </div>
+
+      <div data-repro-slow={slowMotion ? '1' : '0'} ref={rootRef} style={{ minHeight: 200 }}>
+        <Markdown animated streamSmoothingPreset={preset} variant="chat">
+          {content}
+        </Markdown>
+      </div>
+    </Flexbox>
+  );
+};

--- a/src/Markdown/index.md
+++ b/src/Markdown/index.md
@@ -240,6 +240,18 @@ Use this demo to inspect stream-driven React commit frequency, block-level re-re
 
 <code src="./demos/streamingProfiler.tsx" iframe nopadding></code>
 
+### Character Animation Loss Repro
+
+Controlled reproductions for the missing character-by-character fade. Three scenarios target:
+
+- `syncImmediate` fallback when a single append exceeds `largeAppendChars`.
+- Timeline seeding at `latestCharStart` for newly born blocks.
+- 20 TPS input that still skips the fade at every paragraph boundary.
+
+The `skipped` counter tallies `.stream-char` spans that were inserted into the DOM already classed as `.stream-char-revealed` — i.e. the fade was burned before the user could see it.
+
+<code src="./demos/streamingAnimationRepro.tsx" iframe nopadding></code>
+
 ## Custom
 
 ### Markdown Components

--- a/src/Markdown/plugins/rehypeStreamAnimated.ts
+++ b/src/Markdown/plugins/rehypeStreamAnimated.ts
@@ -3,11 +3,10 @@ import { type BuildVisitor } from 'unist-util-visit';
 import { visit } from 'unist-util-visit';
 
 export interface StreamAnimatedOptions {
-  baseCharCount?: number;
-  charDelay?: number;
+  births?: number[];
   fadeDuration?: number;
+  nowMs?: number;
   revealed?: boolean;
-  timelineElapsedMs?: number;
 }
 
 const BLOCK_TAGS = new Set(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li']);
@@ -21,14 +20,8 @@ function hasClass(node: Element, cls: string): boolean {
 }
 
 export const rehypeStreamAnimated = (options: StreamAnimatedOptions = {}) => {
-  const {
-    charDelay = 20,
-    fadeDuration = 150,
-    baseCharCount = 0,
-    revealed = false,
-    timelineElapsedMs,
-  } = options;
-  const hasTimeline = typeof timelineElapsedMs === 'number' && Number.isFinite(timelineElapsedMs);
+  const { births, fadeDuration = 150, nowMs, revealed = false } = options;
+  const hasBirths = !revealed && Array.isArray(births) && typeof nowMs === 'number';
 
   return (tree: Root) => {
     let globalCharIndex = 0;
@@ -42,32 +35,25 @@ export const rehypeStreamAnimated = (options: StreamAnimatedOptions = {}) => {
       for (const child of node.children) {
         if (child.type === 'text') {
           for (const char of child.value) {
-            const relativeIndex = globalCharIndex - baseCharCount;
             let className = 'stream-char';
             let delay: number | undefined;
 
             if (revealed) {
               className = 'stream-char stream-char-revealed';
-            } else if (hasTimeline) {
-              const progress = (timelineElapsedMs as number) - globalCharIndex * charDelay;
-              if (progress >= fadeDuration) {
+            } else if (hasBirths) {
+              const birthTs = births![globalCharIndex];
+              if (birthTs === undefined) {
                 className = 'stream-char stream-char-revealed';
               } else {
-                // Positive delay means "not started yet", negative keeps
-                // the current in-flight progress on rerender.
-                delay = -progress;
-              }
-            } else if (relativeIndex >= 0) {
-              // Newly appended chars start with staggered positive delay.
-              delay = relativeIndex * charDelay;
-            } else {
-              // Previously started chars continue fading with negative delay
-              // instead of being immediately switched to revealed.
-              const elapsed = -relativeIndex * charDelay;
-              if (elapsed >= fadeDuration) {
-                className = 'stream-char stream-char-revealed';
-              } else {
-                delay = -elapsed;
+                const elapsed = (nowMs as number) - birthTs;
+                if (elapsed >= fadeDuration) {
+                  className = 'stream-char stream-char-revealed';
+                } else {
+                  // Negative delay = already elapsed ms into the fade.
+                  // Positive delay = not started yet (char born in the future,
+                  // i.e. staggered within the same commit).
+                  delay = -elapsed;
+                }
               }
             }
 


### PR DESCRIPTION
- Align block animation timing with stream state in StreamdownRender
- Simplify rehypeStreamAnimated and streamAnimationMeta resolution
- Add streaming animation repro demo and doc snippet

Made-with: Cursor
