### PR TITLE
✨ feat(markdown): add copy button to tables

### DIFF
--- a/src/Markdown/components/MarkdownTable/hastTableToMarkdown.test.ts
+++ b/src/Markdown/components/MarkdownTable/hastTableToMarkdown.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { hastTableToMarkdown } from './hastTableToMarkdown';
+
+const text = (value: string) => ({ type: 'text', value });
+
+const el = (tagName: string, properties: any, children: any[] = []) => ({
+  type: 'element',
+  tagName,
+  properties,
+  children,
+});
+
+const cell = (tag: 'th' | 'td', content: any[], properties: any = {}) =>
+  el(tag, properties, content);
+
+const row = (cells: any[]) => el('tr', {}, cells);
+
+const tableOf = (header: any[], body: any[][]) =>
+  el('table', {}, [
+    el('thead', {}, [row(header)]),
+    el(
+      'tbody',
+      {},
+      body.map((r) => row(r)),
+    ),
+  ]);
+
+describe('hastTableToMarkdown', () => {
+  it('serializes a simple table', () => {
+    const node = tableOf(
+      [cell('th', [text('Name')]), cell('th', [text('Age')])],
+      [[cell('td', [text('Alice')]), cell('td', [text('25')])]],
+    );
+    expect(hastTableToMarkdown(node as any)).toBe('| Name | Age |\n| --- | --- |\n| Alice | 25 |');
+  });
+
+  it('honors explicit align attribute even when style is unrelated', () => {
+    const node = tableOf(
+      [
+        cell('th', [text('A')], { style: 'color: red', align: 'right' }),
+        cell('th', [text('B')], { style: 'font-weight: bold', align: 'center' }),
+      ],
+      [[cell('td', [text('1')]), cell('td', [text('2')])]],
+    );
+    expect(hastTableToMarkdown(node as any)).toBe('| A | B |\n| ---: | :---: |\n| 1 | 2 |');
+  });
+
+  it('prefers style alignment over align attribute when both specify it', () => {
+    const node = tableOf(
+      [cell('th', [text('A')], { style: 'text-align: center', align: 'left' })],
+      [[cell('td', [text('1')])]],
+    );
+    expect(hastTableToMarkdown(node as any)).toBe('| A |\n| :---: |\n| 1 |');
+  });
+
+  it('encodes inline code containing backticks with longer fences', () => {
+    const codeNode = el('code', {}, [text('a`b')]);
+    const node = tableOf([cell('th', [text('Snippet')])], [[cell('td', [codeNode])]]);
+    expect(hastTableToMarkdown(node as any)).toBe('| Snippet |\n| --- |\n| ``a`b`` |');
+  });
+
+  it('pads inline code that starts or ends with a backtick', () => {
+    const codeNode = el('code', {}, [text('`x')]);
+    const node = tableOf([cell('th', [text('Code')])], [[cell('td', [codeNode])]]);
+    expect(hastTableToMarkdown(node as any)).toBe('| Code |\n| --- |\n| `` `x `` |');
+  });
+
+  it('escapes pipes inside cells', () => {
+    const node = tableOf([cell('th', [text('a | b')])], [[cell('td', [text('c | d')])]]);
+    expect(hastTableToMarkdown(node as any)).toBe('| a \\| b |\n| --- |\n| c \\| d |');
+  });
+});

