### PR TITLE
✨ feat(menu): add header and footer slots to submenu popups

### DIFF
--- a/src/ContextMenu/renderItems.tsx
+++ b/src/ContextMenu/renderItems.tsx
@@ -26,9 +26,9 @@ import {
   type RenderItemContentOptions,
   type RenderOptions,
 } from '@/Menu';
+import { styles } from '@/Menu/sharedStyle';
 import { preventDefaultAndStopPropagation } from '@/utils/dom';
 
-import { styles } from './style';
 import {
   type ContextMenuCheckboxItem,
   type ContextMenuItem,
@@ -99,14 +99,19 @@ const ContextMenuSwitchItemInternal = ({
       }}
     >
       {children}
-      <Switch
-        checked={checked}
-        disabled={disabled}
-        size="small"
-        style={{ marginInlineStart: 16 }}
-        onChange={handleCheckedChange}
-        onClick={(_, e) => e.stopPropagation()}
-      />
+      <span
+        style={{ display: 'inline-flex', marginInlineStart: 16 }}
+        onFocus={(e) => e.stopPropagation()}
+      >
+        <Switch
+          checked={checked}
+          disabled={disabled}
+          size="small"
+          tabIndex={-1}
+          onChange={handleCheckedChange}
+          onClick={(_, e) => e.stopPropagation()}
+        />
+      </span>
     </ContextMenu.Item>
   );
 };
