### PR TITLE
🐛 fix(action-icon): avoid nested tooltip popup triggers

### DIFF
--- a/src/ActionIcon/ActionIcon.tsx
+++ b/src/ActionIcon/ActionIcon.tsx
@@ -38,6 +38,17 @@ const ActionIcon = memo<ActionIconProps>(
     ...rest
   }) => {
     const { blockSize, borderRadius } = useMemo(() => calcSize(size), [size]);
+    const popupTriggerAria = rest as {
+      'aria-expanded'?: unknown;
+      'aria-haspopup'?: unknown;
+      'aria-label'?: string;
+    };
+    const isPopupTrigger =
+      popupTriggerAria['aria-haspopup'] !== undefined ||
+      popupTriggerAria['aria-expanded'] !== undefined;
+    const popupTriggerLabel =
+      popupTriggerAria['aria-label'] ??
+      (isPopupTrigger && typeof title === 'string' ? title : undefined);
 
     const handleClick = useCallback<MouseEventHandler<HTMLDivElement>>(
       (event) => {
@@ -58,6 +69,7 @@ const ActionIcon = memo<ActionIconProps>(
         tabIndex={disabled ? -1 : 0}
         onClick={handleClick}
         {...rest}
+        aria-label={popupTriggerLabel}
       >
         {icon && (
           <Icon
@@ -77,7 +89,7 @@ const ActionIcon = memo<ActionIconProps>(
       </Center>
     );
 
-    if (!title) return node;
+    if (!title || isPopupTrigger) return node;
 
     return (
       <Tooltip

--- a/src/DropdownMenu/demos/plus-action-submenu.tsx
+++ b/src/DropdownMenu/demos/plus-action-submenu.tsx
@@ -1,0 +1,375 @@
+import { Menu } from '@base-ui/react/menu';
+import {
+  ActionIcon,
+  DropdownMenuPopup,
+  DropdownMenuPortal,
+  DropdownMenuPositioner,
+  DropdownMenuRoot,
+  DropdownMenuTrigger,
+  renderDropdownMenuItems,
+} from '@lobehub/ui';
+import { createStaticStyles } from 'antd-style';
+import { FileTextIcon, PlusIcon, StoreIcon, WrenchIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+import type { DropdownMenuProps } from '../type';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  caseTitle: css`
+    margin-block-end: 10px;
+
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 18px;
+    color: ${cssVar.colorTextSecondary};
+  `,
+  comparison: css`
+    display: grid;
+    grid-template-columns: minmax(360px, max-content) minmax(360px, max-content);
+    gap: 64px;
+    align-items: start;
+
+    padding-block: 160px;
+    padding-inline: 120px;
+  `,
+  countChip: css`
+    flex: none;
+
+    padding-block: 1px;
+    padding-inline: 6px;
+    border-radius: ${cssVar.borderRadiusSM};
+
+    font-size: 11px;
+    line-height: 16px;
+    color: ${cssVar.colorTextSecondary};
+
+    background: ${cssVar.colorFillSecondary};
+  `,
+  labelWithChip: css`
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    justify-content: space-between;
+
+    min-width: 180px;
+  `,
+  menuItem: css`
+    cursor: default;
+
+    display: flex;
+    gap: 8px;
+    align-items: center;
+
+    min-height: 32px;
+    padding-block: 5px;
+    padding-inline: 8px;
+    border-radius: ${cssVar.borderRadiusSM};
+
+    font-size: 13px;
+    color: ${cssVar.colorText};
+
+    outline: none;
+
+    &[data-highlighted],
+    &:hover {
+      background: ${cssVar.colorFillSecondary};
+    }
+  `,
+  menuPopup: css`
+    min-width: 220px;
+    padding: 4px;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: ${cssVar.borderRadius};
+
+    background: ${cssVar.colorBgElevated};
+    box-shadow: ${cssVar.boxShadowSecondary};
+  `,
+  primitiveTrigger: css`
+    cursor: default;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    width: 32px;
+    height: 32px;
+    border-radius: ${cssVar.borderRadius};
+
+    color: ${cssVar.colorText};
+
+    outline: none;
+
+    &:hover,
+    &[data-popup-open] {
+      background: ${cssVar.colorFillSecondary};
+    }
+  `,
+  separator: css`
+    height: 1px;
+    margin-block: 4px;
+    margin-inline: 6px;
+    background: ${cssVar.colorBorderSecondary};
+  `,
+  status: css`
+    display: grid;
+    grid-template-columns: auto auto;
+    gap: 6px 10px;
+    align-items: center;
+
+    min-width: 180px;
+
+    font-size: 12px;
+    line-height: 18px;
+    color: ${cssVar.colorTextSecondary};
+  `,
+  statusValue: css`
+    color: ${cssVar.colorSuccess};
+
+    &[data-closed='true'] {
+      color: ${cssVar.colorError};
+    }
+  `,
+  submenuArrow: css`
+    margin-inline-start: auto;
+    color: ${cssVar.colorTextSecondary};
+  `,
+  triggerRow: css`
+    display: flex;
+    gap: 16px;
+    align-items: center;
+  `,
+}));
+
+interface MenuStatus {
+  lastRootReason: string;
+  rootOpen: boolean;
+  toolsOpen: boolean;
+}
+
+const getReason = (details: { reason?: string }) => details.reason ?? 'unknown';
+
+const LabelWithCount = ({
+  count,
+  label,
+  prefix,
+}: {
+  count: number;
+  label: string;
+  prefix: string;
+}) => (
+  <span className={styles.labelWithChip}>
+    <span>{label}</span>
+    <span className={styles.countChip}>{`${prefix} | ${count}`}</span>
+  </span>
+);
+
+const StatusPanel = ({ lastRootReason, rootOpen, toolsOpen }: MenuStatus) => (
+  <div className={styles.status}>
+    <span>root</span>
+    <span className={styles.statusValue} data-closed={!rootOpen}>
+      {rootOpen ? 'open' : 'closed'}
+    </span>
+    <span>tools submenu</span>
+    <span className={styles.statusValue} data-closed={!toolsOpen}>
+      {toolsOpen ? 'open' : 'closed'}
+    </span>
+    <span>last root reason</span>
+    <span>{lastRootReason}</span>
+  </div>
+);
+
+const LobeUiWrappedCase = () => {
+  const [rootOpen, setRootOpen] = useState(false);
+  const [toolsOpen, setToolsOpen] = useState(false);
+  const [lastRootReason, setLastRootReason] = useState('idle');
+  const menuItemsRef = useRef<ReactNode[] | null>(null);
+
+  const items = useMemo<Exclude<DropdownMenuProps['items'], () => unknown>>(
+    () => [
+      {
+        icon: FileTextIcon,
+        key: 'upload',
+        label: 'Upload file',
+      },
+      { type: 'divider' },
+      {
+        children: [
+          {
+            closeOnClick: false,
+            key: 'skill-excalidraw',
+            label: 'Excalidraw Diagram',
+          },
+          {
+            closeOnClick: false,
+            key: 'skill-flowchart',
+            label: 'Flowchart',
+          },
+          {
+            closeOnClick: false,
+            key: 'skill-ppt',
+            label: 'PPT Creator',
+          },
+        ],
+        closeDelay: 100,
+        delay: 0,
+        icon: WrenchIcon,
+        key: 'tools',
+        label: <LabelWithCount count={17} label="Skills" prefix="Auto" />,
+        onOpenChange: (open) => setToolsOpen(open),
+        openOnHover: true,
+        type: 'submenu',
+      },
+      {
+        icon: StoreIcon,
+        key: 'store',
+        label: 'Skill Store',
+      },
+    ],
+    [],
+  );
+
+  const menuItems = useMemo(() => {
+    if (!rootOpen) return menuItemsRef.current;
+
+    const renderedItems = renderDropdownMenuItems(items);
+    menuItemsRef.current = renderedItems;
+    return renderedItems;
+  }, [items, rootOpen]);
+
+  const handleRootOpenChange = useCallback((open: boolean, details: { reason?: string }) => {
+    setLastRootReason(getReason(details));
+    setRootOpen(open);
+    if (!open) {
+      menuItemsRef.current = null;
+      setToolsOpen(false);
+    }
+  }, []);
+
+  return (
+    <div>
+      <div className={styles.caseTitle}>lobe-ui DropdownMenu composition</div>
+      <div className={styles.triggerRow}>
+        <DropdownMenuRoot open={rootOpen} onOpenChange={handleRootOpenChange}>
+          <DropdownMenuTrigger nativeButton={false}>
+            <ActionIcon
+              icon={PlusIcon}
+              title="Add files, skills, and more context"
+              tooltipProps={{
+                arrow: false,
+                placement: 'top',
+              }}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuPortal>
+            <DropdownMenuPositioner placement="topLeft">
+              <DropdownMenuPopup
+                style={{
+                  minWidth: 220,
+                }}
+              >
+                {menuItems}
+              </DropdownMenuPopup>
+            </DropdownMenuPositioner>
+          </DropdownMenuPortal>
+        </DropdownMenuRoot>
+
+        <StatusPanel lastRootReason={lastRootReason} rootOpen={rootOpen} toolsOpen={toolsOpen} />
+      </div>
+    </div>
+  );
+};
+
+const BaseUiPrimitiveCase = () => {
+  const [rootOpen, setRootOpen] = useState(false);
+  const [toolsOpen, setToolsOpen] = useState(false);
+  const [lastRootReason, setLastRootReason] = useState('idle');
+
+  const handleRootOpenChange = useCallback((open: boolean, details: { reason?: string }) => {
+    setLastRootReason(getReason(details));
+    setRootOpen(open);
+    if (!open) setToolsOpen(false);
+  }, []);
+
+  return (
+    <div>
+      <div className={styles.caseTitle}>Base UI Menu primitives</div>
+      <div className={styles.triggerRow}>
+        <Menu.Root modal={false} open={rootOpen} onOpenChange={handleRootOpenChange}>
+          <Menu.Trigger
+            nativeButton={false}
+            render={
+              <div className={styles.primitiveTrigger} tabIndex={0}>
+                <PlusIcon size={18} />
+              </div>
+            }
+          />
+          <Menu.Portal>
+            <Menu.Positioner align="start" side="top" sideOffset={6}>
+              <Menu.Popup className={styles.menuPopup}>
+                <Menu.Item className={styles.menuItem} label="Upload file">
+                  <FileTextIcon size={14} />
+                  <span>Upload file</span>
+                </Menu.Item>
+                <Menu.Separator className={styles.separator} />
+                <Menu.SubmenuRoot onOpenChange={(open) => setToolsOpen(open)}>
+                  <Menu.SubmenuTrigger
+                    openOnHover
+                    className={styles.menuItem}
+                    closeDelay={100}
+                    delay={0}
+                    label="Skills"
+                  >
+                    <WrenchIcon size={14} />
+                    <LabelWithCount count={17} label="Skills" prefix="Auto" />
+                    <span className={styles.submenuArrow}>›</span>
+                  </Menu.SubmenuTrigger>
+                  <Menu.Portal>
+                    <Menu.Positioner alignOffset={-4} sideOffset={-1}>
+                      <Menu.Popup className={styles.menuPopup}>
+                        <Menu.Item
+                          className={styles.menuItem}
+                          closeOnClick={false}
+                          label="Excalidraw Diagram"
+                        >
+                          <span>Excalidraw Diagram</span>
+                        </Menu.Item>
+                        <Menu.Item
+                          className={styles.menuItem}
+                          closeOnClick={false}
+                          label="Flowchart"
+                        >
+                          <span>Flowchart</span>
+                        </Menu.Item>
+                        <Menu.Item
+                          className={styles.menuItem}
+                          closeOnClick={false}
+                          label="PPT Creator"
+                        >
+                          <span>PPT Creator</span>
+                        </Menu.Item>
+                      </Menu.Popup>
+                    </Menu.Positioner>
+                  </Menu.Portal>
+                </Menu.SubmenuRoot>
+                <Menu.Item className={styles.menuItem} label="Skill Store">
+                  <StoreIcon size={14} />
+                  <span>Skill Store</span>
+                </Menu.Item>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>
+
+        <StatusPanel lastRootReason={lastRootReason} rootOpen={rootOpen} toolsOpen={toolsOpen} />
+      </div>
+    </div>
+  );
+};
+
+export default () => (
+  <div className={styles.comparison}>
+    <LobeUiWrappedCase />
+    <BaseUiPrimitiveCase />
+  </div>
+);

--- a/src/DropdownMenu/index.md
+++ b/src/DropdownMenu/index.md
@@ -19,6 +19,10 @@ Exported primitives can be composed to build custom dropdown menus.
 
 <code src="./demos/submenu.tsx" center></code>
 
+## ActionIcon Trigger With Submenu
+
+<code src="./demos/plus-action-submenu.tsx" center></code>
+
 ## Group
 
 <code src="./demos/group.tsx" center></code>

--- a/src/base-ui/DropdownMenu/index.md
+++ b/src/base-ui/DropdownMenu/index.md
@@ -24,6 +24,10 @@ Exported primitives can be composed to build custom dropdown menus.
 
 <code src="../../DropdownMenu/demos/submenu.tsx" center></code>
 
+## ActionIcon Trigger With Submenu
+
+<code src="../../DropdownMenu/demos/plus-action-submenu.tsx" center></code>
+
 ## Group
 
 <code src="../../DropdownMenu/demos/group.tsx" center></code>


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 Description of Change

- Prevent `ActionIcon` from rendering its internal `Tooltip` when it is already used as an external popup trigger, such as a `DropdownMenuTrigger` child.
- Preserve the string `title` as `aria-label` in that popup-trigger case so the trigger keeps an accessible label without creating a second hover popup.
- Add a DropdownMenu demo that compares the lobe-ui `ActionIcon` trigger composition with a pure Base UI Menu primitive setup.

#### 📝 Additional Information

Validation:

- `bun run type-check`
- Commit hook: `type-check`, `lint:circular`, prettier, stylelint, and eslint staged tasks
- Manual demo verification at `/~demos/src-base-ui-dropdown-menu-demo-plus-action-submenu`: both the lobe-ui `ActionIcon` trigger case and the pure Base UI primitive case keep root and submenu open after hovering the submenu trigger.
