### PR TITLE
🐛 fix(tooltip): preserve popup trigger tooltips

### DIFF
--- a/src/ActionIcon/ActionIcon.tsx
+++ b/src/ActionIcon/ActionIcon.tsx
@@ -89,7 +89,7 @@ const ActionIcon = memo<ActionIconProps>(
       </Center>
     );
 
-    if (!title || isPopupTrigger) return node;
+    if (!title) return node;
 
     return (
       <Tooltip

--- a/src/DropdownMenu/demos/plus-action-submenu.tsx
+++ b/src/DropdownMenu/demos/plus-action-submenu.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuRoot,
   DropdownMenuTrigger,
   renderDropdownMenuItems,
+  Tooltip,
 } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { FileTextIcon, PlusIcon, StoreIcon, WrenchIcon } from 'lucide-react';
@@ -293,17 +294,23 @@ const BaseUiPrimitiveCase = () => {
 
   return (
     <div>
-      <div className={styles.caseTitle}>Base UI Menu primitives</div>
+      <div className={styles.caseTitle}>Base UI Menu primitives with lobe-ui Tooltip</div>
       <div className={styles.triggerRow}>
         <Menu.Root modal={false} open={rootOpen} onOpenChange={handleRootOpenChange}>
-          <Menu.Trigger
-            nativeButton={false}
-            render={
-              <div className={styles.primitiveTrigger} tabIndex={0}>
-                <PlusIcon size={18} />
-              </div>
-            }
-          />
+          <Tooltip arrow={false} placement="top" title="Add files, skills, and more context">
+            <Menu.Trigger
+              nativeButton={false}
+              render={
+                <div
+                  aria-label="Add files, skills, and more context"
+                  className={styles.primitiveTrigger}
+                  tabIndex={0}
+                >
+                  <PlusIcon size={18} />
+                </div>
+              }
+            />
+          </Tooltip>
           <Menu.Portal>
             <Menu.Positioner align="start" side="top" sideOffset={6}>
               <Menu.Popup className={styles.menuPopup}>

--- a/src/DropdownMenu/demos/plus-action-submenu.tsx
+++ b/src/DropdownMenu/demos/plus-action-submenu.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuTrigger,
   renderDropdownMenuItems,
   Tooltip,
+  TooltipGroup,
 } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { FileTextIcon, PlusIcon, StoreIcon, WrenchIcon } from 'lucide-react';
@@ -249,31 +250,33 @@ const LobeUiWrappedCase = () => {
 
   return (
     <div>
-      <div className={styles.caseTitle}>lobe-ui DropdownMenu composition</div>
+      <div className={styles.caseTitle}>lobe-ui DropdownMenu composition with TooltipGroup</div>
       <div className={styles.triggerRow}>
-        <DropdownMenuRoot open={rootOpen} onOpenChange={handleRootOpenChange}>
-          <DropdownMenuTrigger nativeButton={false}>
-            <ActionIcon
-              icon={PlusIcon}
-              title="Add files, skills, and more context"
-              tooltipProps={{
-                arrow: false,
-                placement: 'top',
-              }}
-            />
-          </DropdownMenuTrigger>
-          <DropdownMenuPortal>
-            <DropdownMenuPositioner placement="topLeft">
-              <DropdownMenuPopup
-                style={{
-                  minWidth: 220,
+        <TooltipGroup openDelay={0}>
+          <DropdownMenuRoot open={rootOpen} onOpenChange={handleRootOpenChange}>
+            <DropdownMenuTrigger nativeButton={false}>
+              <ActionIcon
+                icon={PlusIcon}
+                title="Add files, skills, and more context"
+                tooltipProps={{
+                  arrow: false,
+                  placement: 'top',
                 }}
-              >
-                {menuItems}
-              </DropdownMenuPopup>
-            </DropdownMenuPositioner>
-          </DropdownMenuPortal>
-        </DropdownMenuRoot>
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuPortal>
+              <DropdownMenuPositioner placement="topLeft">
+                <DropdownMenuPopup
+                  style={{
+                    minWidth: 220,
+                  }}
+                >
+                  {menuItems}
+                </DropdownMenuPopup>
+              </DropdownMenuPositioner>
+            </DropdownMenuPortal>
+          </DropdownMenuRoot>
+        </TooltipGroup>
 
         <StatusPanel lastRootReason={lastRootReason} rootOpen={rootOpen} toolsOpen={toolsOpen} />
       </div>

--- a/src/Tooltip/TooltipGroup.tsx
+++ b/src/Tooltip/TooltipGroup.tsx
@@ -60,14 +60,14 @@ const TooltipGroup: FC<TooltipGroupProps> = ({
   return (
     <TooltipGroupHandleContext value={handle}>
       <TooltipGroupPropsContext value={sharedProps}>
-        {children}
-
         <BaseTooltip.Root handle={handle} key={key} onOpenChange={handleOpenChange}>
           {({ payload }) => {
             const item = (payload as TooltipGroupItem | null) ?? null;
             activeItemRef.current = item;
 
-            if (!item || (item.title == null && !item.hotkey)) return null;
+            if (!item || (item.title == null && !item.hotkey)) {
+              return children;
+            }
 
             const arrow = item.arrow ?? false;
             const placement = item.placement ?? 'top';
@@ -157,9 +157,16 @@ const TooltipGroup: FC<TooltipGroupProps> = ({
             const resolvedPortalContainer =
               item.popupContainer ?? popupContainer ?? portalContainer;
 
-            return resolvedPortalContainer ? (
-              <BaseTooltip.Portal container={resolvedPortalContainer}>{popup}</BaseTooltip.Portal>
-            ) : null;
+            return (
+              <>
+                {children}
+                {resolvedPortalContainer ? (
+                  <BaseTooltip.Portal container={resolvedPortalContainer}>
+                    {popup}
+                  </BaseTooltip.Portal>
+                ) : null}
+              </>
+            );
           }}
         </BaseTooltip.Root>
       </TooltipGroupPropsContext>

--- a/src/Tooltip/TooltipInGroup.tsx
+++ b/src/Tooltip/TooltipInGroup.tsx
@@ -118,6 +118,12 @@ export const TooltipInGroup: FC<TooltipProps> = ({
   });
 
   const childElement = isValidElement(children) ? children : null;
+  const popupTriggerId =
+    childElement &&
+    (childElement as any).props['aria-haspopup'] !== undefined &&
+    (childElement as any).props.id !== undefined
+      ? (childElement as any).props.id
+      : undefined;
 
   const renderTrigger = useCallback(
     (renderProps: unknown) => {
@@ -130,9 +136,14 @@ export const TooltipInGroup: FC<TooltipProps> = ({
         return triggerRest;
       })();
 
-      const mergedProps = mergeProps(restProps, (childElement as any).props, resolvedProps);
+      const childProps = (childElement as any).props;
+      const mergedProps = mergeProps(restProps, childProps, resolvedProps);
+      const shouldPreservePopupTriggerId =
+        childProps['aria-haspopup'] !== undefined && childProps.id !== undefined;
+
       return cloneElement(childElement as any, {
         ...mergedProps,
+        id: shouldPreservePopupTriggerId ? childProps.id : mergedProps.id,
         ref: mergeRefs([(childElement as any).ref, (renderProps as any).ref, refProp]),
       });
     },
@@ -149,6 +160,8 @@ export const TooltipInGroup: FC<TooltipProps> = ({
     closeDelay: resolvedCloseDelay,
     delay: resolvedOpenDelay,
     disabled,
+    ...item.triggerProps,
+    id: popupTriggerId ?? item.triggerProps?.id,
     payload: item,
   };
 

--- a/src/Tooltip/TooltipStandalone.tsx
+++ b/src/Tooltip/TooltipStandalone.tsx
@@ -150,9 +150,14 @@ export const TooltipStandalone = memo<TooltipProps>(
                 return triggerRest;
               })();
 
-              const mergedProps = mergeProps(restProps, (children as any).props, resolvedProps);
+              const childProps = (children as any).props;
+              const mergedProps = mergeProps(restProps, childProps, resolvedProps);
+              const shouldPreservePopupTriggerId =
+                childProps['aria-haspopup'] !== undefined && childProps.id !== undefined;
+
               return cloneElement(children as any, {
                 ...mergedProps,
+                id: shouldPreservePopupTriggerId ? childProps.id : mergedProps.id,
                 ref: mergeRefs([
                   (children as any).ref,
                   (props as any).ref,

--- a/src/Tooltip/TooltipStandalone.tsx
+++ b/src/Tooltip/TooltipStandalone.tsx
@@ -129,11 +129,19 @@ export const TooltipStandalone = memo<TooltipProps>(
     );
 
     const triggerElement = useMemo(() => {
+      const popupTriggerId =
+        isValidElement(children) &&
+        (children as any).props['aria-haspopup'] !== undefined &&
+        (children as any).props.id !== undefined
+          ? (children as any).props.id
+          : undefined;
+
       const baseTriggerProps = {
         closeDelay: resolvedCloseDelay,
         delay: resolvedOpenDelay,
         disabled,
         ...triggerProps,
+        id: popupTriggerId ?? triggerProps?.id,
       };
 
       if (isValidElement(children)) {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [x] 📝 docs

#### 🔀 Description of Change

- Restore lobe-ui Tooltip rendering for ActionIcon even when ActionIcon is used as a DropdownMenu popup trigger.
- Preserve existing popup trigger IDs as BaseTooltip trigger IDs in both standalone and TooltipGroup singleton paths.
- Keep TooltipGroup children inside the shared BaseTooltip.Root scope so singleton triggers receive the current Base UI interaction context.
- Update the DropdownMenu ActionIcon/submenu demo so it validates the TooltipGroup singleton path and the standalone Base UI primitive comparison.

#### 📝 Additional Information

Validation:
- bun run type-check
- Commit hook: type-check, lint:circular, prettier, stylelint, eslint
- Manual demo check at /~demos/src-base-ui-dropdown-menu-demo-plus-action-submenu: TooltipGroup singleton ActionIcon tooltip is visible, standalone primitive tooltip is visible, no native title attribute exists, clicking opens the menu, and hovering Auto | 17 opens the submenu.