### PR TITLE
💄 style(highlighter): make code block header sticky with copy button

### DIFF
--- a/src/Highlighter/style.ts
+++ b/src/Highlighter/style.ts
@@ -43,7 +43,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => {
     `,
 
     headerFilled: css`
-      background: transparent;
+      background: ${cssVar.containerBg};
     `,
 
     headerOutlined: css`
@@ -54,7 +54,9 @@ export const styles = createStaticStyles(({ css, cssVar }) => {
 
     headerRoot: css`
       cursor: pointer;
-      position: relative;
+      position: sticky;
+      top: 0;
+      z-index: 3;
       padding: 4px;
     `,
 
@@ -88,7 +90,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => {
       css`
         position: relative;
 
-        overflow: hidden;
+        overflow: clip;
 
         width: 100%;
         border-radius: ${cssVar.borderRadius};


### PR DESCRIPTION
## Summary
- Change root `overflow: hidden` to `overflow: clip` to allow sticky-positioned children to escape the clipping container
- Make code block header `position: sticky; top: 0` so the copy button stays visible when scrolling through long code blocks
- Add container background to header for proper sticky rendering (content doesn't show through)

## Related
- Fixes lobehub/lobehub#6764 (difficult to copy long code blocks)
- Fixes lobehub/lobehub#7129 (floating copy/run button for code blocks)

## Test plan
- [ ] Open a chat with a long code block, scroll down - copy button should remain visible at top
- [ ] Code block border-radius clipping should still work correctly
- [ ] Expand/collapse toggle should still work