### PR TITLE
♻️ refactor(accordion): split context to minimize sibling re-renders

### DIFF
--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -4,10 +4,10 @@ import { Divider } from 'antd';
 import { cx } from 'antd-style';
 import { LayoutGroup } from 'motion/react';
 import { type Key } from 'react';
-import { Children, Fragment, isValidElement, memo, useCallback } from 'react';
+import { Children, Fragment, isValidElement, memo, useCallback, useMemo, useRef } from 'react';
 import useMergeState from 'use-merge-value';
 
-import { AccordionContext } from './context';
+import { AccordionConfigContext, AccordionItemStateProvider } from './context';
 import { styles } from './style';
 import { type AccordionProps } from './type';
 
@@ -47,9 +47,19 @@ const Accordion = memo<AccordionProps>(
       value: expandedKeysProp,
     });
 
+    // Hold expandedKeys and setExpandedKeys via refs so toggleExpand can stay
+    // reference-stable. use-merge-value's setter is recreated on every render,
+    // so depending on it would force AccordionItemStateProvider's memoized
+    // value to change identity each render — even when nothing toggled —
+    // re-rendering every nested AccordionItem via "context changed".
+    const expandedKeysRef = useRef(expandedKeys);
+    expandedKeysRef.current = expandedKeys;
+    const setExpandedKeysRef = useRef(setExpandedKeys);
+    setExpandedKeysRef.current = setExpandedKeys;
+
     const toggleExpand = useCallback(
       (key: Key) => {
-        const prev = expandedKeys;
+        const prev = expandedKeysRef.current;
         let newKeys: Key[];
 
         if (accordion) {
@@ -58,39 +68,46 @@ const Accordion = memo<AccordionProps>(
           newKeys = prev.includes(key) ? prev.filter((k: Key) => k !== key) : [...prev, key];
         }
 
-        setExpandedKeys(newKeys);
+        setExpandedKeysRef.current(newKeys);
       },
-      [accordion, expandedKeys, setExpandedKeys],
+      [accordion],
     );
 
-    const isExpanded = useCallback(
-      (key: Key) => {
-        return expandedKeys.includes(key);
-      },
-      [expandedKeys],
+    const configValue = useMemo(
+      () => ({
+        disableAnimation,
+        hideIndicator,
+        indicatorPlacement,
+        keepContentMounted,
+        motionProps,
+        showDivider,
+        variant,
+      }),
+      [
+        disableAnimation,
+        hideIndicator,
+        indicatorPlacement,
+        keepContentMounted,
+        motionProps,
+        showDivider,
+        variant,
+      ],
     );
-
-    const contextValue = {
-      disableAnimation,
-      expandedKeys,
-      hideIndicator,
-      indicatorPlacement,
-      isExpanded,
-      keepContentMounted,
-      motionProps,
-      onToggle: toggleExpand,
-      showDivider,
-      variant,
-    };
 
     const content = (
       <>
         {validChildren.map((child, index) => {
-          // Extract itemKey from child props to use as React key
-          const childKey = (child.props as any).itemKey || index;
+          const childKey = (child.props as any).itemKey ?? index;
+          const itemIsOpen = expandedKeys.includes(childKey);
           return (
             <Fragment key={childKey}>
-              {child}
+              <AccordionItemStateProvider
+                isOpen={itemIsOpen}
+                itemKey={childKey}
+                onToggleKey={toggleExpand}
+              >
+                {child}
+              </AccordionItemStateProvider>
               {showDivider && index < validChildren.length - 1 && (
                 <Divider className={styles.divider} />
               )}
@@ -101,7 +118,7 @@ const Accordion = memo<AccordionProps>(
     );
 
     return (
-      <AccordionContext value={contextValue}>
+      <AccordionConfigContext value={configValue}>
         <div
           className={cx(styles.base, classNames?.base, userClassName)}
           ref={ref}
@@ -114,7 +131,7 @@ const Accordion = memo<AccordionProps>(
         >
           {disableAnimation ? content : <LayoutGroup>{content}</LayoutGroup>}
         </div>
-      </AccordionContext>
+      </AccordionConfigContext>
     );
   },
 );

--- a/src/Accordion/AccordionItem.tsx
+++ b/src/Accordion/AccordionItem.tsx
@@ -22,7 +22,7 @@ import Text from '@/Text';
 import { stopPropagation } from '@/utils/dom';
 
 import ArrowIcon from './ArrowIcon';
-import { useAccordionContext } from './context';
+import { useAccordionConfig, useAccordionItemState } from './context';
 import { styles } from './style';
 import { type AccordionItemProps } from './type';
 
@@ -186,7 +186,6 @@ AccordionItemContent.displayName = 'AccordionItemContent';
 
 const AccordionItem = memo<AccordionItemProps>(
   ({
-    itemKey,
     title,
     children,
     action,
@@ -208,7 +207,10 @@ const AccordionItem = memo<AccordionItemProps>(
     expand,
     onExpandChange,
   }) => {
-    const context = useAccordionContext();
+    // Per-item state context: only this item's provider re-emits when its
+    // own isOpen flips, so siblings stay stable across toggles.
+    const itemStateContext = useAccordionItemState();
+    const configContext = useAccordionConfig();
 
     // Determine if using standalone mode (has expand or defaultExpand props)
     const isStandalone = expand !== undefined || defaultExpand !== undefined;
@@ -222,15 +224,12 @@ const AccordionItem = memo<AccordionItemProps>(
       },
     );
 
-    // Context values (may be null if used standalone)
-    const contextIsExpanded = context?.isExpanded;
-    const contextOnToggle = context?.onToggle;
-    const contextHideIndicator = context?.hideIndicator;
-    const contextIndicatorPlacement = context?.indicatorPlacement;
-    const contextKeepContentMounted = context?.keepContentMounted;
-    const contextDisableAnimation = context?.disableAnimation;
-    const contextMotionProps = context?.motionProps;
-    const contextVariant = context?.variant ?? 'borderless';
+    const contextHideIndicator = configContext?.hideIndicator;
+    const contextIndicatorPlacement = configContext?.indicatorPlacement;
+    const contextKeepContentMounted = configContext?.keepContentMounted;
+    const contextDisableAnimation = configContext?.disableAnimation;
+    const contextMotionProps = configContext?.motionProps;
+    const contextVariant = configContext?.variant ?? 'borderless';
 
     const isInitialRenderRef = useRef(true);
 
@@ -239,11 +238,7 @@ const AccordionItem = memo<AccordionItemProps>(
     }, []);
 
     // Determine expanded state
-    const isOpen = isStandalone
-      ? isExpandedStandalone
-      : contextIsExpanded
-        ? contextIsExpanded(itemKey)
-        : false;
+    const isOpen = isStandalone ? isExpandedStandalone : (itemStateContext?.isOpen ?? false);
 
     // Determine other props with fallbacks
     const hideIndicatorFinal = itemHideIndicator ?? contextHideIndicator ?? false;
@@ -251,6 +246,8 @@ const AccordionItem = memo<AccordionItemProps>(
     const keepContentMounted = contextKeepContentMounted ?? true;
     const disableAnimation = contextDisableAnimation ?? false;
     const variant = customVariant || contextVariant;
+
+    const contextOnToggle = itemStateContext?.onToggle;
 
     const handleToggle = useCallback(() => {
       // If allowExpand is false, only allow controlled expansion via expand prop
@@ -260,7 +257,7 @@ const AccordionItem = memo<AccordionItemProps>(
         if (isStandalone) {
           setIsExpandedStandalone(!isExpandedStandalone);
         } else if (contextOnToggle) {
-          contextOnToggle(itemKey);
+          contextOnToggle();
         }
       }
     }, [
@@ -270,7 +267,6 @@ const AccordionItem = memo<AccordionItemProps>(
       setIsExpandedStandalone,
       isExpandedStandalone,
       contextOnToggle,
-      itemKey,
     ]);
 
     const handleKeyDown = useCallback(
@@ -381,7 +377,7 @@ const AccordionItem = memo<AccordionItemProps>(
             {action}
           </Flexbox>
         ),
-      [action, alwaysShowAction, cx, styles, classNames?.action, customStyles?.action],
+      [action, alwaysShowAction, classNames?.action, customStyles?.action],
     );
 
     const headerElement = useMemo(() => {

--- a/src/Accordion/context.tsx
+++ b/src/Accordion/context.tsx
@@ -1,21 +1,55 @@
-import type { Key } from 'react';
-import { createContext, use } from 'react';
+import type { Key, ReactNode } from 'react';
+import { createContext, memo, use, useMemo } from 'react';
 
-interface AccordionContextValue {
+interface AccordionItemStateValue {
+  isOpen: boolean;
+  onToggle: () => void;
+}
+
+interface AccordionConfigValue {
   disableAnimation?: boolean;
-  expandedKeys: Key[];
   hideIndicator?: boolean;
   indicatorPlacement?: 'end' | 'start';
-  isExpanded: (key: Key) => boolean;
   keepContentMounted?: boolean;
   motionProps?: any;
-  onToggle: (key: Key) => void;
   showDivider?: boolean;
   variant?: 'filled' | 'outlined' | 'borderless';
 }
 
-export const AccordionContext = createContext<AccordionContextValue | null>(null);
+/**
+ * Per-item context: each AccordionItem gets its own provider, so a toggle
+ * only invalidates the value seen by that single item. Sibling items keep
+ * the same context value identity and skip re-render.
+ */
+export const AccordionItemStateContext = createContext<AccordionItemStateValue | null>(null);
 
-export const useAccordionContext = () => {
-  return use(AccordionContext);
-};
+/**
+ * Static config shared by all items. Identity changes only when the user
+ * changes config props on <Accordion>, which is rare.
+ */
+export const AccordionConfigContext = createContext<AccordionConfigValue | null>(null);
+
+export const useAccordionItemState = () => use(AccordionItemStateContext);
+export const useAccordionConfig = () => use(AccordionConfigContext);
+
+interface AccordionItemStateProviderProps {
+  children: ReactNode;
+  isOpen: boolean;
+  itemKey: Key;
+  onToggleKey: (key: Key) => void;
+}
+
+export const AccordionItemStateProvider = memo<AccordionItemStateProviderProps>(
+  ({ children, isOpen, itemKey, onToggleKey }) => {
+    const value = useMemo(
+      () => ({
+        isOpen,
+        onToggle: () => onToggleKey(itemKey),
+      }),
+      [isOpen, itemKey, onToggleKey],
+    );
+    return <AccordionItemStateContext value={value}>{children}</AccordionItemStateContext>;
+  },
+);
+
+AccordionItemStateProvider.displayName = 'AccordionItemStateProvider';


### PR DESCRIPTION
## Summary

Split single `AccordionContext` into per-item `AccordionItemStateContext` and shared `AccordionConfigContext` so that toggling one item only re-renders that item instead of all siblings.

## Key changes

- **AccordionItemStateProvider** wraps each item with its own memoized context value
- **AccordionConfigContext** holds static config (variant, animation, indicator, etc.) shared across all items
- **toggleExpand** uses refs to stay reference-stable across renders — avoids re-creating the callback when expandedKeys changes
- Removed `isExpanded` callback in favor of per-item `isOpen` boolean value

## Why

Previously, toggling any single AccordionItem would change the `AccordionContext` value, causing every sibling item to re-render. With the split, only the toggled item's context value changes while siblings keep their existing context identity.