### PR TITLE
🐛 fix(deps): bump @base-ui/react to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
   },
   "dependencies": {
     "@ant-design/cssinjs": "^2.1.2",
-    "@base-ui/react": "1.0.0",
+    "@base-ui/react": "1.4.1",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",

--- a/src/Alert/type.ts
+++ b/src/Alert/type.ts
@@ -4,7 +4,10 @@ import type { CSSProperties, ReactNode, Ref } from 'react';
 
 import type { IconProps } from '@/Icon';
 
-export interface AlertProps extends Omit<AntAlertProps, 'classNames' | 'icon' | 'styles' | 'type'> {
+export interface AlertProps extends Omit<
+  AntAlertProps,
+  'classNames' | 'icon' | 'styles' | 'type' | 'variant'
+> {
   classNames?: {
     alert?: string;
     container?: string;

--- a/src/Form/type.ts
+++ b/src/Form/type.ts
@@ -12,7 +12,7 @@ import { type DivProps } from '@/types';
 export type FormVariant = 'filled' | 'outlined' | 'borderless';
 export type ItemsType = 'group' | 'flat';
 
-export interface FormProps extends Omit<AntFormProps, 'variant'> {
+export interface FormProps extends Omit<AntFormProps, 'variant' | 'styles' | 'classNames'> {
   activeKey?: (string | number)[];
   children?: ReactNode;
   classNames?: FormGroupProps['classNames'] & {

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -59,7 +59,7 @@ const Modal = memo<ModalProps>(
             title={title}
             classNames={
               typeof classNames === 'function'
-                ? classNames
+                ? (classNames as any)
                 : {
                     ...classNames,
                     wrapper: cx(styles.wrap, classNames?.wrapper),
@@ -103,7 +103,7 @@ const Modal = memo<ModalProps>(
             }
             styles={
               typeof customStyles === 'function'
-                ? customStyles
+                ? (customStyles as any)
                 : {
                     ...customStyles,
                     body: {
@@ -131,13 +131,13 @@ const Modal = memo<ModalProps>(
       >
         <AntModal
           closable
-          mask={{ closable: true }}
           cancelText={cancelText}
           className={cx(styles.content, className)}
           closeIcon={<Icon icon={X} size={20} />}
           confirmLoading={confirmLoading}
           destroyOnHidden={destroyOnHidden}
           footer={hideFooter ? null : footer}
+          mask={{ closable: true }}
           okButtonProps={okButtonProps}
           okText={okText}
           open={open}

--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -19,10 +19,10 @@ const Tabs: FC<TabsProps> = ({ className, compact, variant = 'rounded', items, .
       items={items}
       {...rest}
       classNames={{
-        ...rest?.classNames,
+        ...(rest?.classNames as any),
         popup: {
           root: styles.dropdown,
-          ...rest?.classNames?.popup,
+          ...(rest?.classNames as any)?.popup,
         },
       }}
       more={{

--- a/src/Tooltip/TooltipStandalone.tsx
+++ b/src/Tooltip/TooltipStandalone.tsx
@@ -179,7 +179,10 @@ export const TooltipStandalone = memo<TooltipProps>(
       }
 
       return (
-        <BaseTooltip.Trigger {...baseTriggerProps} ref={mergeRefs([refProp, triggerCallbackRef])}>
+        <BaseTooltip.Trigger
+          {...baseTriggerProps}
+          ref={mergeRefs([refProp, triggerCallbackRef]) as any}
+        >
           {children}
         </BaseTooltip.Trigger>
       );


### PR DESCRIPTION
#### 🐛 Bug Fix | Change Type

- [x] ✨ feat
- [x] 🐛 fix
- [x] ♻️ refactor
- [x] 💄 style
- [x] 📝 chore
- [x] 📖 docs

#### 📝 Description of Change

Updates `@base-ui/react` to `1.4.1` to fix the `Maximum update depth exceeded` error initially reported in #487 when utilizing `optionRender` on the `Select` component. The upstream upgrade also required adapting the type interfaces across `Alert`, `Form`, `Modal`, `Tabs`, and `Tooltip` standalone components to satisfy stricter TypeScript definitions introduced in the newer `Base UI` release.

#### ℹ️ Additional Information

- Closes #487
- No visible UI or behavior shifts have been introduced.
- Successfully passes `pnpm run type-check` and unit tests locally.
