### PR TITLE
fix(accordion): support wrapped AccordionItem keys

### DIFF
--- a/src/Accordion/Accordion.test.tsx
+++ b/src/Accordion/Accordion.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { memo, type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import Accordion from './Accordion';
+import AccordionItem from './AccordionItem';
+
+interface WrappedItemProps {
+  children: ReactNode;
+  id: string;
+  title: string;
+}
+
+const WrappedItem = memo<WrappedItemProps>(({ children, id, title }) => (
+  <AccordionItem itemKey={id} title={title}>
+    {children}
+  </AccordionItem>
+));
+
+const getContentRegion = (text: string) => {
+  const region = screen.getByText(text).closest('[role="region"]');
+  expect(region).not.toBeNull();
+  return region as HTMLElement;
+};
+
+describe('Accordion', () => {
+  it('expands wrapped AccordionItem children from controlled expandedKeys', () => {
+    render(
+      <Accordion disableAnimation expandedKeys={['today']}>
+        <WrappedItem id="today" title="Today">
+          Today content
+        </WrappedItem>
+        <WrappedItem id="yesterday" title="Yesterday">
+          Yesterday content
+        </WrappedItem>
+      </Accordion>,
+    );
+
+    expect(getContentRegion('Today content').style.display).toBe('block');
+    expect(getContentRegion('Yesterday content').style.display).toBe('none');
+  });
+
+  it('toggles wrapped AccordionItem children with their own itemKey', () => {
+    const onExpandedChange = vi.fn();
+
+    render(
+      <Accordion disableAnimation defaultExpandedKeys={[]} onExpandedChange={onExpandedChange}>
+        <WrappedItem id="today" title="Today">
+          Today content
+        </WrappedItem>
+      </Accordion>,
+    );
+
+    expect(getContentRegion('Today content').style.display).toBe('none');
+
+    fireEvent.click(screen.getByText('Today'));
+
+    expect(getContentRegion('Today content').style.display).toBe('block');
+    expect(onExpandedChange.mock.lastCall?.[0]).toEqual(['today']);
+  });
+
+  it('keeps wrapped AccordionItem children expanded by default', () => {
+    const onExpandedChange = vi.fn();
+
+    render(
+      <Accordion disableAnimation onExpandedChange={onExpandedChange}>
+        <WrappedItem id="today" title="Today">
+          Today content
+        </WrappedItem>
+      </Accordion>,
+    );
+
+    expect(getContentRegion('Today content').style.display).toBe('block');
+
+    fireEvent.click(screen.getByText('Today'));
+
+    expect(getContentRegion('Today content').style.display).toBe('none');
+    expect(onExpandedChange.mock.lastCall?.[0]).toEqual([]);
+  });
+});

--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -57,6 +57,8 @@ const Accordion = memo<AccordionProps>(
     const setExpandedKeysRef = useRef(setExpandedKeys);
     setExpandedKeysRef.current = setExpandedKeys;
 
+    const isOpenKey = useCallback((key: Key) => expandedKeysRef.current.includes(key), []);
+
     const toggleExpand = useCallback(
       (key: Key) => {
         const prev = expandedKeysRef.current;
@@ -66,6 +68,25 @@ const Accordion = memo<AccordionProps>(
           newKeys = prev.includes(key) ? [] : [key];
         } else {
           newKeys = prev.includes(key) ? prev.filter((k: Key) => k !== key) : [...prev, key];
+        }
+
+        setExpandedKeysRef.current(newKeys);
+      },
+      [accordion],
+    );
+
+    const toggleExpandKeys = useCallback(
+      (keys: Key[], preferredKey: Key) => {
+        const prev = expandedKeysRef.current;
+        const isOpen = keys.some((key) => prev.includes(key));
+        let newKeys: Key[];
+
+        if (accordion) {
+          newKeys = isOpen ? [] : [preferredKey];
+        } else {
+          newKeys = isOpen
+            ? prev.filter((key: Key) => !keys.includes(key))
+            : [...prev, preferredKey];
         }
 
         setExpandedKeysRef.current(newKeys);
@@ -94,17 +115,25 @@ const Accordion = memo<AccordionProps>(
       ],
     );
 
+    const hasExplicitExpandedKeys =
+      expandedKeysProp !== undefined || defaultExpandedKeys !== undefined;
+
     const content = (
       <>
         {validChildren.map((child, index) => {
-          const childKey = (child.props as any).itemKey ?? index;
+          const hasChildItemKey = (child.props as any).itemKey !== undefined;
+          const childKey = hasChildItemKey ? (child.props as any).itemKey : index;
           const itemIsOpen = expandedKeys.includes(childKey);
           return (
             <Fragment key={childKey}>
               <AccordionItemStateProvider
+                expandedKeys={hasChildItemKey ? undefined : expandedKeys}
                 isOpen={itemIsOpen}
+                isOpenKey={isOpenKey}
                 itemKey={childKey}
+                preferProviderKeyForNestedItems={!hasExplicitExpandedKeys}
                 onToggleKey={toggleExpand}
+                onToggleKeys={toggleExpandKeys}
               >
                 {child}
               </AccordionItemStateProvider>

--- a/src/Accordion/AccordionItem.tsx
+++ b/src/Accordion/AccordionItem.tsx
@@ -186,6 +186,7 @@ AccordionItemContent.displayName = 'AccordionItemContent';
 
 const AccordionItem = memo<AccordionItemProps>(
   ({
+    itemKey,
     title,
     children,
     action,
@@ -237,8 +238,17 @@ const AccordionItem = memo<AccordionItemProps>(
       isInitialRenderRef.current = false;
     }, []);
 
+    const isDirectContextItem = itemStateContext?.itemKey === itemKey;
+    const isOpenKey = itemStateContext?.isOpenKey(itemKey) ?? false;
+
     // Determine expanded state
-    const isOpen = isStandalone ? isExpandedStandalone : (itemStateContext?.isOpen ?? false);
+    const isOpen = isStandalone
+      ? isExpandedStandalone
+      : itemStateContext
+        ? isDirectContextItem
+          ? itemStateContext.isOpen
+          : itemStateContext.isOpen || isOpenKey
+        : false;
 
     // Determine other props with fallbacks
     const hideIndicatorFinal = itemHideIndicator ?? contextHideIndicator ?? false;
@@ -247,7 +257,14 @@ const AccordionItem = memo<AccordionItemProps>(
     const disableAnimation = contextDisableAnimation ?? false;
     const variant = customVariant || contextVariant;
 
-    const contextOnToggle = itemStateContext?.onToggle;
+    const contextOnToggle = useCallback(() => {
+      if (!itemStateContext) return;
+      if (itemStateContext.itemKey === itemKey) {
+        itemStateContext.onToggle();
+        return;
+      }
+      itemStateContext.onToggleNestedKey(itemKey);
+    }, [itemStateContext, itemKey]);
 
     const handleToggle = useCallback(() => {
       // If allowExpand is false, only allow controlled expansion via expand prop

--- a/src/Accordion/AccordionItem.tsx
+++ b/src/Accordion/AccordionItem.tsx
@@ -239,16 +239,16 @@ const AccordionItem = memo<AccordionItemProps>(
     }, []);
 
     const isDirectContextItem = itemStateContext?.itemKey === itemKey;
-    const isOpenKey = itemStateContext?.isOpenKey(itemKey) ?? false;
 
     // Determine expanded state
-    const isOpen = isStandalone
-      ? isExpandedStandalone
-      : itemStateContext
-        ? isDirectContextItem
-          ? itemStateContext.isOpen
-          : itemStateContext.isOpen || isOpenKey
-        : false;
+    let isOpen = false;
+    if (isStandalone) {
+      isOpen = isExpandedStandalone;
+    } else if (itemStateContext) {
+      isOpen = isDirectContextItem
+        ? itemStateContext.isOpen
+        : itemStateContext.isOpen || itemStateContext.isOpenKey(itemKey);
+    }
 
     // Determine other props with fallbacks
     const hideIndicatorFinal = itemHideIndicator ?? contextHideIndicator ?? false;

--- a/src/Accordion/context.tsx
+++ b/src/Accordion/context.tsx
@@ -3,7 +3,11 @@ import { createContext, memo, use, useMemo } from 'react';
 
 interface AccordionItemStateValue {
   isOpen: boolean;
+  isOpenKey: (key: Key) => boolean;
+  itemKey: Key;
   onToggle: () => void;
+  onToggleKey: (key: Key) => void;
+  onToggleNestedKey: (key: Key) => void;
 }
 
 interface AccordionConfigValue {
@@ -34,19 +38,47 @@ export const useAccordionConfig = () => use(AccordionConfigContext);
 
 interface AccordionItemStateProviderProps {
   children: ReactNode;
+  // Used only to refresh the memoized context for wrapper children when
+  // controlled expanded keys change; direct children use `isOpen`.
+  expandedKeys?: Key[];
   isOpen: boolean;
+  isOpenKey: (key: Key) => boolean;
   itemKey: Key;
   onToggleKey: (key: Key) => void;
+  onToggleKeys: (keys: Key[], preferredKey: Key) => void;
+  preferProviderKeyForNestedItems: boolean;
 }
 
 export const AccordionItemStateProvider = memo<AccordionItemStateProviderProps>(
-  ({ children, isOpen, itemKey, onToggleKey }) => {
+  ({
+    children,
+    expandedKeys,
+    isOpenKey,
+    isOpen,
+    itemKey,
+    onToggleKey,
+    onToggleKeys,
+    preferProviderKeyForNestedItems,
+  }) => {
     const value = useMemo(
       () => ({
+        isOpenKey,
         isOpen,
+        itemKey,
         onToggle: () => onToggleKey(itemKey),
+        onToggleKey,
+        onToggleNestedKey: (key: Key) =>
+          onToggleKeys([itemKey, key], preferProviderKeyForNestedItems ? itemKey : key),
       }),
-      [isOpen, itemKey, onToggleKey],
+      [
+        expandedKeys,
+        isOpenKey,
+        isOpen,
+        itemKey,
+        onToggleKey,
+        onToggleKeys,
+        preferProviderKeyForNestedItems,
+      ],
     );
     return <AccordionItemStateContext value={value}>{children}</AccordionItemStateContext>;
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,13 +1,19 @@
+import { fileURLToPath } from 'node:url';
+
 import { defineConfig } from 'vitest/config';
 
 import { name } from './package.json';
 
+const srcPath = fileURLToPath(new URL('./src', import.meta.url));
+
 export default defineConfig({
-  test: {
+  resolve: {
     alias: {
-      '@': './src',
-      [name]: './src',
+      '@': srcPath,
+      [name]: srcPath,
     },
+  },
+  test: {
     environment: 'jsdom',
     globals: true,
   },


### PR DESCRIPTION
## Summary

- Restore AccordionItem `itemKey` handling when Accordion children are wrapper components.
- Preserve the direct-child per-item context optimization from the previous Accordion refactor.
- Add regression coverage for controlled `expandedKeys` and toggle behavior with wrapped AccordionItem children.
- Move Vitest aliases to Vite `resolve.alias` so component tests can resolve `@/*` imports.

## Root Cause

The 5.10.1 Accordion refactor reads `itemKey` from immediate children. Wrapper components such as `<GroupItem />` do not expose the inner `<AccordionItem itemKey={id} />`, so Accordion falls back to numeric indexes and controlled keys like `today` or `yesterday` no longer match.

## Validation

- `bunx vitest run src/Accordion/Accordion.test.tsx`
- `bun run type-check`
- `bunx prettier -c src/Accordion/Accordion.test.tsx src/Accordion/Accordion.tsx src/Accordion/AccordionItem.tsx src/Accordion/context.tsx vitest.config.ts`
- Pre-commit hook: `type-check`, `lint:circular`, `lint-staged`