### PR TITLE
feat(base-ui): unify z-index via floor-and-stack manager

### DIFF
--- a/src/base-ui/ContextMenu/ContextMenuHost.tsx
+++ b/src/base-ui/ContextMenu/ContextMenuHost.tsx
@@ -8,6 +8,7 @@ import { useAppElement } from '@/ThemeProvider';
 import { registerDevSingleton } from '@/utils/devSingleton';
 import { preventDefaultAndStopPropagation } from '@/utils/dom';
 
+import { useLayerZIndex } from '../zIndex';
 import { renderContextMenuItems } from './renderItems';
 import {
   closeContextMenu,
@@ -50,6 +51,7 @@ export const ContextMenuHost = memo(() => {
       }),
     [state.items, state.iconAlign, state.iconSpaceMode],
   );
+  const { zIndex, ref: zRef } = useLayerZIndex<HTMLDivElement>('floating');
   if (!isClient) return null;
   if (!state.open && state.items.length === 0) return null;
 
@@ -68,8 +70,9 @@ export const ContextMenuHost = memo(() => {
         <ContextMenu.Positioner
           anchor={state.anchor ?? undefined}
           className={styles.positioner}
+          ref={zRef as any}
           sideOffset={6}
-          style={noAnimationStyles}
+          style={{ ...noAnimationStyles, zIndex }}
         >
           <ContextMenu.Popup
             className={styles.popup}

--- a/src/base-ui/DropdownMenu/atoms.tsx
+++ b/src/base-ui/DropdownMenu/atoms.tsx
@@ -120,9 +120,16 @@ export const DropdownMenuPositioner = ({
   const [positionerNode, setPositionerNode] = useState<HTMLDivElement | null>(null);
 
   const explicitZIndex =
-    style?.zIndex != null && typeof style.zIndex === 'number' ? style.zIndex : undefined;
+    typeof style !== 'function' && style?.zIndex != null && typeof style.zIndex === 'number'
+      ? style.zIndex
+      : undefined;
   const { zIndex, ref: zRef } = useLayerZIndex<HTMLDivElement>('floating', explicitZIndex);
   const composedRef = useMergeRefs([setPositionerNode, zRef]);
+
+  const resolvedStyle =
+    typeof style === 'function'
+      ? (state: any) => ({ zIndex, ...style(state) })
+      : { zIndex, ...style };
 
   return (
     <Menu.Positioner
@@ -134,7 +141,7 @@ export const DropdownMenuPositioner = ({
       ref={composedRef as any}
       side={side ?? placementConfig?.side}
       sideOffset={sideOffset ?? (placementConfig ? 6 : undefined)}
-      style={{ zIndex, ...style }}
+      style={resolvedStyle}
     >
       <FloatingLayerProvider value={positionerNode}>{children}</FloatingLayerProvider>
     </Menu.Positioner>

--- a/src/base-ui/DropdownMenu/atoms.tsx
+++ b/src/base-ui/DropdownMenu/atoms.tsx
@@ -7,7 +7,7 @@ import { cx } from 'antd-style';
 import clsx from 'clsx';
 import type React from 'react';
 import { cloneElement, isValidElement, useCallback, useState } from 'react';
-import { mergeRefs } from 'react-merge-refs';
+import { mergeRefs, useMergeRefs } from 'react-merge-refs';
 
 import { FloatingLayerProvider } from '@/hooks/useFloatingLayer';
 import { useNativeButton } from '@/hooks/useNativeButton';
@@ -16,6 +16,7 @@ import { CLASSNAMES } from '@/styles/classNames';
 import { useAppElement } from '@/ThemeProvider';
 import { placementMap } from '@/utils/placement';
 
+import { useLayerZIndex } from '../zIndex';
 import { type DropdownMenuPlacement } from './type';
 
 export const DropdownMenuRoot: typeof Menu.Root = (props) => <Menu.Root modal={false} {...props} />;
@@ -112,10 +113,16 @@ export const DropdownMenuPositioner = ({
   side,
   sideOffset,
   children,
+  style,
   ...rest
 }: DropdownMenuPositionerProps) => {
   const placementConfig = placement ? placementMap[placement] : undefined;
   const [positionerNode, setPositionerNode] = useState<HTMLDivElement | null>(null);
+
+  const explicitZIndex =
+    style?.zIndex != null && typeof style.zIndex === 'number' ? style.zIndex : undefined;
+  const { zIndex, ref: zRef } = useLayerZIndex<HTMLDivElement>('floating', explicitZIndex);
+  const composedRef = useMergeRefs([setPositionerNode, zRef]);
 
   return (
     <Menu.Positioner
@@ -124,9 +131,10 @@ export const DropdownMenuPositioner = ({
       className={mergeStateClassName(styles.positioner, className as any) as any}
       data-hover-trigger={hoverTrigger || undefined}
       data-placement={placement}
-      ref={setPositionerNode}
+      ref={composedRef as any}
       side={side ?? placementConfig?.side}
       sideOffset={sideOffset ?? (placementConfig ? 6 : undefined)}
+      style={{ zIndex, ...style }}
     >
       <FloatingLayerProvider value={positionerNode}>{children}</FloatingLayerProvider>
     </Menu.Positioner>

--- a/src/base-ui/Modal/Modal.tsx
+++ b/src/base-ui/Modal/Modal.tsx
@@ -22,7 +22,6 @@ import {
 } from './atoms';
 import { styles } from './style';
 import type { ModalComponentProps } from './type';
-import { acquireModalZIndex } from './zIndexManager';
 
 interface OkBtnProps {
   confirmLoading?: boolean;
@@ -227,16 +226,6 @@ const Modal = memo<ModalComponentProps>(
 
     const container = getContainer === false ? undefined : (getContainer ?? undefined);
 
-    const prevOpenRef = useRef(false);
-    const acquiredZRef = useRef<number | undefined>(undefined);
-    if (open && !prevOpenRef.current) {
-      acquiredZRef.current = acquireModalZIndex();
-    }
-    prevOpenRef.current = !!open;
-    const effectiveZIndex = zIndex ?? acquiredZRef.current;
-    const backdropZIndex = effectiveZIndex ? { zIndex: effectiveZIndex } : undefined;
-    const popupZIndex = effectiveZIndex ? { zIndex: effectiveZIndex + 1 } : undefined;
-
     const shouldDrag = draggable && !isFullscreen;
     const dragProps = shouldDrag
       ? {
@@ -262,19 +251,15 @@ const Modal = memo<ModalComponentProps>(
     return (
       <ModalRoot
         open={open ?? false}
+        zIndex={zIndex}
         onExitComplete={handleExitComplete}
         onOpenChange={handleOpenChange}
       >
         <ModalPortal container={container}>
-          {mask && (
-            <ModalBackdrop
-              className={classNames?.mask}
-              style={{ ...backdropZIndex, ...semanticStyles?.mask }}
-            />
-          )}
+          {mask && <ModalBackdrop className={classNames?.mask} style={semanticStyles?.mask} />}
           <ModalPopup
             className={classNames?.wrapper}
-            popupStyle={{ ...popupZIndex, ...semanticStyles?.wrapper }}
+            popupStyle={semanticStyles?.wrapper}
             ref={constraintsRef}
             style={panelStyle}
             width={isFullscreen ? undefined : width}

--- a/src/base-ui/Modal/ModalLayerContext.tsx
+++ b/src/base-ui/Modal/ModalLayerContext.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { createContext, use } from 'react';
+
+export interface ModalLayer {
+  popupRef: (node: HTMLElement | null) => void;
+  zIndex: number | undefined;
+}
+
+const ModalLayerContext = createContext<ModalLayer | null>(null);
+
+export const useModalLayer = () => use(ModalLayerContext);
+export const ModalLayerProvider = ModalLayerContext.Provider;

--- a/src/base-ui/Modal/atoms.tsx
+++ b/src/base-ui/Modal/atoms.tsx
@@ -16,13 +16,15 @@ import {
   useMemo,
   useState,
 } from 'react';
-import { mergeRefs } from 'react-merge-refs';
+import { mergeRefs, useMergeRefs } from 'react-merge-refs';
 
 import { useNativeButton } from '@/hooks/useNativeButton';
 import { useMotionComponent } from '@/MotionProvider';
 import { useAppElement } from '@/ThemeProvider';
 
+import { useLayerZIndex } from '../zIndex';
 import { backdropTransition, modalMotionConfig } from './constants';
+import { ModalLayerProvider, useModalLayer } from './ModalLayerContext';
 import { styles } from './style';
 
 const mergeStateClassName = <TState,>(
@@ -50,12 +52,14 @@ export const useModalActions = () => use(ModalActionsContext);
 // --- Root ---
 export type ModalRootProps = Dialog.Root.Props & {
   onExitComplete?: () => void;
+  zIndex?: number;
 };
 
 const AnimatedModalRoot = ({
   open,
   children,
   onExitComplete: onExitCompleteProp,
+  zIndex: explicitZIndex,
   ...rest
 }: Omit<ModalRootProps, 'open'> & { open: boolean }) => {
   const [isPresent, setIsPresent] = useState(!!open);
@@ -71,16 +75,39 @@ const AnimatedModalRoot = ({
 
   const actions = useMemo(() => ({ onExitComplete: handleExitComplete }), [handleExitComplete]);
 
+  const { zIndex, ref: popupRef } = useLayerZIndex<HTMLDivElement>('modal', explicitZIndex);
+  const layer = useMemo(
+    () => ({ popupRef: popupRef as (node: HTMLElement | null) => void, zIndex }),
+    [zIndex, popupRef],
+  );
+
   if (!isPresent) return null;
 
   return (
     <ModalOpenContext value={open}>
       <ModalActionsContext value={actions}>
-        <Dialog.Root modal open {...rest}>
-          {children}
-        </Dialog.Root>
+        <ModalLayerProvider value={layer}>
+          <Dialog.Root modal open {...rest}>
+            {children}
+          </Dialog.Root>
+        </ModalLayerProvider>
       </ModalActionsContext>
     </ModalOpenContext>
+  );
+};
+
+const NonAnimatedModalRoot = ({ zIndex: explicitZIndex, children, ...rest }: ModalRootProps) => {
+  const { zIndex, ref: popupRef } = useLayerZIndex<HTMLDivElement>('modal', explicitZIndex);
+  const layer = useMemo(
+    () => ({ popupRef: popupRef as (node: HTMLElement | null) => void, zIndex }),
+    [zIndex, popupRef],
+  );
+  return (
+    <ModalLayerProvider value={layer}>
+      <Dialog.Root modal {...rest}>
+        {children}
+      </Dialog.Root>
+    </ModalLayerProvider>
   );
 };
 
@@ -88,7 +115,7 @@ export const ModalRoot = ({ open, onExitComplete, ...rest }: ModalRootProps) => 
   if (open !== undefined) {
     return <AnimatedModalRoot open={open} onExitComplete={onExitComplete} {...rest} />;
   }
-  return <Dialog.Root modal {...rest} />;
+  return <NonAnimatedModalRoot {...rest} />;
 };
 
 // --- Portal ---
@@ -113,14 +140,16 @@ export const ModalViewport = ({ className, ...rest }: ModalViewportProps) => (
 export type ModalBackdropProps = React.ComponentProps<typeof Dialog.Backdrop>;
 export const ModalBackdrop = ({ className, style, ...rest }: ModalBackdropProps) => {
   const open = useModalOpen();
+  const layer = useModalLayer();
   const Motion = useMotionComponent();
+  const layerStyle = layer?.zIndex !== undefined ? { zIndex: layer.zIndex } : undefined;
 
   if (open !== null) {
     return (
       <Dialog.Backdrop
         {...rest}
         className={cx(styles.backdrop, className as string)}
-        style={{ ...style, transition: 'none' }}
+        style={{ ...layerStyle, ...style, transition: 'none' }}
         render={
           <Motion.div
             animate={{ opacity: open ? 1 : 0 }}
@@ -136,7 +165,7 @@ export const ModalBackdrop = ({ className, style, ...rest }: ModalBackdropProps)
     <Dialog.Backdrop
       {...rest}
       className={mergeStateClassName(styles.backdrop, className as any) as any}
-      style={style}
+      style={{ ...layerStyle, ...style }}
     />
   );
 };
@@ -156,15 +185,24 @@ export const ModalPopup = ({
   motionProps,
   panelClassName,
   popupStyle,
+  ref: forwardedRef,
   ...rest
 }: ModalPopupProps) => {
   const open = useModalOpen();
   const actions = useModalActions();
+  const layer = useModalLayer();
   const Motion = useMotionComponent();
+  const popupZIndexStyle = layer?.zIndex !== undefined ? { zIndex: layer.zIndex + 1 } : undefined;
+  const composedRef = useMergeRefs([forwardedRef, layer?.popupRef]);
 
   if (open !== null && actions) {
     return (
-      <Dialog.Popup {...rest} className={cx(styles.popup, className as string)} style={popupStyle}>
+      <Dialog.Popup
+        {...rest}
+        className={cx(styles.popup, className as string)}
+        ref={composedRef as any}
+        style={{ ...popupZIndexStyle, ...popupStyle }}
+      >
         <AnimatePresence onExitComplete={actions.onExitComplete}>
           {open ? (
             <Motion.div
@@ -186,7 +224,8 @@ export const ModalPopup = ({
     <Dialog.Popup
       {...rest}
       className={mergeStateClassName(styles.popup, className as any) as any}
-      style={popupStyle}
+      ref={composedRef as any}
+      style={{ ...popupZIndexStyle, ...popupStyle }}
     >
       <div
         className={cx(styles.popupInner, panelClassName)}

--- a/src/base-ui/Modal/demos/zindex-dropdown-in-modal.tsx
+++ b/src/base-ui/Modal/demos/zindex-dropdown-in-modal.tsx
@@ -1,0 +1,74 @@
+import { Button, Flexbox, Text } from '@lobehub/ui';
+import {
+  DropdownMenuItem,
+  DropdownMenuPopup,
+  DropdownMenuPortal,
+  DropdownMenuPositioner,
+  DropdownMenuRoot,
+  DropdownMenuTrigger,
+  ModalBackdrop,
+  ModalClose,
+  ModalContent,
+  ModalHeader,
+  ModalPopup,
+  ModalPortal,
+  ModalRoot,
+  ModalTitle,
+} from '@lobehub/ui/base-ui';
+import { useState } from 'react';
+
+export default () => {
+  const [modalOpen, setModalOpen] = useState(false);
+
+  return (
+    <Flexbox gap={16} padding={16} style={{ margin: '0 auto', maxWidth: 560 }}>
+      <Flexbox gap={4}>
+        <Text style={{ fontSize: 14, fontWeight: 500 }}>
+          z-index regression: DropdownMenu inside Modal
+        </Text>
+        <Text style={{ fontSize: 12, opacity: 0.6 }}>
+          Open the modal, then click the in-modal "Open Dropdown" button. Expected: dropdown popup
+          renders above the modal popup. Bug: dropdown sits below the modal panel.
+        </Text>
+      </Flexbox>
+
+      <Button onClick={() => setModalOpen(true)}>Open Modal</Button>
+
+      <ModalRoot
+        open={modalOpen}
+        onOpenChange={(next) => {
+          if (!next) setModalOpen(false);
+        }}
+      >
+        <ModalPortal>
+          <ModalBackdrop />
+          <ModalPopup width={420}>
+            <ModalHeader>
+              <ModalTitle>Modal with inner Dropdown</ModalTitle>
+              <ModalClose />
+            </ModalHeader>
+            <ModalContent>
+              <Flexbox gap={12}>
+                <Text>Click the button below to open a dropdown inside this modal.</Text>
+                <DropdownMenuRoot>
+                  <DropdownMenuTrigger nativeButton>
+                    <Button>Open Dropdown</Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuPortal>
+                    <DropdownMenuPositioner placement="bottomLeft">
+                      <DropdownMenuPopup>
+                        <DropdownMenuItem>Item A</DropdownMenuItem>
+                        <DropdownMenuItem>Item B</DropdownMenuItem>
+                        <DropdownMenuItem>Item C</DropdownMenuItem>
+                      </DropdownMenuPopup>
+                    </DropdownMenuPositioner>
+                  </DropdownMenuPortal>
+                </DropdownMenuRoot>
+              </Flexbox>
+            </ModalContent>
+          </ModalPopup>
+        </ModalPortal>
+      </ModalRoot>
+    </Flexbox>
+  );
+};

--- a/src/base-ui/Modal/demos/zindex-with-dropdown.tsx
+++ b/src/base-ui/Modal/demos/zindex-with-dropdown.tsx
@@ -1,0 +1,84 @@
+import { Button, Flexbox, Text } from '@lobehub/ui';
+import {
+  DropdownMenuItem,
+  DropdownMenuPopup,
+  DropdownMenuPortal,
+  DropdownMenuPositioner,
+  DropdownMenuRoot,
+  DropdownMenuTrigger,
+  ModalBackdrop,
+  ModalClose,
+  ModalContent,
+  ModalHeader,
+  ModalPopup,
+  ModalPortal,
+  ModalRoot,
+  ModalTitle,
+} from '@lobehub/ui/base-ui';
+import { useState } from 'react';
+
+export default () => {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+
+  return (
+    <Flexbox gap={16} padding={16} style={{ margin: '0 auto', maxWidth: 560 }}>
+      <Flexbox gap={4}>
+        <Text style={{ fontSize: 14, fontWeight: 500 }}>
+          z-index regression: Modal vs DropdownMenu
+        </Text>
+        <Text style={{ fontSize: 12, opacity: 0.6 }}>
+          Open the dropdown, then click "Open Modal". Both should remain mounted. Expected: modal
+          renders above the dropdown. Bug: modal sits below the dropdown popup.
+        </Text>
+      </Flexbox>
+
+      <Flexbox horizontal gap={8}>
+        <DropdownMenuRoot open={menuOpen} onOpenChange={setMenuOpen}>
+          <DropdownMenuTrigger nativeButton>
+            <Button>Open Dropdown</Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuPortal>
+            <DropdownMenuPositioner placement="bottomLeft">
+              <DropdownMenuPopup>
+                <DropdownMenuItem
+                  closeOnClick={false}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setModalOpen(true);
+                  }}
+                >
+                  Open Modal (keep menu open)
+                </DropdownMenuItem>
+                <DropdownMenuItem closeOnClick={false}>Stay here</DropdownMenuItem>
+              </DropdownMenuPopup>
+            </DropdownMenuPositioner>
+          </DropdownMenuPortal>
+        </DropdownMenuRoot>
+      </Flexbox>
+
+      <ModalRoot
+        open={modalOpen}
+        onOpenChange={(next) => {
+          if (!next) setModalOpen(false);
+        }}
+      >
+        <ModalPortal>
+          <ModalBackdrop />
+          <ModalPopup width={420}>
+            <ModalHeader>
+              <ModalTitle>Modal from Dropdown</ModalTitle>
+              <ModalClose />
+            </ModalHeader>
+            <ModalContent>
+              <Text>
+                If you can read this, the modal is on top. If the dropdown menu covers this content,
+                the z-index hierarchy is broken.
+              </Text>
+            </ModalContent>
+          </ModalPopup>
+        </ModalPortal>
+      </ModalRoot>
+    </Flexbox>
+  );
+};

--- a/src/base-ui/Modal/imperative.tsx
+++ b/src/base-ui/Modal/imperative.tsx
@@ -2,7 +2,7 @@
 
 import { cx, useTheme } from 'antd-style';
 import type { ReactNode } from 'react';
-import { memo, useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { memo, useCallback, useEffect, useState, useSyncExternalStore } from 'react';
 import { createPortal } from 'react-dom';
 
 import { useIsClient } from '@/hooks/useIsClient';
@@ -24,7 +24,6 @@ import {
 import { ModalContext, useModalContext } from './context';
 import { styles } from './style';
 import type { ImperativeModalProps, ModalConfirmConfig, ModalInstance } from './type';
-import { acquireModalZIndex } from './zIndexManager';
 
 // --- Shared types ---
 
@@ -187,14 +186,6 @@ export function createModalSystem(): ModalSystem {
 
     const isOpen = open ?? true;
 
-    const zIndexRef = useRef<number | undefined>(undefined);
-    const prevOpenRef = useRef(false);
-    if (isOpen && !prevOpenRef.current) {
-      zIndexRef.current = acquireModalZIndex();
-    }
-    prevOpenRef.current = isOpen;
-    const zIndex = zIndexRef.current ?? 1000;
-
     const handleOpenChange = useCallback(
       (nextOpen: boolean, eventDetails?: { reason: string }) => {
         if (!nextOpen && maskClosable === false && eventDetails?.reason === 'outside-press') return;
@@ -225,13 +216,10 @@ export function createModalSystem(): ModalSystem {
           onOpenChange={handleOpenChange}
         >
           <ModalPortal>
-            <ModalBackdrop
-              className={classNames?.backdrop}
-              style={{ zIndex, ...semanticStyles?.backdrop }}
-            />
+            <ModalBackdrop className={classNames?.backdrop} style={semanticStyles?.backdrop} />
             <ModalPopup
               className={classNames?.popup}
-              popupStyle={{ zIndex: zIndex + 1, ...semanticStyles?.popup }}
+              popupStyle={semanticStyles?.popup}
               width={width}
             >
               {showTitle && (

--- a/src/base-ui/Modal/index.md
+++ b/src/base-ui/Modal/index.md
@@ -26,6 +26,18 @@ apiHeader:
 
 <code src="./demos/nested.tsx" nopadding></code>
 
+## z-index with DropdownMenu (TDD repro)
+
+When a dropdown menu stays mounted and a modal opens, the modal must layer above the dropdown popup.
+
+<code src="./demos/zindex-with-dropdown.tsx" nopadding></code>
+
+## z-index — DropdownMenu inside Modal (TDD repro)
+
+A dropdown opened from inside a modal must layer above the modal popup.
+
+<code src="./demos/zindex-dropdown-in-modal.tsx" nopadding></code>
+
 ## Atom Components
 
 <code src="./demos/atoms.tsx" nopadding></code>

--- a/src/base-ui/Modal/style.ts
+++ b/src/base-ui/Modal/style.ts
@@ -3,7 +3,7 @@ import { createStaticStyles } from 'antd-style';
 export const styles = createStaticStyles(({ css, cssVar }) => ({
   backdrop: css`
     position: fixed;
-    z-index: 1000;
+    z-index: 1200;
     inset: 0;
 
     background: color-mix(in srgb, ${cssVar.colorBgContainer} 60%, transparent);
@@ -116,7 +116,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     pointer-events: none;
 
     position: fixed;
-    z-index: 1001;
+    z-index: 1201;
     inset: 0;
 
     display: flex;
@@ -319,7 +319,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
 
   viewport: css`
     position: fixed;
-    z-index: 1000;
+    z-index: 1200;
     inset: 0;
     overflow: auto;
   `,

--- a/src/base-ui/Modal/style.ts
+++ b/src/base-ui/Modal/style.ts
@@ -140,7 +140,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     border: 1px solid ${cssVar.colorBorderSecondary};
     border-radius: 12px;
 
-    background: ${cssVar.colorBgContainer};
+    background: ${cssVar.colorBgElevated};
     box-shadow: ${cssVar.boxShadow};
 
     transition:

--- a/src/base-ui/Modal/zIndexManager.ts
+++ b/src/base-ui/Modal/zIndexManager.ts
@@ -1,8 +1,0 @@
-const BASE_MODAL_Z_INDEX = 1000;
-
-let top = BASE_MODAL_Z_INDEX;
-
-export const acquireModalZIndex = () => {
-  top += 10;
-  return top;
-};

--- a/src/base-ui/Popover/PopoverGroup.tsx
+++ b/src/base-ui/Popover/PopoverGroup.tsx
@@ -95,7 +95,7 @@ const PopoverGroup: FC<PopoverGroupProps> = ({
               arrow: item.styles?.arrow,
               positioner: {
                 ...item.styles?.root,
-                zIndex: item.zIndex ?? 1100,
+                ...(item.zIndex !== undefined ? { zIndex: item.zIndex } : {}),
               },
               viewport: item.styles?.content,
             };

--- a/src/base-ui/Popover/PopoverStandalone.tsx
+++ b/src/base-ui/Popover/PopoverStandalone.tsx
@@ -155,7 +155,7 @@ export const PopoverStandalone = memo<PopoverProps>(
         arrow: styleProps?.arrow,
         positioner: {
           ...styleProps?.root,
-          zIndex: zIndex ?? 1100,
+          ...(zIndex !== undefined ? { zIndex } : {}),
         },
         viewport: styleProps?.content,
       }),

--- a/src/base-ui/Popover/atoms.tsx
+++ b/src/base-ui/Popover/atoms.tsx
@@ -139,9 +139,16 @@ export const PopoverPositioner = ({
   const placementConfig = placement ? placementMap[placement] : undefined;
   const [positionerNode, setPositionerNode] = useState<HTMLDivElement | null>(null);
   const explicitZIndex =
-    style?.zIndex != null && typeof style.zIndex === 'number' ? style.zIndex : undefined;
+    typeof style !== 'function' && style?.zIndex != null && typeof style.zIndex === 'number'
+      ? style.zIndex
+      : undefined;
   const { zIndex, ref: zRef } = useLayerZIndex<HTMLDivElement>('floating', explicitZIndex);
   const composedRef = useMergeRefs([setPositionerNode, zRef]);
+
+  const resolvedStyle =
+    typeof style === 'function'
+      ? (state: any) => ({ zIndex, ...style(state) })
+      : { zIndex, ...style };
 
   return (
     <BasePopover.Positioner
@@ -151,7 +158,7 @@ export const PopoverPositioner = ({
       ref={composedRef as any}
       side={side ?? placementConfig?.side ?? 'bottom'}
       sideOffset={sideOffset ?? 6}
-      style={{ zIndex, ...style }}
+      style={resolvedStyle}
       className={(state) =>
         cx(styles.positioner, typeof className === 'function' ? className(state) : className)
       }

--- a/src/base-ui/Popover/atoms.tsx
+++ b/src/base-ui/Popover/atoms.tsx
@@ -10,12 +10,13 @@ import {
   isValidElement,
   useState,
 } from 'react';
-import { mergeRefs } from 'react-merge-refs';
+import { mergeRefs, useMergeRefs } from 'react-merge-refs';
 
 import { FloatingLayerProvider } from '@/hooks/useFloatingLayer';
 import { useNativeButton } from '@/hooks/useNativeButton';
 import { placementMap } from '@/utils/placement';
 
+import { useLayerZIndex } from '../zIndex';
 import { PopoverArrowIcon } from './ArrowIcon';
 import { usePopoverPortalContainer } from './PopoverPortal';
 import { styles } from './style';
@@ -132,19 +133,25 @@ export const PopoverPositioner = ({
   align,
   side,
   sideOffset,
+  style,
   ...rest
 }: PopoverPositionerAtomProps) => {
   const placementConfig = placement ? placementMap[placement] : undefined;
   const [positionerNode, setPositionerNode] = useState<HTMLDivElement | null>(null);
+  const explicitZIndex =
+    style?.zIndex != null && typeof style.zIndex === 'number' ? style.zIndex : undefined;
+  const { zIndex, ref: zRef } = useLayerZIndex<HTMLDivElement>('floating', explicitZIndex);
+  const composedRef = useMergeRefs([setPositionerNode, zRef]);
 
   return (
     <BasePopover.Positioner
       align={align ?? placementConfig?.align ?? 'center'}
       data-hover-trigger={hoverTrigger || undefined}
       data-placement={placement}
-      ref={setPositionerNode}
+      ref={composedRef as any}
       side={side ?? placementConfig?.side ?? 'bottom'}
       sideOffset={sideOffset ?? 6}
+      style={{ zIndex, ...style }}
       className={(state) =>
         cx(styles.positioner, typeof className === 'function' ? className(state) : className)
       }

--- a/src/base-ui/Popover/style.ts
+++ b/src/base-ui/Popover/style.ts
@@ -60,6 +60,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
 
     min-width: 120px;
     max-width: var(--available-width);
+    border: 1px solid ${cssVar.colorBorderSecondary};
     border-radius: ${cssVar.borderRadius};
 
     color: ${cssVar.colorText};

--- a/src/base-ui/Select/Select.tsx
+++ b/src/base-ui/Select/Select.tsx
@@ -7,6 +7,7 @@ import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { styles as menuStyles } from '@/Menu/sharedStyle';
 
+import { SelectPositioner } from './atoms';
 import { isValueEmpty } from './helpers';
 import {
   usePortalContainer,
@@ -247,7 +248,7 @@ const Select = memo<SelectProps<any>>(
         </BaseSelect.Trigger>
 
         <BaseSelect.Portal container={portalContainer}>
-          <BaseSelect.Positioner
+          <SelectPositioner
             align="start"
             alignItemWithTrigger={isItemAligned}
             className={styles.positioner}
@@ -283,7 +284,7 @@ const Select = memo<SelectProps<any>>(
                 virtualState={virtualState}
               />
             </BaseSelect.Popup>
-          </BaseSelect.Positioner>
+          </SelectPositioner>
         </BaseSelect.Portal>
       </BaseSelect.Root>
     );

--- a/src/base-ui/Select/atoms.tsx
+++ b/src/base-ui/Select/atoms.tsx
@@ -9,12 +9,13 @@ import {
   type ComponentPropsWithRef,
   isValidElement,
 } from 'react';
-import { mergeRefs } from 'react-merge-refs';
+import { mergeRefs, useMergeRefs } from 'react-merge-refs';
 
 import { useNativeButton } from '@/hooks/useNativeButton';
 import { styles as menuStyles } from '@/Menu/sharedStyle';
 import { useAppElement } from '@/ThemeProvider';
 
+import { useLayerZIndex } from '../zIndex';
 import { styles, triggerVariants } from './style';
 import { type SelectSize, type SelectVariant } from './type';
 
@@ -143,15 +144,23 @@ export const SelectPositioner = ({
   className,
   side,
   sideOffset,
+  style,
+  ref: forwardedRef,
   ...rest
 }: SelectPositionerProps) => {
+  const explicitZIndex =
+    style?.zIndex != null && typeof style.zIndex === 'number' ? style.zIndex : undefined;
+  const { zIndex, ref: zRef } = useLayerZIndex<HTMLDivElement>('floating', explicitZIndex);
+  const composedRef = useMergeRefs([forwardedRef, zRef]);
   return (
     <Select.Positioner
       align={align ?? 'start'}
       alignItemWithTrigger={alignItemWithTrigger ?? false}
       className={mergeStateClassName(styles.positioner, className) as any}
+      ref={composedRef as any}
       side={side ?? 'bottom'}
       sideOffset={sideOffset ?? 6}
+      style={{ zIndex, ...style }}
       {...rest}
     />
   );

--- a/src/base-ui/Select/atoms.tsx
+++ b/src/base-ui/Select/atoms.tsx
@@ -149,9 +149,17 @@ export const SelectPositioner = ({
   ...rest
 }: SelectPositionerProps) => {
   const explicitZIndex =
-    style?.zIndex != null && typeof style.zIndex === 'number' ? style.zIndex : undefined;
+    typeof style !== 'function' && style?.zIndex != null && typeof style.zIndex === 'number'
+      ? style.zIndex
+      : undefined;
   const { zIndex, ref: zRef } = useLayerZIndex<HTMLDivElement>('floating', explicitZIndex);
   const composedRef = useMergeRefs([forwardedRef, zRef]);
+
+  const resolvedStyle =
+    typeof style === 'function'
+      ? (state: any) => ({ zIndex, ...style(state) })
+      : { zIndex, ...style };
+
   return (
     <Select.Positioner
       align={align ?? 'start'}
@@ -160,7 +168,7 @@ export const SelectPositioner = ({
       ref={composedRef as any}
       side={side ?? 'bottom'}
       sideOffset={sideOffset ?? 6}
-      style={{ zIndex, ...style }}
+      style={resolvedStyle}
       {...rest}
     />
   );

--- a/src/base-ui/Toast/imperative.tsx
+++ b/src/base-ui/Toast/imperative.tsx
@@ -2,11 +2,12 @@
 
 import { Toast as BaseToast } from '@base-ui/react/toast';
 import { cx } from 'antd-style';
-import { memo, useEffect } from 'react';
+import { memo, useEffect, useState } from 'react';
 
 import { useIsClient } from '@/hooks/useIsClient';
 import { useAppElement } from '@/ThemeProvider';
 
+import { acquireLayerZIndex } from '../zIndex';
 import { ToastContext } from './context';
 import { viewportVariants } from './style';
 import ToastItem from './Toast';
@@ -272,6 +273,7 @@ export const ToastHost = memo(
   }: ToastHostProps) => {
     const isClient = useIsClient();
     const appElement = useAppElement();
+    const [viewportZIndex, setViewportZIndex] = useState<number | undefined>(undefined);
 
     useEffect(() => {
       globalState = {
@@ -282,6 +284,10 @@ export const ToastHost = memo(
       };
     }, [duration, limit, position, swipeDirection]);
 
+    useEffect(() => {
+      setViewportZIndex(acquireLayerZIndex('toast'));
+    }, []);
+
     if (!isClient) return null;
 
     const container = root ?? appElement ?? document.body;
@@ -290,7 +296,10 @@ export const ToastHost = memo(
       <ToastContext key={pos} value={{ position: pos, swipeDirection }}>
         <BaseToast.Provider limit={limit} timeout={duration} toastManager={getManager(pos)}>
           <BaseToast.Portal container={container}>
-            <BaseToast.Viewport className={cx(viewportVariants({ position: pos }), className)}>
+            <BaseToast.Viewport
+              className={cx(viewportVariants({ position: pos }), className)}
+              style={{ zIndex: viewportZIndex }}
+            >
               <ToastList />
             </BaseToast.Viewport>
           </BaseToast.Portal>

--- a/src/base-ui/Toast/style.ts
+++ b/src/base-ui/Toast/style.ts
@@ -332,7 +332,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
 
   viewport: css`
     position: fixed;
-    z-index: 1100;
+    z-index: 100000;
 
     width: 360px;
     max-width: calc(100vw - 32px);

--- a/src/base-ui/zIndex/constants.ts
+++ b/src/base-ui/zIndex/constants.ts
@@ -1,0 +1,8 @@
+export const Z_INDEX_LAYER = {
+  floating: 1100,
+  modal: 1200,
+  toast: 100_000,
+  step: 10,
+} as const;
+
+export type LayerTier = 'floating' | 'modal' | 'toast';

--- a/src/base-ui/zIndex/index.ts
+++ b/src/base-ui/zIndex/index.ts
@@ -1,0 +1,3 @@
+export { type LayerTier, Z_INDEX_LAYER } from './constants';
+export { acquireLayerZIndex } from './manager';
+export { type LayerZIndexResult, useLayerZIndex } from './useLayerZIndex';

--- a/src/base-ui/zIndex/manager.test.ts
+++ b/src/base-ui/zIndex/manager.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Z_INDEX_LAYER } from './constants';
+import { __resetLayerZIndexForTests, __seedMainTopForTests, acquireLayerZIndex } from './manager';
+
+describe('acquireLayerZIndex', () => {
+  beforeEach(() => {
+    __resetLayerZIndexForTests();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    __resetLayerZIndexForTests();
+  });
+
+  it('first floating acquire returns >= floating base + step', () => {
+    const z = acquireLayerZIndex('floating');
+    expect(z).toBeGreaterThanOrEqual(Z_INDEX_LAYER.floating + Z_INDEX_LAYER.step);
+  });
+
+  it('successive floating acquires step by step', () => {
+    const z1 = acquireLayerZIndex('floating');
+    const z2 = acquireLayerZIndex('floating');
+    expect(z2 - z1).toBe(Z_INDEX_LAYER.step);
+  });
+
+  it('modal after floating uses shared main counter (modal > floating)', () => {
+    const zF = acquireLayerZIndex('floating');
+    const zM = acquireLayerZIndex('modal');
+    expect(zM).toBeGreaterThan(zF);
+  });
+
+  it('floating after modal beats modal (open order wins over tier)', () => {
+    const zM = acquireLayerZIndex('modal');
+    const zF = acquireLayerZIndex('floating');
+    expect(zF).toBeGreaterThan(zM);
+  });
+
+  it('toast acquires from independent counter at or above toast base', () => {
+    acquireLayerZIndex('floating');
+    acquireLayerZIndex('modal');
+    const zT = acquireLayerZIndex('toast');
+    expect(zT).toBeGreaterThanOrEqual(Z_INDEX_LAYER.toast + Z_INDEX_LAYER.step);
+  });
+
+  it('500 main acquires stays below toast tier and emits no warning', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let last = 0;
+    for (let i = 0; i < 500; i++) {
+      last = acquireLayerZIndex('floating');
+    }
+    expect(last).toBeLessThan(Z_INDEX_LAYER.toast);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('warns exactly once when main counter reaches toast tier', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    __seedMainTopForTests(Z_INDEX_LAYER.toast - Z_INDEX_LAYER.step);
+    acquireLayerZIndex('floating'); // crosses threshold
+    acquireLayerZIndex('floating'); // already above, should not re-warn
+    acquireLayerZIndex('floating'); // ditto
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('__resetLayerZIndexForTests clears the warn-once flag too', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    __seedMainTopForTests(Z_INDEX_LAYER.toast - Z_INDEX_LAYER.step);
+    acquireLayerZIndex('floating');
+    expect(spy).toHaveBeenCalledTimes(1);
+    __resetLayerZIndexForTests();
+    __seedMainTopForTests(Z_INDEX_LAYER.toast - Z_INDEX_LAYER.step);
+    acquireLayerZIndex('floating');
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/base-ui/zIndex/manager.ts
+++ b/src/base-ui/zIndex/manager.ts
@@ -1,0 +1,35 @@
+import { type LayerTier, Z_INDEX_LAYER } from './constants';
+
+let mainTop = 0;
+let toastTop = 0;
+let warnedMainOverflow = false;
+
+export function acquireLayerZIndex(tier: LayerTier): number {
+  if (tier === 'toast') {
+    toastTop = Math.max(toastTop, Z_INDEX_LAYER.toast) + Z_INDEX_LAYER.step;
+    return toastTop;
+  }
+  mainTop = Math.max(mainTop, Z_INDEX_LAYER[tier]) + Z_INDEX_LAYER.step;
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    !warnedMainOverflow &&
+    mainTop >= Z_INDEX_LAYER.toast
+  ) {
+    warnedMainOverflow = true;
+
+    console.warn(
+      `[lobe-ui z-index] main stack reached toast tier (${mainTop}); unexpected nesting depth`,
+    );
+  }
+  return mainTop;
+}
+
+export function __resetLayerZIndexForTests(): void {
+  mainTop = 0;
+  toastTop = 0;
+  warnedMainOverflow = false;
+}
+
+export function __seedMainTopForTests(value: number): void {
+  mainTop = value;
+}

--- a/src/base-ui/zIndex/useLayerZIndex.test.tsx
+++ b/src/base-ui/zIndex/useLayerZIndex.test.tsx
@@ -1,0 +1,82 @@
+import { act, cleanup, render } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Z_INDEX_LAYER } from './constants';
+import { __resetLayerZIndexForTests } from './manager';
+import { useLayerZIndex } from './useLayerZIndex';
+
+function Probe({
+  initial,
+  explicit,
+  tier = 'floating' as const,
+}: {
+  initial: 'open' | 'closed';
+  explicit?: number;
+  tier?: 'floating' | 'modal' | 'toast';
+}) {
+  const { zIndex, ref } = useLayerZIndex(tier, explicit);
+  return <div data-testid="probe" ref={ref} style={{ zIndex }} {...{ [`data-${initial}`]: '' }} />;
+}
+
+const setState = (el: HTMLElement, state: 'open' | 'closed') => {
+  el.removeAttribute('data-open');
+  el.removeAttribute('data-closed');
+  el.setAttribute(`data-${state}`, '');
+};
+
+describe('useLayerZIndex', () => {
+  beforeEach(() => {
+    __resetLayerZIndexForTests();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    __resetLayerZIndexForTests();
+  });
+
+  it('mounts with data-open: acquires immediately', () => {
+    const { getByTestId } = render(<Probe initial="open" />);
+    const el = getByTestId('probe');
+    expect(Number(el.style.zIndex)).toBeGreaterThanOrEqual(
+      Z_INDEX_LAYER.floating + Z_INDEX_LAYER.step,
+    );
+  });
+
+  it('mounts with data-closed: no acquire until attribute flips', async () => {
+    const { getByTestId } = render(<Probe initial="closed" />);
+    const el = getByTestId('probe');
+    expect(el.style.zIndex).toBe('');
+    await act(async () => {
+      setState(el, 'open');
+    });
+    expect(Number(el.style.zIndex)).toBeGreaterThan(0);
+  });
+
+  it('re-acquires on closed → open → closed → open (open order wins)', async () => {
+    const { getByTestId } = render(<Probe initial="closed" />);
+    const el = getByTestId('probe');
+    await act(async () => {
+      setState(el, 'open');
+    });
+    const first = Number(el.style.zIndex);
+    await act(async () => {
+      setState(el, 'closed');
+    });
+    await act(async () => {
+      setState(el, 'open');
+    });
+    const second = Number(el.style.zIndex);
+    expect(second).toBeGreaterThan(first);
+  });
+
+  it('explicitZIndex short-circuits acquire (counter untouched)', () => {
+    const first = render(<Probe explicit={777} initial="open" />);
+    expect(first.getByTestId('probe').style.zIndex).toBe('777');
+    first.unmount();
+    const second = render(<Probe initial="open" />);
+    const el = second.getByTestId('probe');
+    expect(Number(el.style.zIndex)).toBe(Z_INDEX_LAYER.floating + Z_INDEX_LAYER.step);
+  });
+});

--- a/src/base-ui/zIndex/useLayerZIndex.test.tsx
+++ b/src/base-ui/zIndex/useLayerZIndex.test.tsx
@@ -19,6 +19,17 @@ function Probe({
   return <div data-testid="probe" ref={ref} style={{ zIndex }} {...{ [`data-${initial}`]: '' }} />;
 }
 
+function DynamicProbe({
+  initial,
+  explicit,
+}: {
+  initial: 'open' | 'closed';
+  explicit?: number;
+}) {
+  const { zIndex, ref } = useLayerZIndex('floating', explicit);
+  return <div data-testid="probe" ref={ref} style={{ zIndex }} {...{ [`data-${initial}`]: '' }} />;
+}
+
 const setState = (el: HTMLElement, state: 'open' | 'closed') => {
   el.removeAttribute('data-open');
   el.removeAttribute('data-closed');
@@ -78,5 +89,17 @@ describe('useLayerZIndex', () => {
     const second = render(<Probe initial="open" />);
     const el = second.getByTestId('probe');
     expect(Number(el.style.zIndex)).toBe(Z_INDEX_LAYER.floating + Z_INDEX_LAYER.step);
+  });
+
+  it('updates explicit zIndex when prop changes', () => {
+    const { getByTestId, rerender } = render(<DynamicProbe initial="open" explicit={100} />);
+    expect(getByTestId('probe').style.zIndex).toBe('100');
+    rerender(<DynamicProbe initial="open" explicit={200} />);
+    expect(getByTestId('probe').style.zIndex).toBe('200');
+    // Switching to undefined should fall back to dynamic acquire
+    rerender(<DynamicProbe initial="open" explicit={undefined} />);
+    expect(Number(getByTestId('probe').style.zIndex)).toBeGreaterThanOrEqual(
+      Z_INDEX_LAYER.floating + Z_INDEX_LAYER.step,
+    );
   });
 });

--- a/src/base-ui/zIndex/useLayerZIndex.tsx
+++ b/src/base-ui/zIndex/useLayerZIndex.tsx
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { type LayerTier } from './constants';
+import { acquireLayerZIndex } from './manager';
+
+export interface LayerZIndexResult<T extends HTMLElement = HTMLElement> {
+  ref: (node: T | null) => void;
+  zIndex: number | undefined;
+}
+
+export function useLayerZIndex<T extends HTMLElement = HTMLElement>(
+  tier: LayerTier,
+  explicitZIndex?: number,
+): LayerZIndexResult<T> {
+  const [zIndex, setZIndex] = useState<number | undefined>(undefined);
+
+  const stateRef = useRef<{
+    tier: LayerTier;
+    explicit: number | undefined;
+    node: T | null;
+    observer: MutationObserver | null;
+    prevOpen: boolean;
+  }>({
+    tier,
+    explicit: explicitZIndex,
+    node: null,
+    observer: null,
+    prevOpen: false,
+  });
+
+  const ref = useCallback((node: T | null) => {
+    if (node === stateRef.current.node) return;
+    stateRef.current.observer?.disconnect();
+    stateRef.current.observer = null;
+    stateRef.current.node = node;
+    stateRef.current.prevOpen = false;
+    if (!node) return;
+    if (stateRef.current.explicit !== undefined) return;
+    const handle = () => {
+      const isOpen = node.hasAttribute('data-open');
+      if (isOpen && !stateRef.current.prevOpen) {
+        setZIndex(acquireLayerZIndex(stateRef.current.tier));
+      }
+      stateRef.current.prevOpen = isOpen;
+    };
+    handle();
+    const observer = new MutationObserver(handle);
+    observer.observe(node, {
+      attributes: true,
+      attributeFilter: ['data-open', 'data-closed'],
+    });
+    stateRef.current.observer = observer;
+  }, []);
+
+  useEffect(
+    () => () => {
+      stateRef.current.observer?.disconnect();
+    },
+    [],
+  );
+
+  return { zIndex: stateRef.current.explicit ?? zIndex, ref };
+}

--- a/src/base-ui/zIndex/useLayerZIndex.tsx
+++ b/src/base-ui/zIndex/useLayerZIndex.tsx
@@ -28,9 +28,45 @@ export function useLayerZIndex<T extends HTMLElement = HTMLElement>(
     prevOpen: false,
   });
 
+  const prevExplicitRef = useRef(explicitZIndex);
+
   // Keep ref in sync with latest props so prop changes after mount are respected.
   stateRef.current.tier = tier;
   stateRef.current.explicit = explicitZIndex;
+
+  // When explicitZIndex changes from a value to undefined, and the node is
+  // currently open, we need to acquire a dynamic z-index and start the
+  // observer — neither was set up because the initial mount had an explicit
+  // value that short-circuited the ref callback.
+  if (
+    prevExplicitRef.current !== undefined &&
+    explicitZIndex === undefined &&
+    stateRef.current.node
+  ) {
+    const node = stateRef.current.node;
+    const isOpen = node.hasAttribute('data-open');
+    if (isOpen) {
+      setZIndex(acquireLayerZIndex(tier));
+      stateRef.current.prevOpen = true;
+    }
+    // Ensure observer is running for future open/close changes.
+    if (!stateRef.current.observer) {
+      const handle = () => {
+        const open = node.hasAttribute('data-open');
+        if (open && !stateRef.current.prevOpen) {
+          setZIndex(acquireLayerZIndex(stateRef.current.tier));
+        }
+        stateRef.current.prevOpen = open;
+      };
+      const observer = new MutationObserver(handle);
+      observer.observe(node, {
+        attributes: true,
+        attributeFilter: ['data-open', 'data-closed'],
+      });
+      stateRef.current.observer = observer;
+    }
+  }
+  prevExplicitRef.current = explicitZIndex;
 
   const ref = useCallback((node: T | null) => {
     if (node === stateRef.current.node) return;

--- a/src/base-ui/zIndex/useLayerZIndex.tsx
+++ b/src/base-ui/zIndex/useLayerZIndex.tsx
@@ -28,6 +28,10 @@ export function useLayerZIndex<T extends HTMLElement = HTMLElement>(
     prevOpen: false,
   });
 
+  // Keep ref in sync with latest props so prop changes after mount are respected.
+  stateRef.current.tier = tier;
+  stateRef.current.explicit = explicitZIndex;
+
   const ref = useCallback((node: T | null) => {
     if (node === stateRef.current.node) return;
     stateRef.current.observer?.disconnect();


### PR DESCRIPTION
## Summary

- Introduce a shared `zIndex` module (`acquireLayerZIndex` + `useLayerZIndex` hook) under `src/base-ui/zIndex/` that replaces scattered hardcoded `1100`/`1200` values across base-ui floating layers.
- Stacking follows **floor-and-stack** semantics: every layer acquires `max(tierFloor, currentTop) + step` on the first `closed → open` transition, so open-order beats static tiers. Re-opens of the same instance re-acquire to "bring to front".
- Two failing TDD demos document the bug class and now stay green:
  1. `Modal/demos/zindex-with-dropdown.tsx` — modal opens with dropdown still mounted; modal must layer above dropdown (was already fixed by the modal-base bump, now reaffirmed).
  2. `Modal/demos/zindex-dropdown-in-modal.tsx` — dropdown opens inside an open modal; dropdown must layer above modal popup. **Previously RED, now GREEN.**

## Design highlights

- **Two counters**: `main` (shared by `floating` and `modal` tiers so cross-tier order works) and `toast` (independent, sentinel base `100_000` so the main stack can never realistically overtake notifications). Tier floors: `floating: 1100`, `modal: 1200`, `toast: 100_000`, `step: 10`.
- **Open-state observation via base-ui's public `data-open` / `data-closed` attributes** (`CommonPopupDataAttributes`). Zero coupling to base-ui internals. Immune to consumer `onOpenChange` cancellation because the DOM attribute only flips after base-ui commits state.
- **Render-pure**: acquire runs inside the ref-callback (commit phase) — no global mutation during render, safe under React 19 concurrent rendering and Strict Mode double-renders.
- **Explicit override**: callers may pass `zIndex` prop or `style.zIndex`; the hook short-circuits acquire entirely (counter slot not consumed). Explicit value is mount-stable.
- **Modal atoms unified** via a new `ModalLayerContext` that bridges `ModalRoot` (acquirer) → `ModalBackdrop` / `ModalPopup` (consumers, the latter also attaches the observer ref).
- **Toast** acquires once at `ToastHost` mount and shares the resulting z-index across all `ALL_POSITIONS` viewports; static CSS fallback bumped to `100_000`.

## Files

| File | Change |
| ---- | ------ |
| `src/base-ui/zIndex/{constants,manager,useLayerZIndex,index}.ts(x)` | New module + 12 unit tests |
| `src/base-ui/Modal/zIndexManager.ts` | **Deleted** (replaced by shared manager) |
| `src/base-ui/Modal/ModalLayerContext.tsx` | New context bridging Root → Backdrop/Popup |
| `src/base-ui/Modal/atoms.tsx` | `ModalRoot` acquires + provides via context; `ModalBackdrop` consumes; `ModalPopup` consumes (`zIndex + 1`) and attaches observer ref |
| `src/base-ui/Modal/Modal.tsx`, `imperative.tsx` | Stop calling `acquireModalZIndex` locally; forward `zIndex` prop to `ModalRoot` |
| `src/base-ui/Modal/style.ts` | CSS fallbacks bumped to `1200/1201/1200` (matches the modal tier floor) |
| `src/base-ui/DropdownMenu/atoms.tsx` | `DropdownMenuPositioner` uses hook |
| `src/base-ui/ContextMenu/ContextMenuHost.tsx` | Positioner uses hook |
| `src/base-ui/Popover/atoms.tsx` | `PopoverPositioner` uses hook |
| `src/base-ui/Popover/PopoverStandalone.tsx`, `PopoverGroup.tsx` | Drop hardcoded `1100` fallback in resolved styles |
| `src/base-ui/Select/atoms.tsx` | `SelectPositioner` uses hook |
| `src/base-ui/Select/Select.tsx` | High-level Select now routes through `SelectPositioner` instead of `BaseSelect.Positioner` directly |
| `src/base-ui/Toast/imperative.tsx` | `ToastHost` acquires `'toast'` once in `useEffect`, shared across all viewports |
| `src/base-ui/Toast/style.ts` | Viewport static fallback `1100 → 100_000` |
| `src/base-ui/Modal/demos/zindex-with-dropdown.tsx`, `zindex-dropdown-in-modal.tsx`, `Modal/index.md` | New TDD repro demos |

## Test plan

- [x] Unit tests: 12 passing across `manager.test.ts` (acquisition semantics, shared/independent counters, warn-once flag) and `useLayerZIndex.test.tsx` (mount-with-open, attribute toggle, re-acquire on re-open, explicit short-circuit)
- [x] Browser regression via dumi demos:
  - `Modal/demos/zindex-with-dropdown` — modal=1210/1211 > dropdown=1110 ✓
  - `Modal/demos/zindex-dropdown-in-modal` — dropdown=1220 > modal=1210/1211 ✓ (the previously failing case)
- [x] Lint: 0 errors on changed files
- [ ] Reviewers: please verify nested-modal demo (`Modal/demos/nested.tsx`) still stacks correctly
- [ ] Reviewers: verify Popover/Select/Tooltip composition demos still work