@@ -285,6 +290,16 @@ export const renderContextMenuItems = (
       const label = getItemLabel(submenu);
       const labelText = typeof label === 'string' ? label : undefined;
       const isDanger = 'danger' in submenu && Boolean(submenu.danger);
+      const submenuHasSlots = submenu.header != null || submenu.footer != null;
+      const submenuBody =
+        submenu.children && submenu.children.length > 0 ? (
+          renderContextMenuItems(submenu.children, nextKeyPath, {
+            iconAlign,
+            iconSpaceMode,
+          })
+        ) : (
+          <EmptyMenuItem />
+        );
 
       return (
         <ContextMenu.SubmenuRoot
@@ -317,14 +332,19 @@ export const renderContextMenuItems = (
               sideOffset={-1}
               onContextMenu={preventDefaultAndStopPropagation}
             >
-              <ContextMenu.Popup className={styles.popup}>
-                {submenu.children && submenu.children.length > 0 ? (
-                  renderContextMenuItems(submenu.children, nextKeyPath, {
-                    iconAlign,
-                    iconSpaceMode,
-                  })
+              <ContextMenu.Popup
+                className={submenuHasSlots ? cx(styles.popup, styles.popupWithSlots) : styles.popup}
+              >
+                {submenu.header == null ? null : (
+                  <div className={styles.header}>{submenu.header}</div>
+                )}
+                {submenuHasSlots ? (
+                  <div className={styles.slotViewport}>{submenuBody}</div>
                 ) : (
-                  <EmptyMenuItem />
+                  submenuBody
+                )}
+                {submenu.footer == null ? null : (
+                  <div className={styles.footer}>{submenu.footer}</div>
                 )}
               </ContextMenu.Popup>
             </ContextMenu.Positioner>

--- a/src/DropdownMenu/atoms.tsx
+++ b/src/DropdownMenu/atoms.tsx
@@ -145,6 +145,33 @@ export const DropdownMenuPopup = ({ className, ...rest }: DropdownMenuPopupProps
 
 DropdownMenuPopup.displayName = 'DropdownMenuPopup';
 
+export type DropdownMenuHeaderProps = React.HTMLAttributes<HTMLDivElement>;
+
+export const DropdownMenuHeader = ({ className, ...rest }: DropdownMenuHeaderProps) => {
+  return <div {...rest} className={cx(styles.header, className)} />;
+};
+
+DropdownMenuHeader.displayName = 'DropdownMenuHeader';
+
+export type DropdownMenuFooterProps = React.HTMLAttributes<HTMLDivElement>;
+
+export const DropdownMenuFooter = ({ className, ...rest }: DropdownMenuFooterProps) => {
+  return <div {...rest} className={cx(styles.footer, className)} />;
+};
+
+DropdownMenuFooter.displayName = 'DropdownMenuFooter';
+
+export type DropdownMenuScrollViewportProps = React.HTMLAttributes<HTMLDivElement>;
+
+export const DropdownMenuScrollViewport = ({
+  className,
+  ...rest
+}: DropdownMenuScrollViewportProps) => {
+  return <div {...rest} className={cx(styles.slotViewport, className)} />;
+};
+
+DropdownMenuScrollViewport.displayName = 'DropdownMenuScrollViewport';
+
 export type DropdownMenuItemProps = React.ComponentProps<typeof Menu.Item> & { danger?: boolean };
 
 export const DropdownMenuItem = ({ className, danger, ...rest }: DropdownMenuItemProps) => {

--- a/src/DropdownMenu/renderItems.tsx
+++ b/src/DropdownMenu/renderItems.tsx
@@ -24,8 +24,10 @@ import { styles } from '@/Menu/sharedStyle';
 import {
   DropdownMenuCheckboxItemIndicator,
   DropdownMenuCheckboxItemPrimitive,
+  DropdownMenuFooter,
   DropdownMenuGroup,
   DropdownMenuGroupLabel,
+  DropdownMenuHeader,
   DropdownMenuItem,
   DropdownMenuItemContent,
   DropdownMenuItemDesc,
@@ -36,6 +38,7 @@ import {
   DropdownMenuPopup,
   DropdownMenuPortal,
   DropdownMenuPositioner,
+  DropdownMenuScrollViewport,
   DropdownMenuSeparator,
   DropdownMenuSubmenuArrow,
   DropdownMenuSubmenuRoot,
@@ -216,6 +219,13 @@ export const renderDropdownMenuItems = (
       const label = getItemLabel(submenu);
       const labelText = typeof label === 'string' ? label : undefined;
       const isDanger = 'danger' in submenu && Boolean(submenu.danger);
+      const submenuHasSlots = submenu.header != null || submenu.footer != null;
+      const submenuItems = submenu.children
+        ? renderDropdownMenuItems(submenu.children, nextKeyPath, {
+            iconAlign,
+            iconSpaceMode,
+          })
+        : null;
 
       return (
         <DropdownMenuSubmenuRoot
@@ -242,13 +252,18 @@ export const renderDropdownMenuItems = (
           </DropdownMenuSubmenuTrigger>
           <DropdownMenuPortal>
             <DropdownMenuPositioner alignOffset={-4} data-submenu="" sideOffset={-1}>
-              <DropdownMenuPopup>
-                {submenu.children
-                  ? renderDropdownMenuItems(submenu.children, nextKeyPath, {
-                      iconAlign,
-                      iconSpaceMode,
-                    })
-                  : null}
+              <DropdownMenuPopup className={submenuHasSlots ? styles.popupWithSlots : undefined}>
+                {submenu.header == null ? null : (
+                  <DropdownMenuHeader>{submenu.header}</DropdownMenuHeader>
+                )}
+                {submenuHasSlots ? (
+                  <DropdownMenuScrollViewport>{submenuItems}</DropdownMenuScrollViewport>
+                ) : (
+                  submenuItems
+                )}
+                {submenu.footer == null ? null : (
+                  <DropdownMenuFooter>{submenu.footer}</DropdownMenuFooter>
+                )}
               </DropdownMenuPopup>
             </DropdownMenuPositioner>
           </DropdownMenuPortal>

--- a/src/Menu/baseItem.ts
+++ b/src/Menu/baseItem.ts
@@ -33,6 +33,10 @@ export interface BaseSubMenuType {
   delay?: number;
   desc?: ReactNode;
   disabled?: boolean;
+  /** Pinned footer slot, rendered below the scrollable submenu items with a divider border. */
+  footer?: ReactNode;
+  /** Pinned header slot, rendered above the scrollable submenu items with a divider border. */
+  header?: ReactNode;
   icon?: IconProps['icon'];
   key?: Key;
   label?: ReactNode;

--- a/src/base-ui/ContextMenu/__tests__/slots.test.tsx
+++ b/src/base-ui/ContextMenu/__tests__/slots.test.tsx
@@ -68,3 +68,43 @@ describe('ContextMenu header/footer slots', () => {
     expect(screen.queryByTestId('cm-header')).toBeNull();
   });
 });
+
+const submenuItems: ContextMenuItem[] = [
+  {
+    children: [{ key: 'sub-a', label: 'Sub A' }],
+    defaultOpen: true,
+    footer: <div data-testid="cm-submenu-footer">Submenu Footer</div>,
+    header: <div data-testid="cm-submenu-header">Submenu Header</div>,
+    key: 'parent',
+    label: 'Parent',
+  },
+];
+
+describe('ContextMenu submenu header/footer slots', () => {
+  afterEach(() => {
+    act(() => closeContextMenu());
+  });
+
+  test('renders header and footer inside the open submenu popup', () => {
+    renderHost();
+
+    act(() => {
+      showContextMenu(submenuItems);
+    });
+
+    expect(screen.getByTestId('cm-submenu-header')).toBeDefined();
+    expect(screen.getByTestId('cm-submenu-footer')).toBeDefined();
+    expect(screen.getByText('Sub A')).toBeDefined();
+  });
+
+  test('submenu slots are not registered as menu items', () => {
+    renderHost();
+
+    act(() => {
+      showContextMenu(submenuItems);
+    });
+
+    expect(screen.getByTestId('cm-submenu-header').closest('[role="menuitem"]')).toBeNull();
+    expect(screen.getByTestId('cm-submenu-footer').closest('[role="menuitem"]')).toBeNull();
+  });
+});

--- a/src/base-ui/ContextMenu/renderItems.tsx
+++ b/src/base-ui/ContextMenu/renderItems.tsx
@@ -290,6 +290,16 @@ export const renderContextMenuItems = (
       const label = getItemLabel(submenu);
       const labelText = typeof label === 'string' ? label : undefined;
       const isDanger = 'danger' in submenu && Boolean(submenu.danger);
+      const submenuHasSlots = submenu.header != null || submenu.footer != null;
+      const submenuBody =
+        submenu.children && submenu.children.length > 0 ? (
+          renderContextMenuItems(submenu.children, nextKeyPath, {
+            iconAlign,
+            iconSpaceMode,
+          })
+        ) : (
+          <EmptyMenuItem />
+        );
 
       return (
         <ContextMenu.SubmenuRoot
@@ -322,14 +332,19 @@ export const renderContextMenuItems = (
               sideOffset={-1}
               onContextMenu={preventDefaultAndStopPropagation}
             >
-              <ContextMenu.Popup className={styles.popup}>
-                {submenu.children && submenu.children.length > 0 ? (
-                  renderContextMenuItems(submenu.children, nextKeyPath, {
-                    iconAlign,
-                    iconSpaceMode,
-                  })
+              <ContextMenu.Popup
+                className={submenuHasSlots ? cx(styles.popup, styles.popupWithSlots) : styles.popup}
+              >
+                {submenu.header == null ? null : (
+                  <div className={styles.header}>{submenu.header}</div>
+                )}
+                {submenuHasSlots ? (
+                  <div className={styles.slotViewport}>{submenuBody}</div>
                 ) : (
-                  <EmptyMenuItem />
+                  submenuBody
+                )}
+                {submenu.footer == null ? null : (
+                  <div className={styles.footer}>{submenu.footer}</div>
                 )}
               </ContextMenu.Popup>
             </ContextMenu.Positioner>

--- a/src/base-ui/DropdownMenu/__tests__/slots.test.tsx
+++ b/src/base-ui/DropdownMenu/__tests__/slots.test.tsx
@@ -71,3 +71,42 @@ describe('DropdownMenu header/footer slots', () => {
     expect(screen.getByText('Item B')).toBeDefined();
   });
 });
+
+const submenuItems: DropdownItem[] = [
+  {
+    children: [
+      { key: 'sub-a', label: 'Sub A' },
+      { key: 'sub-b', label: 'Sub B' },
+    ],
+    defaultOpen: true,
+    footer: <div data-testid="submenu-footer">Submenu Footer</div>,
+    header: <div data-testid="submenu-header">Submenu Header</div>,
+    key: 'parent',
+    label: 'Parent',
+  },
+];
+
+describe('DropdownMenu submenu header/footer slots', () => {
+  test('renders header and footer inside the open submenu popup', () => {
+    render(
+      <DropdownMenu open items={submenuItems}>
+        <button type="button">trigger</button>
+      </DropdownMenu>,
+    );
+
+    expect(screen.getByTestId('submenu-header')).toBeDefined();
+    expect(screen.getByTestId('submenu-footer')).toBeDefined();
+    expect(screen.getByText('Sub A')).toBeDefined();
+  });
+
+  test('submenu slots are not registered as menu items', () => {
+    render(
+      <DropdownMenu open items={submenuItems}>
+        <button type="button">trigger</button>
+      </DropdownMenu>,
+    );
+
+    expect(screen.getByTestId('submenu-header').closest('[role="menuitem"]')).toBeNull();
+    expect(screen.getByTestId('submenu-footer').closest('[role="menuitem"]')).toBeNull();
+  });
+});

--- a/src/base-ui/DropdownMenu/renderItems.tsx
+++ b/src/base-ui/DropdownMenu/renderItems.tsx
@@ -24,8 +24,10 @@ import { styles } from '@/Menu/sharedStyle';
 import {
   DropdownMenuCheckboxItemIndicator,
   DropdownMenuCheckboxItemPrimitive,
+  DropdownMenuFooter,
   DropdownMenuGroup,
   DropdownMenuGroupLabel,
+  DropdownMenuHeader,
   DropdownMenuItem,
   DropdownMenuItemContent,
   DropdownMenuItemDesc,
@@ -36,6 +38,7 @@ import {
   DropdownMenuPopup,
   DropdownMenuPortal,
   DropdownMenuPositioner,
+  DropdownMenuScrollViewport,
   DropdownMenuSeparator,
   DropdownMenuSubmenuArrow,
   DropdownMenuSubmenuRoot,
@@ -216,6 +219,13 @@ export const renderDropdownMenuItems = (
       const label = getItemLabel(submenu);
       const labelText = typeof label === 'string' ? label : undefined;
       const isDanger = 'danger' in submenu && Boolean(submenu.danger);
+      const submenuHasSlots = submenu.header != null || submenu.footer != null;
+      const submenuItems = submenu.children
+        ? renderDropdownMenuItems(submenu.children, nextKeyPath, {
+            iconAlign,
+            iconSpaceMode,
+          })
+        : null;
 
       return (
         <DropdownMenuSubmenuRoot
@@ -242,13 +252,18 @@ export const renderDropdownMenuItems = (
           </DropdownMenuSubmenuTrigger>
           <DropdownMenuPortal>
             <DropdownMenuPositioner alignOffset={-4} data-submenu="" sideOffset={-1}>
-              <DropdownMenuPopup>
-                {submenu.children
-                  ? renderDropdownMenuItems(submenu.children, nextKeyPath, {
-                      iconAlign,
-                      iconSpaceMode,
-                    })
-                  : null}
+              <DropdownMenuPopup className={submenuHasSlots ? styles.popupWithSlots : undefined}>
+                {submenu.header == null ? null : (
+                  <DropdownMenuHeader>{submenu.header}</DropdownMenuHeader>
+                )}
+                {submenuHasSlots ? (
+                  <DropdownMenuScrollViewport>{submenuItems}</DropdownMenuScrollViewport>
+                ) : (
+                  submenuItems
+                )}
+                {submenu.footer == null ? null : (
+                  <DropdownMenuFooter>{submenu.footer}</DropdownMenuFooter>
+                )}
               </DropdownMenuPopup>
             </DropdownMenuPositioner>
           </DropdownMenuPortal>


### PR DESCRIPTION
Extend the header/footer slots (245fede7, root popups only) to nested DropdownMenu and ContextMenu submenu popups via BaseSubMenuType's new header/footer fields. Also sync the Header/Footer/ScrollViewport atoms into the main-package DropdownMenu/atoms.tsx copy.

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