--- a/src/Markdown/components/MarkdownTable/hastTableToMarkdown.ts
+++ b/src/Markdown/components/MarkdownTable/hastTableToMarkdown.ts
@@ -8,16 +8,37 @@ type HastNode = {
 
 const escapeCell = (text: string) => text.replaceAll('|', '\\|').replaceAll(/\r?\n/g, '<br>');
 
+const matchAlign = (source: string): 'center' | 'left' | 'right' | null => {
+  if (source.includes('center')) return 'center';
+  if (source.includes('right')) return 'right';
+  if (source.includes('left')) return 'left';
+  return null;
+};
+
 const readAlign = (node: HastNode | undefined): 'center' | 'left' | 'right' | null => {
   const style = node?.properties?.style;
   const align = node?.properties?.align;
-  const haystack = typeof style === 'string' ? style.toLowerCase() : '';
-  const explicit = typeof align === 'string' ? align.toLowerCase() : '';
-  const value = haystack || explicit;
-  if (value.includes('center')) return 'center';
-  if (value.includes('right')) return 'right';
-  if (value.includes('left')) return 'left';
-  return null;
+  const styleStr = typeof style === 'string' ? style.toLowerCase() : '';
+  const alignStr = typeof align === 'string' ? align.toLowerCase() : '';
+  // Prefer the inline style hint (more specific) but fall back to the
+  // explicit `align` attribute when style has no alignment keyword —
+  // otherwise an unrelated style like `color: red` would suppress
+  // `align="right"`.
+  return matchAlign(styleStr) ?? matchAlign(alignStr);
+};
+
+// CommonMark code-span rule: open and close with N backticks where N is
+// longer than any run of consecutive backticks inside the content. If the
+// content starts or ends with a backtick, pad with a single space on each
+// side (the parser strips one space when both sides are padded).
+const encodeInlineCode = (text: string): string => {
+  let longestRun = 0;
+  const runs = text.match(/`+/g);
+  if (runs) for (const run of runs) longestRun = Math.max(longestRun, run.length);
+  const fence = '`'.repeat(longestRun + 1);
+  const needsPad = text.startsWith('`') || text.endsWith('`');
+  const body = needsPad ? ` ${text} ` : text;
+  return `${fence}${body}${fence}`;
 };
 
 const renderInline = (node: HastNode): string => {
@@ -31,7 +52,7 @@ const renderInline = (node: HastNode): string => {
       return '<br>';
     }
     case 'code': {
-      return `\`${inner}\``;
+      return encodeInlineCode(inner);
     }
     case 'strong':
     case 'b': {

--- a/src/Markdown/components/MarkdownTable/hastTableToMarkdown.ts
+++ b/src/Markdown/components/MarkdownTable/hastTableToMarkdown.ts
@@ -1,0 +1,127 @@
+type HastNode = {
+  children?: HastNode[];
+  properties?: Record<string, any>;
+  tagName?: string;
+  type: string;
+  value?: string;
+};
+
+const escapeCell = (text: string) => text.replaceAll('|', '\\|').replaceAll(/\r?\n/g, '<br>');
+
+const readAlign = (node: HastNode | undefined): 'center' | 'left' | 'right' | null => {
+  const style = node?.properties?.style;
+  const align = node?.properties?.align;
+  const haystack = typeof style === 'string' ? style.toLowerCase() : '';
+  const explicit = typeof align === 'string' ? align.toLowerCase() : '';
+  const value = haystack || explicit;
+  if (value.includes('center')) return 'center';
+  if (value.includes('right')) return 'right';
+  if (value.includes('left')) return 'left';
+  return null;
+};
+
+const renderInline = (node: HastNode): string => {
+  if (node.type === 'text') return node.value ?? '';
+  if (node.type !== 'element') return '';
+
+  const inner = (node.children ?? []).map((child) => renderInline(child)).join('');
+
+  switch (node.tagName) {
+    case 'br': {
+      return '<br>';
+    }
+    case 'code': {
+      return `\`${inner}\``;
+    }
+    case 'strong':
+    case 'b': {
+      return `**${inner}**`;
+    }
+    case 'em':
+    case 'i': {
+      return `*${inner}*`;
+    }
+    case 'del':
+    case 's': {
+      return `~~${inner}~~`;
+    }
+    case 'a': {
+      const href = node.properties?.href;
+      return href ? `[${inner}](${href})` : inner;
+    }
+    case 'img': {
+      const src = node.properties?.src ?? '';
+      const alt = node.properties?.alt ?? '';
+      return `![${alt}](${src})`;
+    }
+    default: {
+      return inner;
+    }
+  }
+};
+
+const renderCell = (cell: HastNode): string => escapeCell(renderInline(cell)).trim();
+
+const findChild = (node: HastNode | undefined, tag: string): HastNode | undefined =>
+  node?.children?.find((child) => child.type === 'element' && child.tagName === tag);
+
+const findAllChildren = (node: HastNode | undefined, tag: string): HastNode[] =>
+  (node?.children ?? []).filter((child) => child.type === 'element' && child.tagName === tag);
+
+const getRowCells = (row: HastNode): HastNode[] =>
+  (row.children ?? []).filter(
+    (child) => child.type === 'element' && (child.tagName === 'th' || child.tagName === 'td'),
+  );
+
+const alignToDivider = (align: 'center' | 'left' | 'right' | null): string => {
+  switch (align) {
+    case 'center': {
+      return ':---:';
+    }
+    case 'left': {
+      return ':---';
+    }
+    case 'right': {
+      return '---:';
+    }
+    default: {
+      return '---';
+    }
+  }
+};
+
+export const hastTableToMarkdown = (node: HastNode | undefined): string => {
+  if (!node) return '';
+
+  const thead = findChild(node, 'thead');
+  const tbody = findChild(node, 'tbody');
+
+  const headerRow = findChild(thead, 'tr');
+  const headerCells = headerRow ? getRowCells(headerRow) : [];
+
+  const bodyRows = findAllChildren(tbody, 'tr');
+  const columnCount = Math.max(
+    headerCells.length,
+    ...bodyRows.map((row) => getRowCells(row).length),
+  );
+
+  if (columnCount === 0) return '';
+
+  const headerTexts = Array.from({ length: columnCount }, (_, i) =>
+    headerCells[i] ? renderCell(headerCells[i]) : '',
+  );
+
+  const aligns = Array.from({ length: columnCount }, (_, i) => readAlign(headerCells[i]));
+
+  const headerLine = `| ${headerTexts.join(' | ')} |`;
+  const dividerLine = `| ${aligns.map((a) => alignToDivider(a)).join(' | ')} |`;
+  const bodyLines = bodyRows.map((row) => {
+    const cells = getRowCells(row);
+    const texts = Array.from({ length: columnCount }, (_, i) =>
+      cells[i] ? renderCell(cells[i]) : '',
+    );
+    return `| ${texts.join(' | ')} |`;
+  });
+
+  return [headerLine, dividerLine, ...bodyLines].join('\n');
+};

--- a/src/Markdown/components/MarkdownTable/index.tsx
+++ b/src/Markdown/components/MarkdownTable/index.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { createStyles } from 'antd-style';
+import { memo, useCallback, useRef } from 'react';
+
+import CopyButton from '@/CopyButton';
+
+import { hastTableToMarkdown } from './hastTableToMarkdown';
+
+const useStyles = createStyles(({ css, token }) => ({
+  copyButton: css`
+    position: absolute;
+    z-index: 1;
+    inset-block-start: 6px;
+    inset-inline-end: 6px;
+
+    opacity: 0;
+
+    transition: opacity ${token.motionDurationMid} ${token.motionEaseInOut};
+  `,
+  wrapper: css`
+    position: relative;
+    display: inline-block;
+    max-width: 100%;
+    margin-block: calc(var(--lobe-markdown-margin-multiple) * 0.5em);
+
+    &:hover .table-copy-button,
+    &:focus-within .table-copy-button {
+      opacity: 1;
+    }
+
+    /* Hand spacing to the wrapper so the absolutely-positioned copy
+       button anchors against the visible table edge instead of empty
+       margin space. */
+    > table {
+      margin-block: 0;
+    }
+  `,
+}));
+
+interface MarkdownTableProps {
+  children?: React.ReactNode;
+  node?: any;
+}
+
+const MarkdownTable = memo<MarkdownTableProps>(({ node, children, ...rest }) => {
+  const { styles, cx } = useStyles();
+  const nodeRef = useRef(node);
+  nodeRef.current = node;
+
+  const getMarkdown = useCallback(() => hastTableToMarkdown(nodeRef.current), []);
+
+  return (
+    <div className={styles.wrapper}>
+      <CopyButton
+        className={cx(styles.copyButton, 'table-copy-button')}
+        content={getMarkdown}
+        size={{ blockSize: 24, size: 14 }}
+        title="Copy table"
+      />
+      <table {...rest}>{children}</table>
+    </div>
+  );
+});
+
+MarkdownTable.displayName = 'MarkdownTable';
+
+export default MarkdownTable;

--- a/src/Markdown/components/MarkdownTable/index.tsx
+++ b/src/Markdown/components/MarkdownTable/index.tsx
@@ -11,16 +11,26 @@ const useStyles = createStyles(({ css, token }) => ({
   copyButton: css`
     position: absolute;
     z-index: 1;
-    inset-block-start: 6px;
-    inset-inline-end: 6px;
+
+    /* Vertical center of the header row = top padding (0.75em) + half of
+       the text line-box (line-height * 0.5em). Pulling the button up by
+       50% of its own height with transform parks it on that exact line. */
+    inset-block-start: calc(0.75em + (var(--lobe-markdown-line-height) * 0.5em));
+    inset-inline-end: 0.5em;
+    transform: translateY(-50%);
 
     opacity: 0;
+    background: ${token.colorBgContainer};
+    box-shadow: 0 0 0 1px ${token.colorBorderSecondary};
 
     transition: opacity ${token.motionDurationMid} ${token.motionEaseInOut};
   `,
   wrapper: css`
     position: relative;
-    display: inline-block;
+
+    display: block;
+
+    width: max-content;
     max-width: 100%;
     margin-block: calc(var(--lobe-markdown-margin-multiple) * 0.5em);
 
@@ -34,6 +44,12 @@ const useStyles = createStyles(({ css, token }) => ({
        margin space. */
     > table {
       margin-block: 0;
+    }
+
+    /* Reserve room for the copy button so right-aligned header text
+       doesn't slide under it. */
+    > table thead th:last-child {
+      padding-inline-end: calc(1em + 32px);
     }
   `,
 }));
@@ -55,8 +71,10 @@ const MarkdownTable = memo<MarkdownTableProps>(({ node, children, ...rest }) => 
       <CopyButton
         className={cx(styles.copyButton, 'table-copy-button')}
         content={getMarkdown}
+        glass={false}
         size={{ blockSize: 24, size: 14 }}
         title="Copy table"
+        variant="filled"
       />
       <table {...rest}>{children}</table>
     </div>

--- a/src/hooks/useMarkdown/useMarkdownComponents.tsx
+++ b/src/hooks/useMarkdown/useMarkdownComponents.tsx
@@ -6,6 +6,7 @@ import type { Components } from 'react-markdown';
 import Hotkey from '@/Hotkey';
 import { CodeBlock } from '@/Markdown/components/CodeBlock';
 import { useMarkdownContext } from '@/Markdown/components/MarkdownProvider';
+import MarkdownTable from '@/Markdown/components/MarkdownTable';
 import Image from '@/mdx/mdxComponents/Image';
 import Link from '@/mdx/mdxComponents/Link';
 import Section from '@/mdx/mdxComponents/Section';
@@ -112,6 +113,11 @@ export const useMarkdownComponents = (): Components => {
 
   const memoColorPreview = useCallback(({ node, ...props }: any) => <code {...props} />, []);
 
+  const memoTable = useCallback(
+    ({ node, ...props }: any) => <MarkdownTable node={node} {...props} />,
+    [],
+  );
+
   const memoComponents = useMemo(
     () => ({
       a: memoA,
@@ -122,9 +128,21 @@ export const useMarkdownComponents = (): Components => {
       p: memeP,
       pre: memoPre,
       section: memoSection,
+      table: memoTable,
       video: memoVideo,
     }),
-    [memoA, memoBr, memoImg, memoVideo, memoPre, memoSection, memeP, memoColorPreview, memoKbd],
+    [
+      memoA,
+      memoBr,
+      memoImg,
+      memoVideo,
+      memoPre,
+      memoSection,
+      memeP,
+      memoColorPreview,
+      memoKbd,
+      memoTable,
+    ],
   );
 
   return useMemo(


### PR DESCRIPTION
## Summary

- Wraps every rendered Markdown `<table>` with a hover-revealed copy button anchored to the top-right corner (mirrors the cherry-markdown UX requested in feedback).
- Copy payload is GFM markdown reconstructed from the table's hast node — preserves column alignment markers (`:---` / `:---:` / `---:`), inline code, bold, italic, strikethrough, links, images, and escapes `|` inside cells.
- Hooked into `useMarkdownComponents` as a new `table` override, so the behavior applies to every consumer of `<Markdown />` automatically.

## Test plan

- [x] Type check (`tsc --noEmit`) passes
- [x] ESLint passes for changed files
- [x] Verified locally on `/~demos/src-markdown-demo-tables`: 2 tables render with hidden copy buttons that fade in on hover
- [x] Clicked both buttons via DevTools clipboard interception — payload matches expected GFM, including alignment markers and inline `` `code` ``
- [ ] Manual smoke: open Markdown demos page and confirm copy button doesn't visually clash with `htmlPreview` / code blocks
- [ ] Manual smoke: paste the copied markdown back into a Markdown demo and confirm it round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)