### PR TITLE
:sparkles: feat(scroll-area): support horizontal and both-axis scroll fade

### DIFF
--- a/src/ContextMenu/renderItems.tsx
+++ b/src/ContextMenu/renderItems.tsx
@@ -14,17 +14,17 @@ import common from '@/i18n/resources/en/common';
 import { useTranslation } from '@/i18n/useTranslation';
 import Icon from '@/Icon';
 import {
+  type BaseMenuItemGroupType,
+  type BaseSubMenuType,
   getItemKey,
   getItemLabel,
   hasAnyIcon,
   hasCheckboxAndIcon,
   type MenuDividerType,
-  type MenuItemGroupType,
   type MenuItemType,
   renderIcon,
   type RenderItemContentOptions,
   type RenderOptions,
-  type SubMenuType,
 } from '@/Menu';
 import { preventDefaultAndStopPropagation } from '@/utils/dom';
 
@@ -112,7 +112,7 @@ const ContextMenuSwitchItemInternal = ({
 };
 
 const renderItemContent = (
-  item: MenuItemType | SubMenuType | ContextMenuCheckboxItem | ContextMenuSwitchItem,
+  item: MenuItemType | BaseSubMenuType | ContextMenuCheckboxItem | ContextMenuSwitchItem,
   options?: RenderItemContentOptions,
   iconNode?: ReactNode,
 ) => {
@@ -249,8 +249,8 @@ export const renderContextMenuItems = (
       return <ContextMenu.Separator className={styles.separator} key={itemKey} />;
     }
 
-    if ((item as MenuItemGroupType).type === 'group') {
-      const group = item as MenuItemGroupType;
+    if ((item as BaseMenuItemGroupType).type === 'group') {
+      const group = item as BaseMenuItemGroupType;
       const groupReserveIconSpace =
         iconSpaceMode === 'group'
           ? group.children
@@ -278,20 +278,30 @@ export const renderContextMenuItems = (
     }
 
     if (
-      (item as SubMenuType).type === 'submenu' ||
-      ('children' in item && (item as SubMenuType).children)
+      (item as BaseSubMenuType).type === 'submenu' ||
+      ('children' in item && (item as BaseSubMenuType).children)
     ) {
-      const submenu = item as SubMenuType;
+      const submenu = item as BaseSubMenuType;
       const label = getItemLabel(submenu);
       const labelText = typeof label === 'string' ? label : undefined;
       const isDanger = 'danger' in submenu && Boolean(submenu.danger);
 
       return (
-        <ContextMenu.SubmenuRoot key={itemKey}>
+        <ContextMenu.SubmenuRoot
+          defaultOpen={submenu.defaultOpen}
+          key={itemKey}
+          open={submenu.open}
+          onOpenChange={submenu.onOpenChange}
+        >
           <ContextMenu.SubmenuTrigger
+            {...submenu.triggerProps}
             className={cx(styles.item, isDanger && styles.danger)}
+            closeDelay={submenu.closeDelay}
+            delay={submenu.delay}
             disabled={submenu.disabled}
             label={labelText}
+            openOnHover={submenu.openOnHover}
+            onClick={submenu.onClick}
           >
             {renderItemContent(submenu, {
               iconAlign,

--- a/src/DropdownMenu/renderItems.tsx
+++ b/src/DropdownMenu/renderItems.tsx
@@ -7,17 +7,17 @@ import {
 } from 'react';
 
 import {
+  type BaseMenuItemGroupType,
+  type BaseSubMenuType,
   getItemKey,
   getItemLabel,
   hasAnyIcon,
   hasCheckboxAndIcon,
   type MenuDividerType,
-  type MenuItemGroupType,
   type MenuItemType,
   renderIcon,
   type RenderItemContentOptions,
   type RenderOptions,
-  type SubMenuType,
 } from '@/Menu';
 import { styles } from '@/Menu/sharedStyle';
 
@@ -51,7 +51,7 @@ import {
 export type { IconAlign, IconSpaceMode } from '@/Menu';
 
 const renderItemContent = (
-  item: MenuItemType | SubMenuType | DropdownMenuCheckboxItemType | DropdownMenuSwitchItemType,
+  item: MenuItemType | BaseSubMenuType | DropdownMenuCheckboxItemType | DropdownMenuSwitchItemType,
   options?: RenderItemContentOptions,
   iconNode?: ReactNode,
 ) => {
@@ -187,8 +187,8 @@ export const renderDropdownMenuItems = (
       return <DropdownMenuSeparator key={itemKey} />;
     }
 
-    if ((item as MenuItemGroupType).type === 'group') {
-      const group = item as MenuItemGroupType;
+    if ((item as BaseMenuItemGroupType).type === 'group') {
+      const group = item as BaseMenuItemGroupType;
       const groupReserveIconSpace =
         iconSpaceMode === 'group'
           ? group.children
@@ -211,18 +211,28 @@ export const renderDropdownMenuItems = (
       );
     }
 
-    if ((item as SubMenuType).type === 'submenu' || 'children' in item) {
-      const submenu = item as SubMenuType;
+    if ((item as BaseSubMenuType).type === 'submenu' || 'children' in item) {
+      const submenu = item as BaseSubMenuType;
       const label = getItemLabel(submenu);
       const labelText = typeof label === 'string' ? label : undefined;
       const isDanger = 'danger' in submenu && Boolean(submenu.danger);
 
       return (
-        <DropdownMenuSubmenuRoot key={itemKey}>
+        <DropdownMenuSubmenuRoot
+          defaultOpen={submenu.defaultOpen}
+          key={itemKey}
+          open={submenu.open}
+          onOpenChange={submenu.onOpenChange}
+        >
           <DropdownMenuSubmenuTrigger
+            {...submenu.triggerProps}
+            closeDelay={submenu.closeDelay}
             danger={isDanger}
+            delay={submenu.delay}
             disabled={submenu.disabled}
             label={labelText}
+            openOnHover={submenu.openOnHover}
+            onClick={submenu.onClick}
           >
             {renderItemContent(submenu, {
               iconAlign,

--- a/src/Menu/baseItem.ts
+++ b/src/Menu/baseItem.ts
@@ -1,4 +1,7 @@
-import type { Key, ReactNode } from 'react';
+import type { MenuSubmenuRoot } from '@base-ui/react/menu';
+import type { ComponentPropsWithRef, Key, MouseEventHandler, ReactNode } from 'react';
+
+import type { IconProps } from '@/Icon';
 
 import type { MenuCheckboxItemType } from './checkboxItem';
 import type { MenuSwitchItemType } from './switchItem';
@@ -17,10 +20,36 @@ export interface BaseMenuItemGroupType {
 
 /**
  * Submenu type for Base UI driven menus (DropdownMenu / ContextMenu).
- * Unlike SubMenuType, this supports checkbox/switch items in children.
+ * Unlike rc-menu's SubMenuType, this maps to @base-ui's Menu.SubmenuRoot + Menu.SubmenuTrigger.
  */
-export interface BaseSubMenuType extends Omit<SubMenuType, 'children'> {
+export interface BaseSubMenuType {
   children?: BaseMenuItemType[];
+  /** Hover-close delay in ms. Requires `openOnHover`. */
+  closeDelay?: number;
+  danger?: boolean;
+  /** Initial open state when uncontrolled. */
+  defaultOpen?: boolean;
+  /** Hover-open delay in ms. Requires `openOnHover`. */
+  delay?: number;
+  desc?: ReactNode;
+  disabled?: boolean;
+  icon?: IconProps['icon'];
+  key?: Key;
+  label?: ReactNode;
+  /** Click handler on the trigger. */
+  onClick?: MouseEventHandler<HTMLElement>;
+  /** Fired when the submenu opens or closes. */
+  onOpenChange?: (open: boolean, eventDetails: MenuSubmenuRoot.ChangeEventDetails) => void;
+  /** Controlled open state of the submenu. */
+  open?: boolean;
+  /** Open the submenu when the trigger is hovered. */
+  openOnHover?: boolean;
+  /**
+   * Extra DOM props spread onto the trigger element.
+   * Use for `ref`, `id`, `style`, `data-*`, `aria-*`, mouse/focus events, etc.
+   */
+  triggerProps?: ComponentPropsWithRef<'div'>;
+  type?: 'submenu';
 }
 
 /**
@@ -32,6 +61,8 @@ export interface BaseSubMenuType extends Omit<SubMenuType, 'children'> {
 export type BaseMenuItemType =
   | MenuItemType
   | BaseSubMenuType
+  // Backward-compat: rc-menu's SubMenuType is still accepted for consumers that build items with rc-menu types.
+  | SubMenuType
   | BaseMenuItemGroupType
   | MenuDividerType
   | MenuCheckboxItemType

--- a/src/ScrollArea/atoms.tsx
+++ b/src/ScrollArea/atoms.tsx
@@ -16,12 +16,21 @@ const mergeStateClassName = <TState,>(
 };
 
 export type ScrollAreaRootProps = React.ComponentProps<typeof BaseScrollArea.Root>;
+
+export type ScrollAreaFadeOrientation = 'vertical' | 'horizontal' | 'both';
+
 export type ScrollAreaViewportProps = React.ComponentProps<typeof BaseScrollArea.Viewport> & {
   /**
    * Enable gradient scroll fade on the viewport edges.
+   *
+   * - `true` / `'vertical'`: fade top and bottom edges.
+   * - `'horizontal'`: fade start and end edges.
+   * - `'both'`: fade all four edges (combined via `mask-composite: intersect`).
+   * - `false`: no fade.
+   *
    * @default false
    */
-  scrollFade?: boolean;
+  scrollFade?: boolean | ScrollAreaFadeOrientation;
 };
 export type ScrollAreaContentProps = React.ComponentProps<typeof BaseScrollArea.Content>;
 export type ScrollAreaScrollbarProps = React.ComponentProps<typeof BaseScrollArea.Scrollbar>;
@@ -36,6 +45,16 @@ export const ScrollAreaRoot = ({ className, ...rest }: ScrollAreaRootProps) => {
 
 ScrollAreaRoot.displayName = 'ScrollAreaRoot';
 
+const resolveFadeClass = (
+  scrollFade: ScrollAreaViewportProps['scrollFade'],
+): string | undefined => {
+  if (!scrollFade) return undefined;
+  const orientation: ScrollAreaFadeOrientation = scrollFade === true ? 'vertical' : scrollFade;
+  if (orientation === 'horizontal') return styles.viewportFadeHorizontal;
+  if (orientation === 'both') return styles.viewportFadeBoth;
+  return styles.viewportFade;
+};
+
 export const ScrollAreaViewport = ({
   className,
   scrollFade = false,
@@ -47,10 +66,7 @@ export const ScrollAreaViewport = ({
       <BaseScrollArea.Viewport
         {...rest}
         className={
-          mergeStateClassName(
-            cx(styles.viewport, scrollFade && styles.viewportFade),
-            className,
-          ) as any
+          mergeStateClassName(cx(styles.viewport, resolveFadeClass(scrollFade)), className) as any
         }
       />
     </>

--- a/src/ScrollArea/demos/fade-both.tsx
+++ b/src/ScrollArea/demos/fade-both.tsx
@@ -1,0 +1,63 @@
+import {
+  ScrollAreaContent,
+  ScrollAreaCorner,
+  ScrollAreaRoot,
+  ScrollAreaScrollbar,
+  ScrollAreaThumb,
+  ScrollAreaViewport,
+} from '@lobehub/ui';
+
+const items = Array.from({ length: 64 }, (_, index) => index + 1);
+
+export default () => {
+  return (
+    <ScrollAreaRoot
+      style={{
+        height: 240,
+        maxWidth: 'calc(100vw - 8rem)',
+        width: '100%',
+      }}
+    >
+      <ScrollAreaViewport scrollFade="both">
+        <ScrollAreaContent style={{ padding: 16 }}>
+          <ul
+            style={{
+              display: 'grid',
+              gap: 12,
+              gridTemplateColumns: 'repeat(8, 6rem)',
+              gridTemplateRows: 'repeat(8, 6rem)',
+              listStyle: 'none',
+              margin: 0,
+              padding: 0,
+            }}
+          >
+            {items.map((item) => (
+              <li
+                key={item}
+                style={{
+                  alignItems: 'center',
+                  background: 'var(--lobe-color-fill-tertiary)',
+                  borderRadius: 8,
+                  color: 'var(--lobe-color-text-secondary)',
+                  display: 'flex',
+                  fontSize: 14,
+                  fontWeight: 500,
+                  justifyContent: 'center',
+                }}
+              >
+                {item}
+              </li>
+            ))}
+          </ul>
+        </ScrollAreaContent>
+      </ScrollAreaViewport>
+      <ScrollAreaScrollbar>
+        <ScrollAreaThumb />
+      </ScrollAreaScrollbar>
+      <ScrollAreaScrollbar orientation="horizontal">
+        <ScrollAreaThumb />
+      </ScrollAreaScrollbar>
+      <ScrollAreaCorner />
+    </ScrollAreaRoot>
+  );
+};

--- a/src/ScrollArea/demos/horizontal.tsx
+++ b/src/ScrollArea/demos/horizontal.tsx
@@ -1,0 +1,58 @@
+import { ScrollArea } from '@lobehub/ui';
+
+const tags = [
+  'Vernacular',
+  'Architecture',
+  'Vitruvius',
+  'De architectura',
+  'Sustainable design',
+  'Energy conscious',
+  'Local traditions',
+  'Cultural practices',
+  'Folk building',
+  'Indigenous design',
+  'Climate-responsive',
+  'Material literacy',
+];
+
+export default () => {
+  return (
+    <ScrollArea
+      scrollFade="horizontal"
+      scrollbarProps={{ orientation: 'horizontal' }}
+      contentProps={{
+        style: {
+          alignItems: 'center',
+          display: 'flex',
+          flexDirection: 'row',
+          gap: 8,
+          padding: 16,
+          width: 'max-content',
+        },
+      }}
+      style={{
+        height: 80,
+        maxWidth: 'calc(100vw - 8rem)',
+        width: '100%',
+      }}
+    >
+      {tags.map((tag) => (
+        <span
+          key={tag}
+          style={{
+            background: 'var(--lobe-color-fill-tertiary)',
+            borderRadius: 999,
+            color: 'var(--lobe-color-text-secondary)',
+            flexShrink: 0,
+            fontSize: 13,
+            fontWeight: 500,
+            padding: '6px 12px',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {tag}
+        </span>
+      ))}
+    </ScrollArea>
+  );
+};

--- a/src/ScrollArea/demos/horizontal.tsx
+++ b/src/ScrollArea/demos/horizontal.tsx
@@ -26,12 +26,13 @@ export default () => {
           display: 'flex',
           flexDirection: 'row',
           gap: 8,
-          padding: 16,
+          paddingBlock: 8,
+          paddingInline: 12,
           width: 'max-content',
         },
       }}
       style={{
-        height: 80,
+        height: 48,
         maxWidth: 'calc(100vw - 8rem)',
         width: '100%',
       }}
@@ -46,7 +47,7 @@ export default () => {
             flexShrink: 0,
             fontSize: 13,
             fontWeight: 500,
-            padding: '6px 12px',
+            padding: '4px 12px',
             whiteSpace: 'nowrap',
           }}
         >

--- a/src/ScrollArea/index.md
+++ b/src/ScrollArea/index.md
@@ -13,9 +13,24 @@ description: A native scroll container with custom scrollbars and gradient scrol
 
 <code src="./demos/background.tsx" nopadding></code>
 
+## Horizontal fade
+
+Set `scrollFade="horizontal"` to mask the start and end edges of a horizontally
+scrolled viewport (tab strips, chip lists, etc.).
+
+<code src="./demos/horizontal.tsx" nopadding></code>
+
 ## Both scrollbars
 
 <code src="./demos/both.tsx" nopadding></code>
+
+## Fade in both directions
+
+Set `scrollFade="both"` to mask every edge that overflows. Vertical and
+horizontal gradient masks are combined via `mask-composite: intersect`, so the
+four corners only fade when both axes overflow.
+
+<code src="./demos/fade-both.tsx" nopadding></code>
 
 ## Usage
 
@@ -117,15 +132,15 @@ ScrollArea is built on top of Base UI Scroll Area and exposes the same primitive
 
 Composed scroll area with defaults for viewport, content, scrollbar, and thumb.
 
-| Prop           | Type                                                        | Default | Description                                        |
-| -------------- | ----------------------------------------------------------- | ------- | -------------------------------------------------- |
-| scrollFade     | `boolean`                                                   | `false` | Enable gradient scroll fade on the viewport edges. |
-| contentProps   | `Omit<ScrollAreaContentProps, 'children'>`                  | -       | Props passed to `ScrollAreaContent`.               |
-| corner         | `boolean`                                                   | `false` | Whether to render the corner.                      |
-| cornerProps    | `ScrollAreaCornerProps`                                     | -       | Props passed to `ScrollAreaCorner`.                |
-| scrollbarProps | `Omit<ScrollAreaScrollbarProps, 'children'>`                | -       | Props passed to `ScrollAreaScrollbar`.             |
-| thumbProps     | `ScrollAreaThumbProps`                                      | -       | Props passed to `ScrollAreaThumb`.                 |
-| viewportProps  | `Omit<ScrollAreaViewportProps, 'children' \| 'scrollFade'>` | -       | Props passed to `ScrollAreaViewport`.              |
+| Prop           | Type                                                        | Default | Description                                                                                                          |
+| -------------- | ----------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------- |
+| scrollFade     | `boolean \| 'vertical' \| 'horizontal' \| 'both'`           | `false` | Enable gradient scroll fade on the viewport edges. `true` ≡ `'vertical'`. `'both'` intersects vertical + horizontal. |
+| contentProps   | `Omit<ScrollAreaContentProps, 'children'>`                  | -       | Props passed to `ScrollAreaContent`.                                                                                 |
+| corner         | `boolean`                                                   | `false` | Whether to render the corner.                                                                                        |
+| cornerProps    | `ScrollAreaCornerProps`                                     | -       | Props passed to `ScrollAreaCorner`.                                                                                  |
+| scrollbarProps | `Omit<ScrollAreaScrollbarProps, 'children'>`                | -       | Props passed to `ScrollAreaScrollbar`.                                                                               |
+| thumbProps     | `ScrollAreaThumbProps`                                      | -       | Props passed to `ScrollAreaThumb`.                                                                                   |
+| viewportProps  | `Omit<ScrollAreaViewportProps, 'children' \| 'scrollFade'>` | -       | Props passed to `ScrollAreaViewport`.                                                                                |
 
 ### Root
 
@@ -164,12 +179,12 @@ The actual scrollable container of the scroll area. Renders a `div` element.
 
 **Viewport Props:**
 
-| Prop       | Type                                                                                     | Default | Description                                                                                        |
-| ---------- | ---------------------------------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------- |
-| scrollFade | `boolean`                                                                                | `false` | Enable gradient scroll fade on the viewport edges.                                                 |
-| className  | `string \| ((state: ScrollArea.Viewport.State) => string \| undefined)`                  | -       | CSS class applied to the element, or a function that returns a class based on the component state. |
-| style      | `CSSProperties \| ((state: ScrollArea.Viewport.State) => CSSProperties \| undefined)`    | -       | Inline styles for the viewport element.                                                            |
-| render     | `ReactElement \| ((props: HTMLProps, state: ScrollArea.Viewport.State) => ReactElement)` | -       | Replace the component element with a different tag or compose it with another component.           |
+| Prop       | Type                                                                                     | Default | Description                                                                                                          |
+| ---------- | ---------------------------------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------- |
+| scrollFade | `boolean \| 'vertical' \| 'horizontal' \| 'both'`                                        | `false` | Enable gradient scroll fade on the viewport edges. `true` ≡ `'vertical'`. `'both'` intersects vertical + horizontal. |
+| className  | `string \| ((state: ScrollArea.Viewport.State) => string \| undefined)`                  | -       | CSS class applied to the element, or a function that returns a class based on the component state.                   |
+| style      | `CSSProperties \| ((state: ScrollArea.Viewport.State) => CSSProperties \| undefined)`    | -       | Inline styles for the viewport element.                                                                              |
+| render     | `ReactElement \| ((props: HTMLProps, state: ScrollArea.Viewport.State) => ReactElement)` | -       | Replace the component element with a different tag or compose it with another component.                             |
 
 **Viewport Data Attributes:**
 

--- a/src/ScrollArea/style.ts
+++ b/src/ScrollArea/style.ts
@@ -25,11 +25,6 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   scrollbar: css`
     pointer-events: none;
 
-    position: relative;
-
-    display: flex;
-    justify-content: center;
-
     margin: 8px;
     border-radius: ${cssVar.borderRadiusSM};
 

--- a/src/ScrollArea/style.ts
+++ b/src/ScrollArea/style.ts
@@ -73,6 +73,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
 
   thumb: css`
     width: 100%;
+    height: 100%;
     border-radius: inherit;
     background: ${cssVar.colorTextQuaternary};
   `,

--- a/src/ScrollArea/style.ts
+++ b/src/ScrollArea/style.ts
@@ -154,4 +154,172 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
         calc(100% - var(--lobe-scroll-area-fade-size)) 100%;
     }
   `,
+
+  viewportFadeHorizontal: css`
+    --scroll-area-overflow-x-start: inherit;
+    --scroll-area-overflow-x-end: inherit;
+    --lobe-scroll-area-fade-size: 40px;
+    --lobe-scroll-area-fade-left: min(
+      var(--lobe-scroll-area-fade-size),
+      var(--scroll-area-overflow-x-start, 0px)
+    );
+    --lobe-scroll-area-fade-right: min(
+      var(--lobe-scroll-area-fade-size),
+      var(--scroll-area-overflow-x-end, 0px)
+    );
+
+    /* Fade the CONTENT via mask, so it works on background images too. */
+    mask-image: linear-gradient(
+      to right,
+      transparent 0,
+      #000 var(--lobe-scroll-area-fade-left),
+      #000 calc(100% - var(--lobe-scroll-area-fade-right)),
+      transparent 100%
+    );
+    mask-repeat: no-repeat;
+    mask-size: 100% 100%;
+
+    /* Scroll-driven animation: use scroll position to drive the mask. */
+    @supports (animation-timeline: scroll()) {
+      /*
+       * Important: drive fade by *distance to edges* (first/last 40px),
+       * so reaching start/end doesn't cause a sudden snap.
+       */
+      @keyframes lobe-scroll-area-fade-left-in {
+        from {
+          --lobe-scroll-area-fade-left: 0;
+        }
+
+        to {
+          --lobe-scroll-area-fade-left: var(--lobe-scroll-area-fade-size);
+        }
+      }
+
+      @keyframes lobe-scroll-area-fade-right-out {
+        from {
+          --lobe-scroll-area-fade-right: var(--lobe-scroll-area-fade-size);
+        }
+
+        to {
+          --lobe-scroll-area-fade-right: 0;
+        }
+      }
+
+      animation-name: lobe-scroll-area-fade-left-in, lobe-scroll-area-fade-right-out;
+      animation-duration: 1ms, 1ms;
+      animation-timing-function: linear, linear;
+      animation-fill-mode: both, both;
+      animation-timeline: scroll(self x), scroll(self x);
+
+      animation-range:
+        0 var(--lobe-scroll-area-fade-size),
+        calc(100% - var(--lobe-scroll-area-fade-size)) 100%;
+    }
+  `,
+
+  viewportFadeBoth: css`
+    --scroll-area-overflow-x-start: inherit;
+    --scroll-area-overflow-x-end: inherit;
+    --scroll-area-overflow-y-start: inherit;
+    --scroll-area-overflow-y-end: inherit;
+    --lobe-scroll-area-fade-size: 40px;
+    --lobe-scroll-area-fade-top: min(
+      var(--lobe-scroll-area-fade-size),
+      var(--scroll-area-overflow-y-start, 0px)
+    );
+    --lobe-scroll-area-fade-bottom: min(
+      var(--lobe-scroll-area-fade-size),
+      var(--scroll-area-overflow-y-end, 0px)
+    );
+    --lobe-scroll-area-fade-left: min(
+      var(--lobe-scroll-area-fade-size),
+      var(--scroll-area-overflow-x-start, 0px)
+    );
+    --lobe-scroll-area-fade-right: min(
+      var(--lobe-scroll-area-fade-size),
+      var(--scroll-area-overflow-x-end, 0px)
+    );
+
+    mask-composite: intersect;
+
+    /*
+     * Combine vertical + horizontal fades by intersecting two gradient masks
+     * so the four corners stay transparent only when both axes overflow.
+     */
+    mask-image:
+      linear-gradient(
+        to bottom,
+        transparent 0,
+        #000 var(--lobe-scroll-area-fade-top),
+        #000 calc(100% - var(--lobe-scroll-area-fade-bottom)),
+        transparent 100%
+      ),
+      linear-gradient(
+        to right,
+        transparent 0,
+        #000 var(--lobe-scroll-area-fade-left),
+        #000 calc(100% - var(--lobe-scroll-area-fade-right)),
+        transparent 100%
+      );
+    mask-repeat: no-repeat, no-repeat;
+    mask-size:
+      100% 100%,
+      100% 100%;
+
+    @supports (animation-timeline: scroll()) {
+      @keyframes lobe-scroll-area-fade-top-in-both {
+        from {
+          --lobe-scroll-area-fade-top: 0;
+        }
+
+        to {
+          --lobe-scroll-area-fade-top: var(--lobe-scroll-area-fade-size);
+        }
+      }
+
+      @keyframes lobe-scroll-area-fade-bottom-out-both {
+        from {
+          --lobe-scroll-area-fade-bottom: var(--lobe-scroll-area-fade-size);
+        }
+
+        to {
+          --lobe-scroll-area-fade-bottom: 0;
+        }
+      }
+
+      @keyframes lobe-scroll-area-fade-left-in-both {
+        from {
+          --lobe-scroll-area-fade-left: 0;
+        }
+
+        to {
+          --lobe-scroll-area-fade-left: var(--lobe-scroll-area-fade-size);
+        }
+      }
+
+      @keyframes lobe-scroll-area-fade-right-out-both {
+        from {
+          --lobe-scroll-area-fade-right: var(--lobe-scroll-area-fade-size);
+        }
+
+        to {
+          --lobe-scroll-area-fade-right: 0;
+        }
+      }
+
+      animation-name:
+        lobe-scroll-area-fade-top-in-both, lobe-scroll-area-fade-bottom-out-both,
+        lobe-scroll-area-fade-left-in-both, lobe-scroll-area-fade-right-out-both;
+      animation-duration: 1ms, 1ms, 1ms, 1ms;
+      animation-timing-function: linear, linear, linear, linear;
+      animation-fill-mode: both, both, both, both;
+      animation-timeline: scroll(self y), scroll(self y), scroll(self x), scroll(self x);
+
+      animation-range:
+        0 var(--lobe-scroll-area-fade-size),
+        calc(100% - var(--lobe-scroll-area-fade-size)) 100%,
+        0 var(--lobe-scroll-area-fade-size),
+        calc(100% - var(--lobe-scroll-area-fade-size)) 100%;
+    }
+  `,
 }));

--- a/src/ScrollArea/type.ts
+++ b/src/ScrollArea/type.ts
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import type {
   ScrollAreaContentProps,
   ScrollAreaCornerProps,
+  ScrollAreaFadeOrientation,
   ScrollAreaRootProps,
   ScrollAreaScrollbarProps,
   ScrollAreaThumbProps,
@@ -15,7 +16,15 @@ export interface ScrollAreaProps extends Omit<ScrollAreaRootProps, 'children'> {
   corner?: boolean;
   cornerProps?: ScrollAreaCornerProps;
   scrollbarProps?: Omit<ScrollAreaScrollbarProps, 'children'>;
-  scrollFade?: boolean;
+  /**
+   * Enable gradient scroll fade on the viewport edges.
+   *
+   * Accepts a boolean (true ≡ vertical) or an explicit orientation:
+   * `'vertical' | 'horizontal' | 'both'`.
+   *
+   * @default false
+   */
+  scrollFade?: boolean | ScrollAreaFadeOrientation;
   thumbProps?: ScrollAreaThumbProps;
   viewportProps?: Omit<ScrollAreaViewportProps, 'children' | 'scrollFade'>;
 }

--- a/src/base-ui/ContextMenu/renderItems.tsx
+++ b/src/base-ui/ContextMenu/renderItems.tsx
@@ -14,17 +14,17 @@ import common from '@/i18n/resources/en/common';
 import { useTranslation } from '@/i18n/useTranslation';
 import Icon from '@/Icon';
 import {
+  type BaseMenuItemGroupType,
+  type BaseSubMenuType,
   getItemKey,
   getItemLabel,
   hasAnyIcon,
   hasCheckboxAndIcon,
   type MenuDividerType,
-  type MenuItemGroupType,
   type MenuItemType,
   renderIcon,
   type RenderItemContentOptions,
   type RenderOptions,
-  type SubMenuType,
 } from '@/Menu';
 import { styles } from '@/Menu/sharedStyle';
 import { preventDefaultAndStopPropagation } from '@/utils/dom';
@@ -117,7 +117,7 @@ const ContextMenuSwitchItemInternal = ({
 };
 
 const renderItemContent = (
-  item: MenuItemType | SubMenuType | ContextMenuCheckboxItem | ContextMenuSwitchItem,
+  item: MenuItemType | BaseSubMenuType | ContextMenuCheckboxItem | ContextMenuSwitchItem,
   options?: RenderItemContentOptions,
   iconNode?: ReactNode,
 ) => {
@@ -254,8 +254,8 @@ export const renderContextMenuItems = (
       return <ContextMenu.Separator className={styles.separator} key={itemKey} />;
     }
 
-    if ((item as MenuItemGroupType).type === 'group') {
-      const group = item as MenuItemGroupType;
+    if ((item as BaseMenuItemGroupType).type === 'group') {
+      const group = item as BaseMenuItemGroupType;
       const groupReserveIconSpace =
         iconSpaceMode === 'group'
           ? group.children
@@ -283,20 +283,30 @@ export const renderContextMenuItems = (
     }
 
     if (
-      (item as SubMenuType).type === 'submenu' ||
-      ('children' in item && (item as SubMenuType).children)
+      (item as BaseSubMenuType).type === 'submenu' ||
+      ('children' in item && (item as BaseSubMenuType).children)
     ) {
-      const submenu = item as SubMenuType;
+      const submenu = item as BaseSubMenuType;
       const label = getItemLabel(submenu);
       const labelText = typeof label === 'string' ? label : undefined;
       const isDanger = 'danger' in submenu && Boolean(submenu.danger);
 
       return (
-        <ContextMenu.SubmenuRoot key={itemKey}>
+        <ContextMenu.SubmenuRoot
+          defaultOpen={submenu.defaultOpen}
+          key={itemKey}
+          open={submenu.open}
+          onOpenChange={submenu.onOpenChange}
+        >
           <ContextMenu.SubmenuTrigger
+            {...submenu.triggerProps}
             className={cx(styles.item, isDanger && styles.danger)}
+            closeDelay={submenu.closeDelay}
+            delay={submenu.delay}
             disabled={submenu.disabled}
             label={labelText}
+            openOnHover={submenu.openOnHover}
+            onClick={submenu.onClick}
           >
             {renderItemContent(submenu, {
               iconAlign,

--- a/src/base-ui/DropdownMenu/renderItems.tsx
+++ b/src/base-ui/DropdownMenu/renderItems.tsx
@@ -7,17 +7,17 @@ import {
 } from 'react';
 
 import {
+  type BaseMenuItemGroupType,
+  type BaseSubMenuType,
   getItemKey,
   getItemLabel,
   hasAnyIcon,
   hasCheckboxAndIcon,
   type MenuDividerType,
-  type MenuItemGroupType,
   type MenuItemType,
   renderIcon,
   type RenderItemContentOptions,
   type RenderOptions,
-  type SubMenuType,
 } from '@/Menu';
 import { styles } from '@/Menu/sharedStyle';
 
@@ -51,7 +51,7 @@ import {
 export type { IconAlign, IconSpaceMode } from '@/Menu';
 
 const renderItemContent = (
-  item: MenuItemType | SubMenuType | DropdownMenuCheckboxItemType | DropdownMenuSwitchItemType,
+  item: MenuItemType | BaseSubMenuType | DropdownMenuCheckboxItemType | DropdownMenuSwitchItemType,
   options?: RenderItemContentOptions,
   iconNode?: ReactNode,
 ) => {
@@ -187,8 +187,8 @@ export const renderDropdownMenuItems = (
       return <DropdownMenuSeparator key={itemKey} />;
     }
 
-    if ((item as MenuItemGroupType).type === 'group') {
-      const group = item as MenuItemGroupType;
+    if ((item as BaseMenuItemGroupType).type === 'group') {
+      const group = item as BaseMenuItemGroupType;
       const groupReserveIconSpace =
         iconSpaceMode === 'group'
           ? group.children
@@ -211,18 +211,28 @@ export const renderDropdownMenuItems = (
       );
     }
 
-    if ((item as SubMenuType).type === 'submenu' || 'children' in item) {
-      const submenu = item as SubMenuType;
+    if ((item as BaseSubMenuType).type === 'submenu' || 'children' in item) {
+      const submenu = item as BaseSubMenuType;
       const label = getItemLabel(submenu);
       const labelText = typeof label === 'string' ? label : undefined;
       const isDanger = 'danger' in submenu && Boolean(submenu.danger);
 
       return (
-        <DropdownMenuSubmenuRoot key={itemKey}>
+        <DropdownMenuSubmenuRoot
+          defaultOpen={submenu.defaultOpen}
+          key={itemKey}
+          open={submenu.open}
+          onOpenChange={submenu.onOpenChange}
+        >
           <DropdownMenuSubmenuTrigger
+            {...submenu.triggerProps}
+            closeDelay={submenu.closeDelay}
             danger={isDanger}
+            delay={submenu.delay}
             disabled={submenu.disabled}
             label={labelText}
+            openOnHover={submenu.openOnHover}
+            onClick={submenu.onClick}
           >
             {renderItemContent(submenu, {
               iconAlign,

--- a/src/base-ui/ScrollArea/atoms.tsx
+++ b/src/base-ui/ScrollArea/atoms.tsx
@@ -16,12 +16,21 @@ const mergeStateClassName = <TState,>(
 };
 
 export type ScrollAreaRootProps = React.ComponentProps<typeof BaseScrollArea.Root>;
+
+export type ScrollAreaFadeOrientation = 'vertical' | 'horizontal' | 'both';
+
 export type ScrollAreaViewportProps = React.ComponentProps<typeof BaseScrollArea.Viewport> & {
   /**
    * Enable gradient scroll fade on the viewport edges.
+   *
+   * - `true` / `'vertical'`: fade top and bottom edges.
+   * - `'horizontal'`: fade start and end edges.
+   * - `'both'`: fade all four edges (combined via `mask-composite: intersect`).
+   * - `false`: no fade.
+   *
    * @default false
    */
-  scrollFade?: boolean;
+  scrollFade?: boolean | ScrollAreaFadeOrientation;
 };
 export type ScrollAreaContentProps = React.ComponentProps<typeof BaseScrollArea.Content>;
 export type ScrollAreaScrollbarProps = React.ComponentProps<typeof BaseScrollArea.Scrollbar>;
@@ -36,6 +45,16 @@ export const ScrollAreaRoot = ({ className, ...rest }: ScrollAreaRootProps) => {
 
 ScrollAreaRoot.displayName = 'ScrollAreaRoot';
 
+const resolveFadeClass = (
+  scrollFade: ScrollAreaViewportProps['scrollFade'],
+): string | undefined => {
+  if (!scrollFade) return undefined;
+  const orientation: ScrollAreaFadeOrientation = scrollFade === true ? 'vertical' : scrollFade;
+  if (orientation === 'horizontal') return styles.viewportFadeHorizontal;
+  if (orientation === 'both') return styles.viewportFadeBoth;
+  return styles.viewportFade;
+};
+
 export const ScrollAreaViewport = ({
   className,
   scrollFade = false,
@@ -47,10 +66,7 @@ export const ScrollAreaViewport = ({
       <BaseScrollArea.Viewport
         {...rest}
         className={
-          mergeStateClassName(
-            cx(styles.viewport, scrollFade && styles.viewportFade),
-            className,
-          ) as any
+          mergeStateClassName(cx(styles.viewport, resolveFadeClass(scrollFade)), className) as any
         }
       />
     </>

--- a/src/base-ui/ScrollArea/index.md
+++ b/src/base-ui/ScrollArea/index.md
@@ -18,9 +18,24 @@ apiHeader:
 
 <code src="../../ScrollArea/demos/background.tsx" nopadding></code>
 
+## Horizontal fade
+
+Set `scrollFade="horizontal"` to mask the start and end edges of a horizontally
+scrolled viewport (tab strips, chip lists, etc.).
+
+<code src="../../ScrollArea/demos/horizontal.tsx" nopadding></code>
+
 ## Both scrollbars
 
 <code src="../../ScrollArea/demos/both.tsx" nopadding></code>
+
+## Fade in both directions
+
+Set `scrollFade="both"` to mask every edge that overflows. Vertical and
+horizontal gradient masks are combined via `mask-composite: intersect`, so the
+four corners only fade when both axes overflow.
+
+<code src="../../ScrollArea/demos/fade-both.tsx" nopadding></code>
 
 ## Usage
 
@@ -122,15 +137,15 @@ ScrollArea is built on top of Base UI Scroll Area and exposes the same primitive
 
 Composed scroll area with defaults for viewport, content, scrollbar, and thumb.
 
-| Prop           | Type                                                        | Default | Description                                        |
-| -------------- | ----------------------------------------------------------- | ------- | -------------------------------------------------- |
-| scrollFade     | `boolean`                                                   | `false` | Enable gradient scroll fade on the viewport edges. |
-| contentProps   | `Omit<ScrollAreaContentProps, 'children'>`                  | -       | Props passed to `ScrollAreaContent`.               |
-| corner         | `boolean`                                                   | `false` | Whether to render the corner.                      |
-| cornerProps    | `ScrollAreaCornerProps`                                     | -       | Props passed to `ScrollAreaCorner`.                |
-| scrollbarProps | `Omit<ScrollAreaScrollbarProps, 'children'>`                | -       | Props passed to `ScrollAreaScrollbar`.             |
-| thumbProps     | `ScrollAreaThumbProps`                                      | -       | Props passed to `ScrollAreaThumb`.                 |
-| viewportProps  | `Omit<ScrollAreaViewportProps, 'children' \| 'scrollFade'>` | -       | Props passed to `ScrollAreaViewport`.              |
+| Prop           | Type                                                        | Default | Description                                                                                                          |
+| -------------- | ----------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------- |
+| scrollFade     | `boolean \| 'vertical' \| 'horizontal' \| 'both'`           | `false` | Enable gradient scroll fade on the viewport edges. `true` ≡ `'vertical'`. `'both'` intersects vertical + horizontal. |
+| contentProps   | `Omit<ScrollAreaContentProps, 'children'>`                  | -       | Props passed to `ScrollAreaContent`.                                                                                 |
+| corner         | `boolean`                                                   | `false` | Whether to render the corner.                                                                                        |
+| cornerProps    | `ScrollAreaCornerProps`                                     | -       | Props passed to `ScrollAreaCorner`.                                                                                  |
+| scrollbarProps | `Omit<ScrollAreaScrollbarProps, 'children'>`                | -       | Props passed to `ScrollAreaScrollbar`.                                                                               |
+| thumbProps     | `ScrollAreaThumbProps`                                      | -       | Props passed to `ScrollAreaThumb`.                                                                                   |
+| viewportProps  | `Omit<ScrollAreaViewportProps, 'children' \| 'scrollFade'>` | -       | Props passed to `ScrollAreaViewport`.                                                                                |
 
 ### Root
 
@@ -169,12 +184,12 @@ The actual scrollable container of the scroll area. Renders a `div` element.
 
 **Viewport Props:**
 
-| Prop       | Type                                                                                     | Default | Description                                                                                        |
-| ---------- | ---------------------------------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------- |
-| scrollFade | `boolean`                                                                                | `false` | Enable gradient scroll fade on the viewport edges.                                                 |
-| className  | `string \| ((state: ScrollArea.Viewport.State) => string \| undefined)`                  | -       | CSS class applied to the element, or a function that returns a class based on the component state. |
-| style      | `CSSProperties \| ((state: ScrollArea.Viewport.State) => CSSProperties \| undefined)`    | -       | Inline styles for the viewport element.                                                            |
-| render     | `ReactElement \| ((props: HTMLProps, state: ScrollArea.Viewport.State) => ReactElement)` | -       | Replace the component element with a different tag or compose it with another component.           |
+| Prop       | Type                                                                                     | Default | Description                                                                                                          |
+| ---------- | ---------------------------------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------- |
+| scrollFade | `boolean \| 'vertical' \| 'horizontal' \| 'both'`                                        | `false` | Enable gradient scroll fade on the viewport edges. `true` ≡ `'vertical'`. `'both'` intersects vertical + horizontal. |
+| className  | `string \| ((state: ScrollArea.Viewport.State) => string \| undefined)`                  | -       | CSS class applied to the element, or a function that returns a class based on the component state.                   |
+| style      | `CSSProperties \| ((state: ScrollArea.Viewport.State) => CSSProperties \| undefined)`    | -       | Inline styles for the viewport element.                                                                              |
+| render     | `ReactElement \| ((props: HTMLProps, state: ScrollArea.Viewport.State) => ReactElement)` | -       | Replace the component element with a different tag or compose it with another component.                             |
 
 **Viewport Data Attributes:**
 

--- a/src/base-ui/ScrollArea/style.ts
+++ b/src/base-ui/ScrollArea/style.ts
@@ -25,11 +25,6 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   scrollbar: css`
     pointer-events: none;
 
-    position: relative;
-
-    display: flex;
-    justify-content: center;
-
     margin: 8px;
     border-radius: ${cssVar.borderRadiusSM};
 

--- a/src/base-ui/ScrollArea/style.ts
+++ b/src/base-ui/ScrollArea/style.ts
@@ -73,6 +73,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
 
   thumb: css`
     width: 100%;
+    height: 100%;
     border-radius: inherit;
     background: ${cssVar.colorTextQuaternary};
   `,

--- a/src/base-ui/ScrollArea/style.ts
+++ b/src/base-ui/ScrollArea/style.ts
@@ -154,4 +154,172 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
         calc(100% - var(--lobe-scroll-area-fade-size)) 100%;
     }
   `,
+
+  viewportFadeHorizontal: css`
+    --scroll-area-overflow-x-start: inherit;
+    --scroll-area-overflow-x-end: inherit;
+    --lobe-scroll-area-fade-size: 40px;
+    --lobe-scroll-area-fade-left: min(
+      var(--lobe-scroll-area-fade-size),
+      var(--scroll-area-overflow-x-start, 0px)
+    );
+    --lobe-scroll-area-fade-right: min(
+      var(--lobe-scroll-area-fade-size),
+      var(--scroll-area-overflow-x-end, 0px)
+    );
+
+    /* Fade the CONTENT via mask, so it works on background images too. */
+    mask-image: linear-gradient(
+      to right,
+      transparent 0,
+      #000 var(--lobe-scroll-area-fade-left),
+      #000 calc(100% - var(--lobe-scroll-area-fade-right)),
+      transparent 100%
+    );
+    mask-repeat: no-repeat;
+    mask-size: 100% 100%;
+
+    /* Scroll-driven animation: use scroll position to drive the mask. */
+    @supports (animation-timeline: scroll()) {
+      /*
+       * Important: drive fade by *distance to edges* (first/last 40px),
+       * so reaching start/end doesn't cause a sudden snap.
+       */
+      @keyframes lobe-scroll-area-fade-left-in {
+        from {
+          --lobe-scroll-area-fade-left: 0;
+        }
+
+        to {
+          --lobe-scroll-area-fade-left: var(--lobe-scroll-area-fade-size);
+        }
+      }
+
+      @keyframes lobe-scroll-area-fade-right-out {
+        from {
+          --lobe-scroll-area-fade-right: var(--lobe-scroll-area-fade-size);
+        }
+
+        to {
+          --lobe-scroll-area-fade-right: 0;
+        }
+      }
+
+      animation-name: lobe-scroll-area-fade-left-in, lobe-scroll-area-fade-right-out;
+      animation-duration: 1ms, 1ms;
+      animation-timing-function: linear, linear;
+      animation-fill-mode: both, both;
+      animation-timeline: scroll(self x), scroll(self x);
+
+      animation-range:
+        0 var(--lobe-scroll-area-fade-size),
+        calc(100% - var(--lobe-scroll-area-fade-size)) 100%;
+    }
+  `,
+
+  viewportFadeBoth: css`
+    --scroll-area-overflow-x-start: inherit;
+    --scroll-area-overflow-x-end: inherit;
+    --scroll-area-overflow-y-start: inherit;
+    --scroll-area-overflow-y-end: inherit;
+    --lobe-scroll-area-fade-size: 40px;
+    --lobe-scroll-area-fade-top: min(
+      var(--lobe-scroll-area-fade-size),
+      var(--scroll-area-overflow-y-start, 0px)
+    );
+    --lobe-scroll-area-fade-bottom: min(
+      var(--lobe-scroll-area-fade-size),
+      var(--scroll-area-overflow-y-end, 0px)
+    );
+    --lobe-scroll-area-fade-left: min(
+      var(--lobe-scroll-area-fade-size),
+      var(--scroll-area-overflow-x-start, 0px)
+    );
+    --lobe-scroll-area-fade-right: min(
+      var(--lobe-scroll-area-fade-size),
+      var(--scroll-area-overflow-x-end, 0px)
+    );
+
+    mask-composite: intersect;
+
+    /*
+     * Combine vertical + horizontal fades by intersecting two gradient masks
+     * so the four corners stay transparent only when both axes overflow.
+     */
+    mask-image:
+      linear-gradient(
+        to bottom,
+        transparent 0,
+        #000 var(--lobe-scroll-area-fade-top),
+        #000 calc(100% - var(--lobe-scroll-area-fade-bottom)),
+        transparent 100%
+      ),
+      linear-gradient(
+        to right,
+        transparent 0,
+        #000 var(--lobe-scroll-area-fade-left),
+        #000 calc(100% - var(--lobe-scroll-area-fade-right)),
+        transparent 100%
+      );
+    mask-repeat: no-repeat, no-repeat;
+    mask-size:
+      100% 100%,
+      100% 100%;
+
+    @supports (animation-timeline: scroll()) {
+      @keyframes lobe-scroll-area-fade-top-in-both {
+        from {
+          --lobe-scroll-area-fade-top: 0;
+        }
+
+        to {
+          --lobe-scroll-area-fade-top: var(--lobe-scroll-area-fade-size);
+        }
+      }
+
+      @keyframes lobe-scroll-area-fade-bottom-out-both {
+        from {
+          --lobe-scroll-area-fade-bottom: var(--lobe-scroll-area-fade-size);
+        }
+
+        to {
+          --lobe-scroll-area-fade-bottom: 0;
+        }
+      }
+
+      @keyframes lobe-scroll-area-fade-left-in-both {
+        from {
+          --lobe-scroll-area-fade-left: 0;
+        }
+
+        to {
+          --lobe-scroll-area-fade-left: var(--lobe-scroll-area-fade-size);
+        }
+      }
+
+      @keyframes lobe-scroll-area-fade-right-out-both {
+        from {
+          --lobe-scroll-area-fade-right: var(--lobe-scroll-area-fade-size);
+        }
+
+        to {
+          --lobe-scroll-area-fade-right: 0;
+        }
+      }
+
+      animation-name:
+        lobe-scroll-area-fade-top-in-both, lobe-scroll-area-fade-bottom-out-both,
+        lobe-scroll-area-fade-left-in-both, lobe-scroll-area-fade-right-out-both;
+      animation-duration: 1ms, 1ms, 1ms, 1ms;
+      animation-timing-function: linear, linear, linear, linear;
+      animation-fill-mode: both, both, both, both;
+      animation-timeline: scroll(self y), scroll(self y), scroll(self x), scroll(self x);
+
+      animation-range:
+        0 var(--lobe-scroll-area-fade-size),
+        calc(100% - var(--lobe-scroll-area-fade-size)) 100%,
+        0 var(--lobe-scroll-area-fade-size),
+        calc(100% - var(--lobe-scroll-area-fade-size)) 100%;
+    }
+  `,
 }));

--- a/src/base-ui/ScrollArea/type.ts
+++ b/src/base-ui/ScrollArea/type.ts
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import type {
   ScrollAreaContentProps,
   ScrollAreaCornerProps,
+  ScrollAreaFadeOrientation,
   ScrollAreaRootProps,
   ScrollAreaScrollbarProps,
   ScrollAreaThumbProps,
@@ -15,7 +16,15 @@ export interface ScrollAreaProps extends Omit<ScrollAreaRootProps, 'children'> {
   corner?: boolean;
   cornerProps?: ScrollAreaCornerProps;
   scrollbarProps?: Omit<ScrollAreaScrollbarProps, 'children'>;
-  scrollFade?: boolean;
+  /**
+   * Enable gradient scroll fade on the viewport edges.
+   *
+   * Accepts a boolean (true ≡ vertical) or an explicit orientation:
+   * `'vertical' | 'horizontal' | 'both'`.
+   *
+   * @default false
+   */
+  scrollFade?: boolean | ScrollAreaFadeOrientation;
   thumbProps?: ScrollAreaThumbProps;
   viewportProps?: Omit<ScrollAreaViewportProps, 'children' | 'scrollFade'>;
 }

--- a/src/base-ui/Select/Select.tsx
+++ b/src/base-ui/Select/Select.tsx
@@ -2,63 +2,31 @@
 
 import { Select as BaseSelect } from '@base-ui/react/select';
 import { cx, useThemeMode } from 'antd-style';
-import { Check, ChevronDown, Loader2, X } from 'lucide-react';
-import {
-  type ChangeEvent,
-  type HTMLAttributes,
-  type KeyboardEvent,
-  type MouseEvent,
-  type MutableRefObject,
-  type Ref,
-} from 'react';
-import { isValidElement, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Virtualizer } from 'virtua';
+import { type MouseEvent } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
-import Icon from '@/Icon';
 import { styles as menuStyles } from '@/Menu/sharedStyle';
-import { useAppElement } from '@/ThemeProvider';
 
-import { styles, triggerVariants } from './style';
+import { isValueEmpty } from './helpers';
 import {
-  type SelectOption,
-  type SelectOptionGroup,
-  type SelectOptions,
-  type SelectProps,
-  type SelectRootChangeEventDetails,
-} from './type';
-
-const isGroupOption = <Value,>(
-  option: SelectOption<Value> | SelectOptionGroup<Value>,
-): option is SelectOptionGroup<Value> => Boolean((option as SelectOptionGroup<Value>).options);
-
-const getOptionSearchText = <Value,>(option: SelectOption<Value>) => {
-  if (typeof option.label === 'string' || typeof option.label === 'number') {
-    return String(option.label);
-  }
-  if (typeof option.value === 'string' || typeof option.value === 'number') {
-    return String(option.value);
-  }
-  if (option.title) return option.title;
-  return '';
-};
-
-const escapeRegExp = (value: string) => value.replaceAll(/[$()*+.?[\\\]^{|}]/g, '\\$&');
-
-const splitBySeparators = (value: string, separators?: string[]) => {
-  if (!separators || separators.length === 0) return [value];
-  const pattern = separators.map(escapeRegExp).join('|');
-  return value.split(new RegExp(pattern, 'g'));
-};
-
-const countVirtualItems = (items: SelectOptions) =>
-  items.reduce((count, item) => {
-    if (isGroupOption(item)) {
-      return count + item.options.length + 1;
-    }
-    return count + 1;
-  }, 0);
-
-const isValueEmpty = (value: unknown) => value === null || value === undefined || value === '';
+  usePortalContainer,
+  useSelectOpen,
+  useSelectSearch,
+  useSelectValue,
+  useSelectVirtual,
+} from './hooks';
+import {
+  createTriggerValueRenderer,
+  EmptyContent,
+  resolveIconNode,
+  resolveSuffixIcon,
+  SelectListSection,
+  SelectSearchInput,
+  SelectTriggerSuffix,
+} from './parts';
+import { renderOptions } from './renderOptions';
+import { styles, triggerVariants } from './style';
+import { type SelectOption, type SelectProps } from './type';
 
 const Select = memo<SelectProps<any>>(
   ({
@@ -106,39 +74,6 @@ const Select = memo<SelectProps<any>>(
     const isMultiple = mode === 'multiple' || mode === 'tags';
     const isItemAligned = behaviorVariant === 'item-aligned';
 
-    const [uncontrolledValue, setUncontrolledValue] = useState<any>(() => {
-      if (defaultValue !== undefined) return defaultValue;
-      return isMultiple ? [] : null;
-    });
-
-    const normalizeValue = useCallback(
-      (nextValue: any) => {
-        if (isMultiple) {
-          if (Array.isArray(nextValue)) return nextValue;
-          if (nextValue === null || nextValue === undefined) return [];
-          return [nextValue];
-        }
-        if (Array.isArray(nextValue)) return nextValue[0] ?? null;
-        return nextValue === undefined ? null : nextValue;
-      },
-      [isMultiple],
-    );
-
-    const mergedValue = value !== undefined ? value : uncontrolledValue;
-    const normalizedValue = useMemo(
-      () => normalizeValue(mergedValue),
-      [mergedValue, normalizeValue],
-    );
-    const valueArray = useMemo(
-      () =>
-        isMultiple
-          ? (normalizedValue as any[])
-          : isValueEmpty(normalizedValue)
-            ? []
-            : [normalizedValue],
-      [isMultiple, normalizedValue],
-    );
-
     const [extraOptions, setExtraOptions] = useState<SelectOption<any>[]>([]);
 
     useEffect(() => {
@@ -147,279 +82,63 @@ const Select = memo<SelectProps<any>>(
       }
     }, [mode, extraOptions.length]);
 
-    const { resolvedOptions, optionMap } = useMemo(() => {
-      const baseOptions = options ?? [];
-      const optionValueMap = new Map<any, SelectOption<any>>();
+    const {
+      appendTagValues,
+      getOption,
+      handleValueChange,
+      normalizedValue,
+      normalizeValue,
+      resolvedOptions,
+      valueArray,
+    } = useSelectValue({
+      defaultValue,
+      extraOptions,
+      isMultiple,
+      onChange,
+      onSelect,
+      options,
+      setExtraOptions,
+      value,
+    });
 
-      const addOption = (item: SelectOption<any>) => {
-        if (!optionValueMap.has(item.value)) {
-          optionValueMap.set(item.value, item);
-        }
-      };
+    const { handleOpenChange, mergedOpen } = useSelectOpen({ defaultOpen, onOpenChange, open });
 
-      const walkOptions = (items: SelectOptions) => {
-        items.forEach((item) => {
-          if (isGroupOption(item)) {
-            item.options.forEach(addOption);
-          } else {
-            addOption(item);
-          }
-        });
-      };
+    const {
+      filteredOptions,
+      handleSearchChange,
+      handleSearchKeyDown,
+      searchValue,
+      shouldShowSearch,
+      stopSearchPropagation,
+    } = useSelectSearch({
+      appendTagValues,
+      handleOpenChange,
+      mergedOpen,
+      mode,
+      resolvedOptions,
+      showSearch,
+      tokenSeparators,
+    });
 
-      walkOptions(baseOptions);
+    const virtualState = useSelectVirtual({
+      filteredOptions,
+      listItemHeight,
+      size,
+      valueArray,
+      virtual,
+    });
 
-      const filteredExtraOptions = extraOptions.filter((item) => !optionValueMap.has(item.value));
-      filteredExtraOptions.forEach(addOption);
+    const portalContainer = usePortalContainer();
 
-      const mergedOptions: SelectOptions = [...baseOptions, ...filteredExtraOptions];
-
-      const missingValueOptions: SelectOption<any>[] = valueArray
-        .filter((val) => !optionValueMap.has(val))
-        .map((val) => ({
-          label: String(val),
-          value: val,
-        }));
-      missingValueOptions.forEach(addOption);
-
-      return {
-        optionMap: optionValueMap,
-        resolvedOptions: missingValueOptions.length
-          ? [...mergedOptions, ...missingValueOptions]
-          : mergedOptions,
-      };
-    }, [extraOptions, options, valueArray]);
-
-    const [uncontrolledOpen, setUncontrolledOpen] = useState(Boolean(defaultOpen));
-
-    useEffect(() => {
-      if (open !== undefined) {
-        setUncontrolledOpen(open);
-      }
-    }, [open]);
-
-    const mergedOpen = open ?? uncontrolledOpen;
-
-    const handleOpenChange = useCallback(
-      (nextOpen: boolean, eventDetails?: SelectRootChangeEventDetails) => {
-        onOpenChange?.(nextOpen, eventDetails);
-        if (open === undefined) {
-          setUncontrolledOpen(nextOpen);
-        }
-      },
-      [onOpenChange, open],
-    );
-
-    const [searchValue, setSearchValue] = useState('');
-    const shouldShowSearch = Boolean(showSearch || mode === 'tags');
-
-    useEffect(() => {
-      if (!mergedOpen) setSearchValue('');
-    }, [mergedOpen]);
-
-    const getOption = useCallback(
-      (optionValue: any): SelectOption<any> => {
-        const matched = optionMap.get(optionValue);
-        if (matched) return matched;
-        if (optionValue && typeof optionValue === 'object' && 'label' in optionValue) {
-          return {
-            label: (optionValue as any).label,
-            value: optionValue,
-          };
-        }
-        return {
-          label: String(optionValue),
-          value: optionValue,
-        };
-      },
-      [optionMap],
-    );
-
-    const previousValueRef = useRef<any>(normalizedValue);
-
-    useEffect(() => {
-      previousValueRef.current = normalizedValue;
-    }, [normalizedValue]);
-
-    const handleValueChange = useCallback(
-      (nextValue: any) => {
-        const normalizedNextValue = normalizeValue(nextValue);
-        const previousValue = previousValueRef.current;
-
-        if (isMultiple) {
-          const prevValues = Array.isArray(previousValue) ? previousValue : [];
-          const nextValues = Array.isArray(normalizedNextValue) ? normalizedNextValue : [];
-          const addedValues = nextValues.filter(
-            (val) => !prevValues.some((prev) => Object.is(prev, val)),
-          );
-
-          addedValues.forEach((val) => {
-            onSelect?.(val, getOption(val));
-          });
-
-          if (value === undefined) {
-            setUncontrolledValue(nextValues);
-          }
-          onChange?.(
-            nextValues,
-            nextValues.map((val) => getOption(val)),
-          );
-        } else {
-          if (
-            !isValueEmpty(normalizedNextValue) &&
-            !Object.is(previousValue, normalizedNextValue)
-          ) {
-            onSelect?.(normalizedNextValue, getOption(normalizedNextValue));
-          }
-          if (value === undefined) {
-            setUncontrolledValue(normalizedNextValue);
-          }
-          onChange?.(
-            normalizedNextValue,
-            isValueEmpty(normalizedNextValue) ? undefined : getOption(normalizedNextValue),
-          );
-        }
-
-        previousValueRef.current = normalizedNextValue;
-      },
-      [getOption, isMultiple, normalizeValue, onChange, onSelect, value],
-    );
-
-    const appendTagValues = useCallback(
-      (rawValues: string[]) => {
-        const valuesToAdd = rawValues.map((val) => val.trim()).filter(Boolean);
-        if (!valuesToAdd.length) return;
-
-        const nextValues = [...valueArray];
-        const newOptionValues = valuesToAdd.filter((val) => !optionMap.has(val));
-
-        if (newOptionValues.length > 0) {
-          setExtraOptions((prev) => {
-            const existingValues = new Set(prev.map((item) => item.value));
-            const merged = [...prev];
-            newOptionValues.forEach((val) => {
-              if (!existingValues.has(val)) {
-                merged.push({ label: val, value: val });
-              }
-            });
-            return merged;
-          });
-        }
-
-        valuesToAdd.forEach((val) => {
-          if (!nextValues.some((item) => Object.is(item, val))) {
-            nextValues.push(val);
-          }
-        });
-
-        if (nextValues.length !== valueArray.length) {
-          handleValueChange(nextValues);
-        }
-      },
-      [handleValueChange, optionMap, valueArray],
-    );
-
-    const handleSearchChange = useCallback(
-      (event: ChangeEvent<HTMLInputElement>) => {
-        const nextValue = event.target.value;
-        if (mode === 'tags') {
-          const parts = splitBySeparators(nextValue, tokenSeparators);
-          if (parts.length > 1) {
-            const pending = parts.pop() ?? '';
-            appendTagValues(parts.filter(Boolean));
-            setSearchValue(pending);
-            return;
-          }
-        }
-        setSearchValue(nextValue);
-      },
-      [appendTagValues, mode, tokenSeparators],
-    );
-
-    const handleSearchKeyDown = useCallback(
-      (event: KeyboardEvent<HTMLInputElement>) => {
-        event.stopPropagation();
-
-        if (event.key === 'Escape') {
-          handleOpenChange(false);
-          return;
-        }
-
-        if (mode !== 'tags') return;
-
-        if (event.key === 'Enter') {
-          event.preventDefault();
-          event.stopPropagation();
-          appendTagValues([searchValue]);
-          setSearchValue('');
-          return;
-        }
-
-        if (tokenSeparators?.includes(event.key)) {
-          event.preventDefault();
-          event.stopPropagation();
-          appendTagValues([searchValue]);
-          setSearchValue('');
-        }
-      },
-      [appendTagValues, handleOpenChange, mode, searchValue, tokenSeparators],
-    );
-
-    const filteredOptions = useMemo(() => {
-      if (!shouldShowSearch || !searchValue.trim()) return resolvedOptions;
-      const query = searchValue.trim().toLowerCase();
-
-      const filterItems = (items: SelectOptions): SelectOptions => {
-        const filtered = items
-          .map((item) => {
-            if (isGroupOption(item)) {
-              const groupItems = item.options.filter((option) =>
-                getOptionSearchText(option).toLowerCase().includes(query),
-              );
-              if (!groupItems.length) return null;
-              return { ...item, options: groupItems };
-            }
-            return getOptionSearchText(item).toLowerCase().includes(query) ? item : null;
-          })
-          .filter(Boolean) as SelectOptions;
-
-        return filtered;
-      };
-
-      return filterItems(resolvedOptions);
-    }, [resolvedOptions, searchValue, shouldShowSearch]);
-
-    const renderValue = useCallback(
-      (currentValue: any) => {
-        const resolved = normalizeValue(currentValue);
-        const placeholderNode =
-          placeholder === undefined ? null : (
-            <span className={styles.valueText}>{placeholder}</span>
-          );
-
-        if (isMultiple) {
-          const values = Array.isArray(resolved) ? resolved : [];
-          if (values.length === 0) return placeholderNode;
-          return (
-            <span className={styles.tags}>
-              {values.map((val, index) => {
-                const option = getOption(val);
-                const content = labelRender ? labelRender(option) : (option.label ?? String(val));
-                return (
-                  <span className={styles.tag} key={`${String(val)}-${index}`}>
-                    {content}
-                  </span>
-                );
-              })}
-            </span>
-          );
-        }
-
-        if (isValueEmpty(resolved)) return placeholderNode;
-        const option = getOption(resolved);
-        const content = labelRender ? labelRender(option) : (option.label ?? String(resolved));
-        return <span className={styles.valueText}>{content}</span>;
-      },
+    const renderValue = useMemo(
+      () =>
+        createTriggerValueRenderer({
+          getOption,
+          isMultiple,
+          labelRender,
+          normalizeValue,
+          placeholder,
+        }),
       [getOption, isMultiple, labelRender, normalizeValue, placeholder],
     );
 
@@ -435,38 +154,11 @@ const Select = memo<SelectProps<any>>(
       [handleValueChange, isMultiple],
     );
 
-    const prefixNode = useMemo(() => {
-      if (prefix === undefined || prefix === null) return null;
-      if (isValidElement(prefix) || typeof prefix === 'string' || typeof prefix === 'number') {
-        return prefix;
-      }
-      return <Icon icon={prefix as any} size={'small'} />;
-    }, [prefix]);
-
-    const suffixIconNode = useMemo(() => {
-      if (loading) {
-        return <Icon spin icon={Loader2} size={'small'} />;
-      }
-      if (suffixIcon === null) return null;
-      if (
-        isValidElement(suffixIcon) ||
-        typeof suffixIcon === 'string' ||
-        typeof suffixIcon === 'number'
-      ) {
-        return suffixIcon;
-      }
-      return (
-        <Icon
-          icon={(suffixIcon as any) || ChevronDown}
-          size={'small'}
-          {...suffixIconProps}
-          style={{
-            pointerEvents: 'none',
-            ...suffixIconProps?.style,
-          }}
-        />
-      );
-    }, [loading, suffixIcon, suffixIconProps]);
+    const prefixNode = useMemo(() => resolveIconNode(prefix), [prefix]);
+    const suffixIconNode = useMemo(
+      () => resolveSuffixIcon(suffixIcon, suffixIconProps, loading),
+      [loading, suffixIcon, suffixIconProps],
+    );
 
     const popupStyle = useMemo(() => {
       const maxHeight = isItemAligned ? '80vh' : `${listHeight}px`;
@@ -487,10 +179,7 @@ const Select = memo<SelectProps<any>>(
           width: popupMatchSelectWidth,
         };
       }
-      return {
-        ...baseStyle,
-        minWidth: 'max-content',
-      };
+      return { ...baseStyle, minWidth: 'max-content' };
     }, [isItemAligned, listHeight, popupMatchSelectWidth]);
 
     const triggerClassName = cx(
@@ -500,209 +189,29 @@ const Select = memo<SelectProps<any>>(
       classNames?.trigger,
     );
 
-    const listRef = useRef<HTMLDivElement | null>(null);
-    const pointerScrollRef = useRef(false);
-    const pointerScrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-    const renderVirtualItem = useCallback((props: HTMLAttributes<HTMLDivElement>) => {
-      const { ref, ...rest } = props as HTMLAttributes<HTMLDivElement> & {
-        ref?: Ref<HTMLDivElement>;
-      };
-
-      return (
-        <div
-          {...rest}
-          ref={(node) => {
-            if (node) {
-              node.scrollIntoView = (...args) => {
-                if (!pointerScrollRef.current) {
-                  HTMLElement.prototype.scrollIntoView.call(node, ...args);
-                }
-              };
-            }
-
-            if (typeof ref === 'function') {
-              ref(node);
-            } else if (ref && 'current' in ref) {
-              (ref as MutableRefObject<HTMLDivElement | null>).current = node;
-            }
-          }}
-        />
-      );
-    }, []);
-
-    const markPointerScroll = useCallback(() => {
-      pointerScrollRef.current = true;
-      if (pointerScrollTimeoutRef.current) {
-        clearTimeout(pointerScrollTimeoutRef.current);
-      }
-      pointerScrollTimeoutRef.current = setTimeout(() => {
-        pointerScrollRef.current = false;
-      }, 120);
-    }, []);
-
-    const handleListScroll = useCallback(() => {
-      if (!virtual || !pointerScrollRef.current) return;
-      const listElement = listRef.current;
-      const activeElement = document.activeElement;
-      if (listElement && activeElement && listElement.contains(activeElement)) {
-        listElement.focus({ preventScroll: true });
-      }
-    }, [virtual]);
-
-    useEffect(() => {
-      return () => {
-        if (pointerScrollTimeoutRef.current) {
-          clearTimeout(pointerScrollTimeoutRef.current);
-        }
-      };
-    }, []);
-    const virtualListStyle = useMemo(() => {
-      if (!virtual) return undefined;
-      const rowCount = countVirtualItems(filteredOptions);
-      const maxVisibleRows = 6;
-      const estimatedRowHeight =
-        listItemHeight ?? (size === 'large' ? 40 : size === 'small' ? 28 : 32);
-      const visibleRows = Math.min(Math.max(rowCount, 1), maxVisibleRows);
-      const estimatedHeight = visibleRows * estimatedRowHeight + 8;
-
-      return {
-        height: `min(${estimatedHeight}px, var(--lobe-select-available-height, var(--available-height)))`,
-      };
-    }, [filteredOptions, listItemHeight, size, virtual]);
-
-    const keepMountedIndices = useMemo(() => {
-      if (!virtual || valueArray.length === 0) return undefined;
-      const selectedSet = new Set(valueArray);
-      const indices: number[] = [];
-      let index = 0;
-
-      filteredOptions.forEach((item) => {
-        if (isGroupOption(item)) {
-          if (item.options.some((option) => selectedSet.has(option.value))) {
-            indices.push(index);
-          }
-          index += 1;
-          return;
-        }
-
-        if (selectedSet.has(item.value)) {
-          indices.push(index);
-        }
-        index += 1;
-      });
-
-      return indices.length ? indices : undefined;
-    }, [filteredOptions, valueArray, virtual]);
-
+    const isBoldIndicator = selectedIndicatorVariant === 'bold';
     const itemTextClassName = cx(
       optionRender ? menuStyles.itemContent : menuStyles.label,
       styles.itemText,
       classNames?.itemText,
     );
 
-    const isBoldIndicator = selectedIndicatorVariant === 'bold';
-    let optionIndex = 0;
-    const renderOptions = (items: SelectOptions) =>
-      items.map((item, index) => {
-        if (isGroupOption(item)) {
-          return (
-            <BaseSelect.Group
-              className={cx(styles.group, classNames?.group)}
-              key={`group-${index}`}
-            >
-              <BaseSelect.GroupLabel
-                className={cx(menuStyles.groupLabel, styles.groupLabel, classNames?.groupLabel)}
-              >
-                {item.label}
-              </BaseSelect.GroupLabel>
-              {item.options.map((option) => {
-                const currentIndex = optionIndex++;
-                return (
-                  <BaseSelect.Item
-                    disabled={option.disabled}
-                    key={`${String(option.value)}-${currentIndex}`}
-                    label={getOptionSearchText(option)}
-                    render={virtual ? renderVirtualItem : undefined}
-                    value={option.value}
-                    className={cx(
-                      menuStyles.item,
-                      styles.item,
-                      isBoldIndicator && styles.itemBoldSelected,
-                      classNames?.item,
-                      classNames?.option,
-                      option.className,
-                    )}
-                    style={{
-                      minHeight: listItemHeight,
-                      ...option.style,
-                    }}
-                  >
-                    <BaseSelect.ItemText className={itemTextClassName}>
-                      {optionRender ? optionRender(option, { index: currentIndex }) : option.label}
-                    </BaseSelect.ItemText>
-                    {!isBoldIndicator && (
-                      <BaseSelect.ItemIndicator
-                        className={cx(styles.itemIndicator, classNames?.itemIndicator)}
-                      >
-                        <Icon icon={Check} size={'small'} />
-                      </BaseSelect.ItemIndicator>
-                    )}
-                  </BaseSelect.Item>
-                );
-              })}
-            </BaseSelect.Group>
-          );
-        }
+    const isEmpty = filteredOptions.length === 0;
+    const listContent = isEmpty ? (
+      <EmptyContent classNames={classNames} />
+    ) : (
+      renderOptions({
+        classNames,
+        isBoldIndicator,
+        items: filteredOptions,
+        itemTextClassName,
+        listItemHeight,
+        optionRender,
+        renderVirtualItem: virtualState.renderVirtualItem,
+        virtual,
+      })
+    );
 
-        const currentIndex = optionIndex++;
-        return (
-          <BaseSelect.Item
-            disabled={item.disabled}
-            key={`${String(item.value)}-${currentIndex}`}
-            label={getOptionSearchText(item)}
-            render={virtual ? renderVirtualItem : undefined}
-            value={item.value}
-            className={cx(
-              menuStyles.item,
-              styles.item,
-              isBoldIndicator && styles.itemBoldSelected,
-              classNames?.item,
-              classNames?.option,
-              item.className,
-            )}
-            style={{
-              minHeight: listItemHeight,
-              ...item.style,
-            }}
-          >
-            <BaseSelect.ItemText className={itemTextClassName}>
-              {optionRender ? optionRender(item, { index: currentIndex }) : item.label}
-            </BaseSelect.ItemText>
-            {!isBoldIndicator && (
-              <BaseSelect.ItemIndicator
-                className={cx(styles.itemIndicator, classNames?.itemIndicator)}
-              >
-                <Icon icon={Check} size={'small'} />
-              </BaseSelect.ItemIndicator>
-            )}
-          </BaseSelect.Item>
-        );
-      });
-
-    const appElement = useAppElement();
-    // `appElement` is the ThemeProvider wrapper div, which uses
-    // `display: contents` so it has no layout box. `@base-ui/react/select`
-    // fails to mount its Popup into a `display: contents` container in
-    // certain hosts (editor/chat inputs with focus traps). Fall back to
-    // `document.body` in that case; keep the original behavior when the
-    // wrapper has a real layout (older themes, SSR snapshot, etc.).
-    const portalContainer = useMemo(() => {
-      if (typeof window === 'undefined') return appElement;
-      if (!(appElement instanceof HTMLElement)) return undefined;
-      const display = window.getComputedStyle(appElement).display;
-      return display === 'contents' ? document.body : appElement;
-    }, [appElement]);
     return (
       <BaseSelect.Root
         disabled={disabled}
@@ -729,22 +238,12 @@ const Select = memo<SelectProps<any>>(
           <BaseSelect.Value className={cx(styles.value, classNames?.value)}>
             {renderValue}
           </BaseSelect.Value>
-          <span className={cx(styles.suffix, classNames?.suffix)}>
-            {showClear && (
-              <span
-                className={cx(styles.clear, classNames?.clear)}
-                data-role="lobe-select-clear"
-                onClick={handleClear}
-              >
-                <Icon icon={X} size={'small'} />
-              </span>
-            )}
-            {suffixIconNode !== null && suffixIconNode !== undefined && (
-              <BaseSelect.Icon className={cx(styles.icon, classNames?.icon)}>
-                {suffixIconNode}
-              </BaseSelect.Icon>
-            )}
-          </span>
+          <SelectTriggerSuffix
+            classNames={classNames}
+            showClear={showClear}
+            suffixIconNode={suffixIconNode}
+            onClear={handleClear}
+          />
         </BaseSelect.Trigger>
 
         <BaseSelect.Portal container={portalContainer}>
@@ -766,62 +265,23 @@ const Select = memo<SelectProps<any>>(
               )}
             >
               {shouldShowSearch && (
-                <div className={cx(styles.search, classNames?.search)}>
-                  <input
-                    className={styles.searchInput}
-                    placeholder={typeof placeholder === 'string' ? placeholder : undefined}
-                    value={searchValue}
-                    onChange={handleSearchChange}
-                    onKeyDown={handleSearchKeyDown}
-                  />
-                </div>
+                <SelectSearchInput
+                  classNames={classNames}
+                  placeholder={placeholder}
+                  stopPropagation={stopSearchPropagation}
+                  value={searchValue}
+                  onChange={handleSearchChange}
+                  onKeyDown={handleSearchKeyDown}
+                />
               )}
-              {(() => {
-                const content =
-                  filteredOptions.length > 0 ? (
-                    renderOptions(filteredOptions)
-                  ) : (
-                    <div
-                      className={cx(
-                        menuStyles.item,
-                        menuStyles.empty,
-                        styles.empty,
-                        classNames?.empty,
-                      )}
-                    >
-                      No data
-                    </div>
-                  );
-
-                if (!virtual || filteredOptions.length === 0) {
-                  return (
-                    <BaseSelect.List
-                      className={cx(styles.list, classNames?.list)}
-                      data-virtual={virtual || undefined}
-                    >
-                      {content}
-                    </BaseSelect.List>
-                  );
-                }
-
-                return (
-                  <BaseSelect.List
-                    className={cx(styles.list, classNames?.list)}
-                    data-virtual={virtual || undefined}
-                    ref={listRef}
-                    style={virtualListStyle}
-                    tabIndex={virtual ? -1 : undefined}
-                    onPointerDown={virtual ? markPointerScroll : undefined}
-                    onScroll={virtual ? handleListScroll : undefined}
-                    onTouchMove={virtual ? markPointerScroll : undefined}
-                    onWheel={virtual ? markPointerScroll : undefined}
-                  >
-                    <Virtualizer itemSize={listItemHeight} keepMounted={keepMountedIndices}>
-                      {content}
-                    </Virtualizer>
-                  </BaseSelect.List>
-                );
-              })()}
+              <SelectListSection
+                classNames={classNames}
+                isEmpty={isEmpty}
+                listContent={listContent}
+                listItemHeight={listItemHeight}
+                virtual={virtual}
+                virtualState={virtualState}
+              />
             </BaseSelect.Popup>
           </BaseSelect.Positioner>
         </BaseSelect.Portal>

--- a/src/base-ui/Select/helpers.ts
+++ b/src/base-ui/Select/helpers.ts
@@ -1,0 +1,45 @@
+import { type SelectOption, type SelectOptionGroup, type SelectOptions } from './type';
+
+export const isGroupOption = <Value>(
+  option: SelectOption<Value> | SelectOptionGroup<Value>,
+): option is SelectOptionGroup<Value> => Boolean((option as SelectOptionGroup<Value>).options);
+
+export const getOptionSearchText = <Value>(option: SelectOption<Value>) => {
+  if (typeof option.label === 'string' || typeof option.label === 'number') {
+    return String(option.label);
+  }
+  if (typeof option.value === 'string' || typeof option.value === 'number') {
+    return String(option.value);
+  }
+  if (option.title) return option.title;
+  return '';
+};
+
+const escapeRegExp = (value: string) => value.replaceAll(/[$()*+.?[\\\]^{|}]/g, '\\$&');
+
+export const splitBySeparators = (value: string, separators?: string[]) => {
+  if (!separators || separators.length === 0) return [value];
+  const pattern = separators.map(escapeRegExp).join('|');
+  return value.split(new RegExp(pattern, 'g'));
+};
+
+export const countVirtualItems = (items: SelectOptions) =>
+  items.reduce((count, item) => {
+    if (isGroupOption(item)) {
+      return count + item.options.length + 1;
+    }
+    return count + 1;
+  }, 0);
+
+export const isValueEmpty = (value: unknown) =>
+  value === null || value === undefined || value === '';
+
+export const normalizeValueFor = (isMultiple: boolean) => (nextValue: any) => {
+  if (isMultiple) {
+    if (Array.isArray(nextValue)) return nextValue;
+    if (nextValue === null || nextValue === undefined) return [];
+    return [nextValue];
+  }
+  if (Array.isArray(nextValue)) return nextValue[0] ?? null;
+  return nextValue === undefined ? null : nextValue;
+};

--- a/src/base-ui/Select/hooks.tsx
+++ b/src/base-ui/Select/hooks.tsx
@@ -1,0 +1,458 @@
+'use client';
+
+import {
+  type ChangeEvent,
+  type HTMLAttributes,
+  type KeyboardEvent,
+  type MutableRefObject,
+  type Ref,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { useAppElement } from '@/ThemeProvider';
+
+import {
+  countVirtualItems,
+  getOptionSearchText,
+  isGroupOption,
+  isValueEmpty,
+  normalizeValueFor,
+  splitBySeparators,
+} from './helpers';
+import {
+  type SelectOption,
+  type SelectOptions,
+  type SelectProps,
+  type SelectRootChangeEventDetails,
+  type SelectSize,
+} from './type';
+
+interface UseSelectValueParams {
+  defaultValue: SelectProps['defaultValue'];
+  extraOptions: SelectOption<any>[];
+  isMultiple: boolean;
+  onChange: SelectProps['onChange'];
+  onSelect: SelectProps['onSelect'];
+  options: SelectOptions<any> | undefined;
+  setExtraOptions: React.Dispatch<React.SetStateAction<SelectOption<any>[]>>;
+  value: SelectProps['value'];
+}
+
+export function useSelectValue({
+  defaultValue,
+  extraOptions,
+  isMultiple,
+  onChange,
+  onSelect,
+  options,
+  setExtraOptions,
+  value,
+}: UseSelectValueParams) {
+  const [uncontrolledValue, setUncontrolledValue] = useState<any>(() => {
+    if (defaultValue !== undefined) return defaultValue;
+    return isMultiple ? [] : null;
+  });
+
+  const normalizeValue = useMemo(() => normalizeValueFor(isMultiple), [isMultiple]);
+
+  const mergedValue = value !== undefined ? value : uncontrolledValue;
+  const normalizedValue = useMemo(() => normalizeValue(mergedValue), [mergedValue, normalizeValue]);
+
+  const valueArray = useMemo(() => {
+    if (isMultiple) return normalizedValue as any[];
+    return isValueEmpty(normalizedValue) ? [] : [normalizedValue];
+  }, [isMultiple, normalizedValue]);
+
+  const { optionMap, resolvedOptions } = useMemo(() => {
+    const baseOptions = options ?? [];
+    const optionValueMap = new Map<any, SelectOption<any>>();
+
+    const addOption = (item: SelectOption<any>) => {
+      if (!optionValueMap.has(item.value)) {
+        optionValueMap.set(item.value, item);
+      }
+    };
+
+    baseOptions.forEach((item) => {
+      if (isGroupOption(item)) {
+        item.options.forEach(addOption);
+      } else {
+        addOption(item);
+      }
+    });
+
+    const filteredExtraOptions = extraOptions.filter((item) => !optionValueMap.has(item.value));
+    filteredExtraOptions.forEach(addOption);
+    const mergedOptions: SelectOptions<any> = [...baseOptions, ...filteredExtraOptions];
+
+    const missingValueOptions: SelectOption<any>[] = valueArray
+      .filter((val) => !optionValueMap.has(val))
+      .map((val) => ({ label: String(val), value: val }));
+    missingValueOptions.forEach(addOption);
+
+    return {
+      optionMap: optionValueMap,
+      resolvedOptions: missingValueOptions.length
+        ? [...mergedOptions, ...missingValueOptions]
+        : mergedOptions,
+    };
+  }, [extraOptions, options, valueArray]);
+
+  const getOption = useCallback(
+    (optionValue: any): SelectOption<any> => {
+      const matched = optionMap.get(optionValue);
+      if (matched) return matched;
+      if (optionValue && typeof optionValue === 'object' && 'label' in optionValue) {
+        return { label: (optionValue as any).label, value: optionValue };
+      }
+      return { label: String(optionValue), value: optionValue };
+    },
+    [optionMap],
+  );
+
+  const previousValueRef = useRef<any>(normalizedValue);
+  useEffect(() => {
+    previousValueRef.current = normalizedValue;
+  }, [normalizedValue]);
+
+  const handleValueChange = useCallback(
+    (nextValue: any) => {
+      const normalizedNextValue = normalizeValue(nextValue);
+      const previousValue = previousValueRef.current;
+
+      if (isMultiple) {
+        const prevValues = Array.isArray(previousValue) ? previousValue : [];
+        const nextValues = Array.isArray(normalizedNextValue) ? normalizedNextValue : [];
+        const addedValues = nextValues.filter(
+          (val) => !prevValues.some((prev) => Object.is(prev, val)),
+        );
+        addedValues.forEach((val) => onSelect?.(val, getOption(val)));
+
+        if (value === undefined) setUncontrolledValue(nextValues);
+        onChange?.(
+          nextValues,
+          nextValues.map((val) => getOption(val)),
+        );
+      } else {
+        if (!isValueEmpty(normalizedNextValue) && !Object.is(previousValue, normalizedNextValue)) {
+          onSelect?.(normalizedNextValue, getOption(normalizedNextValue));
+        }
+        if (value === undefined) setUncontrolledValue(normalizedNextValue);
+        onChange?.(
+          normalizedNextValue,
+          isValueEmpty(normalizedNextValue) ? undefined : getOption(normalizedNextValue),
+        );
+      }
+
+      previousValueRef.current = normalizedNextValue;
+    },
+    [getOption, isMultiple, normalizeValue, onChange, onSelect, value],
+  );
+
+  const appendTagValues = useCallback(
+    (rawValues: string[]) => {
+      const valuesToAdd = rawValues.map((val) => val.trim()).filter(Boolean);
+      if (!valuesToAdd.length) return;
+
+      const nextValues = [...valueArray];
+      const newOptionValues = valuesToAdd.filter((val) => !optionMap.has(val));
+
+      if (newOptionValues.length > 0) {
+        setExtraOptions((prev) => {
+          const existingValues = new Set(prev.map((item) => item.value));
+          const merged = [...prev];
+          newOptionValues.forEach((val) => {
+            if (!existingValues.has(val)) {
+              merged.push({ label: val, value: val });
+            }
+          });
+          return merged;
+        });
+      }
+
+      valuesToAdd.forEach((val) => {
+        if (!nextValues.some((item) => Object.is(item, val))) {
+          nextValues.push(val);
+        }
+      });
+
+      if (nextValues.length !== valueArray.length) {
+        handleValueChange(nextValues);
+      }
+    },
+    [handleValueChange, optionMap, setExtraOptions, valueArray],
+  );
+
+  return {
+    appendTagValues,
+    getOption,
+    handleValueChange,
+    normalizedValue,
+    normalizeValue,
+    optionMap,
+    resolvedOptions,
+    valueArray,
+  };
+}
+
+interface UseSelectOpenParams {
+  defaultOpen: boolean | undefined;
+  onOpenChange: SelectProps['onOpenChange'];
+  open: boolean | undefined;
+}
+
+export function useSelectOpen({ defaultOpen, onOpenChange, open }: UseSelectOpenParams) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(Boolean(defaultOpen));
+
+  useEffect(() => {
+    if (open !== undefined) setUncontrolledOpen(open);
+  }, [open]);
+
+  const mergedOpen = open ?? uncontrolledOpen;
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean, eventDetails?: SelectRootChangeEventDetails) => {
+      onOpenChange?.(nextOpen, eventDetails);
+      if (open === undefined) setUncontrolledOpen(nextOpen);
+    },
+    [onOpenChange, open],
+  );
+
+  return { handleOpenChange, mergedOpen };
+}
+
+interface UseSelectSearchParams {
+  appendTagValues: (values: string[]) => void;
+  handleOpenChange: (nextOpen: boolean) => void;
+  mergedOpen: boolean;
+  mode: SelectProps['mode'];
+  resolvedOptions: SelectOptions;
+  showSearch: boolean | undefined;
+  tokenSeparators: string[] | undefined;
+}
+
+export function useSelectSearch({
+  appendTagValues,
+  handleOpenChange,
+  mergedOpen,
+  mode,
+  resolvedOptions,
+  showSearch,
+  tokenSeparators,
+}: UseSelectSearchParams) {
+  const [searchValue, setSearchValue] = useState('');
+  const shouldShowSearch = Boolean(showSearch || mode === 'tags');
+
+  useEffect(() => {
+    if (!mergedOpen) setSearchValue('');
+  }, [mergedOpen]);
+
+  const handleSearchChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const nextValue = event.target.value;
+      if (mode === 'tags') {
+        const parts = splitBySeparators(nextValue, tokenSeparators);
+        if (parts.length > 1) {
+          const pending = parts.pop() ?? '';
+          appendTagValues(parts.filter(Boolean));
+          setSearchValue(pending);
+          return;
+        }
+      }
+      setSearchValue(nextValue);
+    },
+    [appendTagValues, mode, tokenSeparators],
+  );
+
+  const handleSearchKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      event.stopPropagation();
+
+      if (event.key === 'Escape') {
+        handleOpenChange(false);
+        return;
+      }
+      if (mode !== 'tags') return;
+
+      const isSeparator = tokenSeparators?.includes(event.key);
+      if (event.key === 'Enter' || isSeparator) {
+        event.preventDefault();
+        event.stopPropagation();
+        appendTagValues([searchValue]);
+        setSearchValue('');
+      }
+    },
+    [appendTagValues, handleOpenChange, mode, searchValue, tokenSeparators],
+  );
+
+  // Stop propagation in capture phase + on keyup to block base-ui Popup-level
+  // `useTypeahead` (and any ancestor typeahead) from hijacking the search
+  // input's first-letter focus behavior. Do not remove.
+  const stopSearchPropagation = useCallback((event: KeyboardEvent<HTMLInputElement>) => {
+    event.stopPropagation();
+  }, []);
+
+  const filteredOptions = useMemo(() => {
+    if (!shouldShowSearch || !searchValue.trim()) return resolvedOptions;
+    const query = searchValue.trim().toLowerCase();
+
+    return resolvedOptions
+      .map((item) => {
+        if (isGroupOption(item)) {
+          const groupItems = item.options.filter((option) =>
+            getOptionSearchText(option).toLowerCase().includes(query),
+          );
+          if (!groupItems.length) return null;
+          return { ...item, options: groupItems };
+        }
+        return getOptionSearchText(item).toLowerCase().includes(query) ? item : null;
+      })
+      .filter(Boolean) as SelectOptions;
+  }, [resolvedOptions, searchValue, shouldShowSearch]);
+
+  return {
+    filteredOptions,
+    handleSearchChange,
+    handleSearchKeyDown,
+    searchValue,
+    shouldShowSearch,
+    stopSearchPropagation,
+  };
+}
+
+interface UseSelectVirtualParams {
+  filteredOptions: SelectOptions;
+  listItemHeight: number | undefined;
+  size: SelectSize;
+  valueArray: any[];
+  virtual: boolean | undefined;
+}
+
+export function useSelectVirtual({
+  filteredOptions,
+  listItemHeight,
+  size,
+  valueArray,
+  virtual,
+}: UseSelectVirtualParams) {
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const pointerScrollRef = useRef(false);
+  const pointerScrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const renderVirtualItem = useCallback((props: HTMLAttributes<HTMLDivElement>) => {
+    const { ref, ...rest } = props as HTMLAttributes<HTMLDivElement> & {
+      ref?: Ref<HTMLDivElement>;
+    };
+
+    return (
+      <div
+        {...rest}
+        ref={(node) => {
+          if (node) {
+            node.scrollIntoView = (...args) => {
+              if (!pointerScrollRef.current) {
+                HTMLElement.prototype.scrollIntoView.call(node, ...args);
+              }
+            };
+          }
+          if (typeof ref === 'function') {
+            ref(node);
+          } else if (ref && 'current' in ref) {
+            (ref as MutableRefObject<HTMLDivElement | null>).current = node;
+          }
+        }}
+      />
+    );
+  }, []);
+
+  const markPointerScroll = useCallback(() => {
+    pointerScrollRef.current = true;
+    if (pointerScrollTimeoutRef.current) {
+      clearTimeout(pointerScrollTimeoutRef.current);
+    }
+    pointerScrollTimeoutRef.current = setTimeout(() => {
+      pointerScrollRef.current = false;
+    }, 120);
+  }, []);
+
+  const handleListScroll = useCallback(() => {
+    if (!virtual || !pointerScrollRef.current) return;
+    const listElement = listRef.current;
+    const activeElement = document.activeElement;
+    if (listElement && activeElement && listElement.contains(activeElement)) {
+      listElement.focus({ preventScroll: true });
+    }
+  }, [virtual]);
+
+  useEffect(() => {
+    return () => {
+      if (pointerScrollTimeoutRef.current) {
+        clearTimeout(pointerScrollTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const virtualListStyle = useMemo(() => {
+    if (!virtual) return undefined;
+    const rowCount = countVirtualItems(filteredOptions);
+    const maxVisibleRows = 6;
+    const estimatedRowHeight =
+      listItemHeight ?? (size === 'large' ? 40 : size === 'small' ? 28 : 32);
+    const visibleRows = Math.min(Math.max(rowCount, 1), maxVisibleRows);
+    const estimatedHeight = visibleRows * estimatedRowHeight + 8;
+
+    return {
+      height: `min(${estimatedHeight}px, var(--lobe-select-available-height, var(--available-height)))`,
+    };
+  }, [filteredOptions, listItemHeight, size, virtual]);
+
+  const keepMountedIndices = useMemo(() => {
+    if (!virtual || valueArray.length === 0) return undefined;
+    const selectedSet = new Set(valueArray);
+    const indices: number[] = [];
+    let index = 0;
+
+    filteredOptions.forEach((item) => {
+      if (isGroupOption(item)) {
+        if (item.options.some((option) => selectedSet.has(option.value))) {
+          indices.push(index);
+        }
+        index += 1;
+        return;
+      }
+      if (selectedSet.has(item.value)) indices.push(index);
+      index += 1;
+    });
+
+    return indices.length ? indices : undefined;
+  }, [filteredOptions, valueArray, virtual]);
+
+  return {
+    handleListScroll,
+    keepMountedIndices,
+    listRef,
+    markPointerScroll,
+    renderVirtualItem,
+    virtualListStyle,
+  };
+}
+
+export function usePortalContainer() {
+  const appElement = useAppElement();
+  // `appElement` is the ThemeProvider wrapper div, which uses `display: contents`
+  // so it has no layout box. `@base-ui/react/select` fails to mount its Popup
+  // into a `display: contents` container in certain hosts (editor/chat inputs
+  // with focus traps). Fall back to `document.body` in that case; keep the
+  // original behavior when the wrapper has a real layout (older themes, SSR
+  // snapshot, etc.).
+  return useMemo(() => {
+    if (typeof window === 'undefined') return appElement;
+    if (!(appElement instanceof HTMLElement)) return undefined;
+    const display = window.getComputedStyle(appElement).display;
+    return display === 'contents' ? document.body : appElement;
+  }, [appElement]);
+}

--- a/src/base-ui/Select/parts.tsx
+++ b/src/base-ui/Select/parts.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { Select as BaseSelect } from '@base-ui/react/select';
+import { cx } from 'antd-style';
+import { ChevronDown, Loader2, X } from 'lucide-react';
+import {
+  type ChangeEvent,
+  isValidElement,
+  type KeyboardEvent,
+  type MouseEvent,
+  type ReactNode,
+} from 'react';
+import { Virtualizer } from 'virtua';
+
+import Icon, { type IconProps } from '@/Icon';
+import { styles as menuStyles } from '@/Menu/sharedStyle';
+
+import { isValueEmpty } from './helpers';
+import { type useSelectVirtual } from './hooks';
+import { styles } from './style';
+import { type SelectClassNames, type SelectOption, type SelectProps } from './type';
+
+export function resolveIconNode(node: ReactNode | IconProps['icon'] | undefined | null) {
+  if (node === undefined || node === null) return null;
+  if (isValidElement(node) || typeof node === 'string' || typeof node === 'number') {
+    return node;
+  }
+  return <Icon icon={node as any} size={'small'} />;
+}
+
+export function resolveSuffixIcon(
+  suffixIcon: SelectProps['suffixIcon'],
+  suffixIconProps: SelectProps['suffixIconProps'],
+  loading: boolean | undefined,
+) {
+  if (loading) return <Icon spin icon={Loader2} size={'small'} />;
+  if (suffixIcon === null) return null;
+  if (
+    isValidElement(suffixIcon) ||
+    typeof suffixIcon === 'string' ||
+    typeof suffixIcon === 'number'
+  ) {
+    return suffixIcon;
+  }
+  return (
+    <Icon
+      icon={(suffixIcon as any) || ChevronDown}
+      size={'small'}
+      {...suffixIconProps}
+      style={{
+        pointerEvents: 'none',
+        ...suffixIconProps?.style,
+      }}
+    />
+  );
+}
+
+interface TriggerValueRendererParams {
+  getOption: (value: any) => SelectOption<any>;
+  isMultiple: boolean;
+  labelRender: SelectProps['labelRender'];
+  normalizeValue: (value: any) => any;
+  placeholder: ReactNode;
+}
+
+export function createTriggerValueRenderer({
+  getOption,
+  isMultiple,
+  labelRender,
+  normalizeValue,
+  placeholder,
+}: TriggerValueRendererParams) {
+  return function renderValue(currentValue: any): ReactNode {
+    const resolved = normalizeValue(currentValue);
+    const placeholderNode =
+      placeholder === undefined ? null : <span className={styles.valueText}>{placeholder}</span>;
+
+    if (isMultiple) {
+      const values = Array.isArray(resolved) ? resolved : [];
+      if (values.length === 0) return placeholderNode;
+      return (
+        <span className={styles.tags}>
+          {values.map((val, index) => {
+            const option = getOption(val);
+            const content = labelRender ? labelRender(option) : (option.label ?? String(val));
+            return (
+              <span className={styles.tag} key={`${String(val)}-${index}`}>
+                {content}
+              </span>
+            );
+          })}
+        </span>
+      );
+    }
+
+    if (isValueEmpty(resolved)) return placeholderNode;
+    const option = getOption(resolved);
+    const content = labelRender ? labelRender(option) : (option.label ?? String(resolved));
+    return <span className={styles.valueText}>{content}</span>;
+  };
+}
+
+type SelectVirtualReturn = ReturnType<typeof useSelectVirtual>;
+
+interface SelectListSectionProps {
+  classNames: SelectClassNames | undefined;
+  isEmpty: boolean;
+  listContent: ReactNode;
+  listItemHeight: number | undefined;
+  virtual: boolean | undefined;
+  virtualState: SelectVirtualReturn;
+}
+
+export function SelectListSection({
+  classNames,
+  isEmpty,
+  listContent,
+  listItemHeight,
+  virtual,
+  virtualState,
+}: SelectListSectionProps) {
+  const listClassName = cx(styles.list, classNames?.list);
+
+  if (!virtual || isEmpty) {
+    return (
+      <BaseSelect.List className={listClassName} data-virtual={virtual || undefined}>
+        {listContent}
+      </BaseSelect.List>
+    );
+  }
+
+  const { handleListScroll, keepMountedIndices, listRef, markPointerScroll, virtualListStyle } =
+    virtualState;
+
+  return (
+    <BaseSelect.List
+      data-virtual
+      className={listClassName}
+      ref={listRef}
+      style={virtualListStyle}
+      tabIndex={-1}
+      onPointerDown={markPointerScroll}
+      onScroll={handleListScroll}
+      onTouchMove={markPointerScroll}
+      onWheel={markPointerScroll}
+    >
+      <Virtualizer itemSize={listItemHeight} keepMounted={keepMountedIndices}>
+        {listContent}
+      </Virtualizer>
+    </BaseSelect.List>
+  );
+}
+
+interface EmptyContentProps {
+  classNames: SelectClassNames | undefined;
+}
+
+export function EmptyContent({ classNames }: EmptyContentProps) {
+  return (
+    <div className={cx(menuStyles.item, menuStyles.empty, styles.empty, classNames?.empty)}>
+      No data
+    </div>
+  );
+}
+
+interface SelectSearchInputProps {
+  classNames: SelectClassNames | undefined;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
+  placeholder: ReactNode;
+  stopPropagation: (event: KeyboardEvent<HTMLInputElement>) => void;
+  value: string;
+}
+
+export function SelectSearchInput({
+  classNames,
+  onChange,
+  onKeyDown,
+  placeholder,
+  stopPropagation,
+  value,
+}: SelectSearchInputProps) {
+  return (
+    <div className={cx(styles.search, classNames?.search)}>
+      <input
+        className={styles.searchInput}
+        placeholder={typeof placeholder === 'string' ? placeholder : undefined}
+        value={value}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+        onKeyDownCapture={stopPropagation}
+        onKeyUp={stopPropagation}
+        onKeyUpCapture={stopPropagation}
+      />
+    </div>
+  );
+}
+
+interface SelectTriggerSuffixProps {
+  classNames: SelectClassNames | undefined;
+  onClear: (event: MouseEvent) => void;
+  showClear: boolean;
+  suffixIconNode: ReactNode;
+}
+
+export function SelectTriggerSuffix({
+  classNames,
+  onClear,
+  showClear,
+  suffixIconNode,
+}: SelectTriggerSuffixProps) {
+  return (
+    <span className={cx(styles.suffix, classNames?.suffix)}>
+      {showClear && (
+        <span
+          className={cx(styles.clear, classNames?.clear)}
+          data-role="lobe-select-clear"
+          onClick={onClear}
+        >
+          <Icon icon={X} size={'small'} />
+        </span>
+      )}
+      {suffixIconNode !== null && suffixIconNode !== undefined && (
+        <BaseSelect.Icon className={cx(styles.icon, classNames?.icon)}>
+          {suffixIconNode}
+        </BaseSelect.Icon>
+      )}
+    </span>
+  );
+}

--- a/src/base-ui/Select/renderOptions.tsx
+++ b/src/base-ui/Select/renderOptions.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { Select as BaseSelect } from '@base-ui/react/select';
+import { cx } from 'antd-style';
+import { Check } from 'lucide-react';
+import { type ComponentProps } from 'react';
+
+import Icon from '@/Icon';
+import { styles as menuStyles } from '@/Menu/sharedStyle';
+
+import { getOptionSearchText, isGroupOption } from './helpers';
+import { styles } from './style';
+import {
+  type SelectClassNames,
+  type SelectOption,
+  type SelectOptions,
+  type SelectProps,
+} from './type';
+
+interface RenderOptionsParams {
+  classNames: SelectClassNames | undefined;
+  isBoldIndicator: boolean;
+  items: SelectOptions<any>;
+  itemTextClassName: string;
+  listItemHeight: number | undefined;
+  optionRender: SelectProps['optionRender'];
+  renderVirtualItem: NonNullable<ComponentProps<typeof BaseSelect.Item>['render']>;
+  virtual: boolean | undefined;
+}
+
+function renderItem(
+  option: SelectOption<any>,
+  index: number,
+  params: Omit<RenderOptionsParams, 'items'>,
+) {
+  const {
+    classNames,
+    isBoldIndicator,
+    itemTextClassName,
+    listItemHeight,
+    optionRender,
+    renderVirtualItem,
+    virtual,
+  } = params;
+
+  return (
+    <BaseSelect.Item
+      disabled={option.disabled}
+      key={`${String(option.value)}-${index}`}
+      label={getOptionSearchText(option)}
+      render={virtual ? renderVirtualItem : undefined}
+      value={option.value}
+      className={cx(
+        menuStyles.item,
+        styles.item,
+        isBoldIndicator && styles.itemBoldSelected,
+        classNames?.item,
+        classNames?.option,
+        option.className,
+      )}
+      style={{
+        minHeight: listItemHeight,
+        ...option.style,
+      }}
+    >
+      <BaseSelect.ItemText className={itemTextClassName}>
+        {optionRender ? optionRender(option, { index }) : option.label}
+      </BaseSelect.ItemText>
+      {!isBoldIndicator && (
+        <BaseSelect.ItemIndicator className={cx(styles.itemIndicator, classNames?.itemIndicator)}>
+          <Icon icon={Check} size={'small'} />
+        </BaseSelect.ItemIndicator>
+      )}
+    </BaseSelect.Item>
+  );
+}
+
+export function renderOptions(params: RenderOptionsParams) {
+  const { classNames, items } = params;
+  let optionIndex = 0;
+
+  return items.map((item, index) => {
+    if (isGroupOption(item)) {
+      return (
+        <BaseSelect.Group className={cx(styles.group, classNames?.group)} key={`group-${index}`}>
+          <BaseSelect.GroupLabel
+            className={cx(menuStyles.groupLabel, styles.groupLabel, classNames?.groupLabel)}
+          >
+            {item.label}
+          </BaseSelect.GroupLabel>
+          {item.options.map((option) => renderItem(option, optionIndex++, params))}
+        </BaseSelect.Group>
+      );
+    }
+
+    return renderItem(item, optionIndex++, params);
+  });
+}


### PR DESCRIPTION
## Summary

Extend `ScrollArea` / `ScrollAreaViewport` `scrollFade` to accept an explicit
orientation in addition to the existing boolean, unlocking horizontal scroll
fade for tab strips, chip lists and any \`overflow-x\` viewport.

### API

\`\`\`ts
scrollFade?: boolean | 'vertical' | 'horizontal' | 'both';
\`\`\`

- \`false\` — no fade (default, unchanged).
- \`true\` / \`'vertical'\` — fade top and bottom edges (unchanged behavior).
- \`'horizontal'\` — fade start and end edges.
- \`'both'\` — fade all four edges; the two gradient masks are combined via
  \`mask-composite: intersect\` so corners only fade when both axes overflow.

\`true\` keeps mapping to \`'vertical'\` so every existing call site is preserved.

### Implementation

- Add \`viewportFadeHorizontal\` / \`viewportFadeBoth\` style variants mirroring
  the existing vertical implementation: \`mask-image\` driven by the matching
  \`--scroll-area-overflow-x|y-*\` CSS variables that Base UI exposes, with a
  scroll-driven animation (\`animation-timeline: scroll(self x|y)\`) on top.
- Route \`scrollFade\` through a small \`resolveFadeClass\` helper inside
  \`ScrollAreaViewport\` (both in \`src/ScrollArea\` and \`src/base-ui/ScrollArea\`).
- Update \`ScrollAreaProps\` / \`ScrollAreaViewportProps\` types and component
  docs (both pages, with the new value table entries).
- Add two demos: \`demos/horizontal.tsx\` (chip strip) and \`demos/fade-both.tsx\`
  (grid). The existing \`demos/index.tsx\`, \`demos/background.tsx\` and
  \`demos/both.tsx\` are unchanged.

### Compatibility

No breaking change. \`scrollFade={true}\` and \`scrollFade={false}\` continue to
work exactly as before.

## Test plan

- [ ] Verify \`scrollFade\` accepts \`'vertical' | 'horizontal' | 'both'\` and
      falls back correctly on browsers without \`animation-timeline: scroll()\`
      via the Base UI overflow CSS variables.
- [ ] Run \`pnpm docs:dev\` and visually inspect the three new sections:
      *Default*, *Horizontal fade*, *Fade in both directions*.
- [ ] Confirm \`true\` still renders the vertical fade (no regression).