### PR TITLE
⬆️ chore(deps): upgrade @base-ui/react to 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
   },
   "dependencies": {
     "@ant-design/cssinjs": "^2.1.2",
-    "@base-ui/react": "1.0.0",
+    "@base-ui/react": "1.5.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.1.2
         version: 2.1.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@base-ui/react':
-        specifier: 1.0.0
-        version: 1.0.0(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: 1.5.0
+        version: 1.5.0(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -269,7 +269,7 @@ importers:
         version: 8.59.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@26.1.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.99.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@26.1.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
       antd:
         specifier: ^6.3.6
         version: 6.3.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -374,7 +374,7 @@ importers:
         version: 5.1.0
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@26.1.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.99.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@26.1.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
 
 packages:
 
@@ -701,19 +701,25 @@ packages:
     resolution: {integrity: sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@base-ui/react@1.0.0':
-    resolution: {integrity: sha512-4USBWz++DUSLTuIYpbYkSgy1F9ZmNG9S/lXvlUN6qMK0P0RlW+6eQmDUB4DgZ7HVvtXl4pvi4z5J2fv6Z3+9hg==}
+  '@base-ui/react@1.5.0':
+    resolution: {integrity: sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
+      '@date-fns/tz': ^1.2.0
       '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
       react: ^17 || ^18 || ^19
       react-dom: ^17 || ^18 || ^19
     peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
       '@types/react':
         optional: true
+      date-fns:
+        optional: true
 
-  '@base-ui/utils@0.2.3':
-    resolution: {integrity: sha512-/CguQ2PDaOzeVOkllQR8nocJ0FFIDqsWIcURsVmm53QGo8NhFNpePjNlyPIB41luxfOqnG7PU0xicMEw3ls7XQ==}
+  '@base-ui/utils@0.2.9':
+    resolution: {integrity: sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==}
     peerDependencies:
       '@types/react': ^17 || ^18 || ^19
       react: ^17 || ^18 || ^19
@@ -10937,6 +10943,7 @@ packages:
 
   sliced@1.0.1:
     resolution: {integrity: sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==}
+    deprecated: Unsupported
 
   sonic-boom@2.8.0:
     resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
@@ -12869,21 +12876,19 @@ snapshots:
       '@babel/helper-string-parser': 8.0.0-rc.4
       '@babel/helper-validator-identifier': 8.0.0-rc.3
 
-  '@base-ui/react@1.0.0(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@base-ui/react@1.5.0(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.2
-      '@base-ui/utils': 0.2.3(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@base-ui/utils': 0.2.9(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@floating-ui/utils': 0.2.11
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      reselect: 5.1.1
-      tabbable: 6.4.0
       use-sync-external-store: 1.6.0(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@base-ui/utils@0.2.3(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@base-ui/utils@0.2.9(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@floating-ui/utils': 0.2.11
@@ -13897,14 +13902,14 @@ snapshots:
 
   '@loadable/component@5.15.2(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.23.6
+      '@babel/runtime': 7.29.2
       hoist-non-react-statics: 3.3.2
       react: 18.3.1
       react-is: 16.13.1
 
   '@loadable/component@5.15.2(react@19.2.6)':
     dependencies:
-      '@babel/runtime': 7.23.6
+      '@babel/runtime': 7.29.2
       hoist-non-react-statics: 3.3.2
       react: 19.2.6
       react-is: 16.13.1
@@ -16267,7 +16272,7 @@ snapshots:
       postcss: 8.5.14
       resolve-url-loader: 5.0.0
       sass: 1.54.0
-      sass-loader: 13.2.0(sass@1.99.0)(webpack@5.106.2)
+      sass-loader: 13.2.0(sass@1.54.0)(webpack@5.106.2)
     transitivePeerDependencies:
       - '@types/webpack'
       - bufferutil
@@ -16394,7 +16399,7 @@ snapshots:
 
   '@umijs/history@5.3.1':
     dependencies:
-      '@babel/runtime': 7.23.6
+      '@babel/runtime': 7.29.2
       query-string: 6.14.1
 
   '@umijs/lint@4.6.51(eslint@9.39.4(jiti@2.7.0))(stylelint@16.26.1(typescript@6.0.3))(typescript@6.0.3)':
@@ -16753,7 +16758,7 @@ snapshots:
       postcss: 8.5.14
       resolve-url-loader: 5.0.0
       sass: 1.54.0
-      sass-loader: 13.2.0(sass@1.99.0)(webpack@5.106.2)
+      sass-loader: 13.2.0(sass@1.54.0)(webpack@5.106.2)
       semver: 7.7.4
       send: 0.17.1
       styled-jsx: 5.1.7(@babel/core@7.29.0)(react@19.2.6)
@@ -16781,7 +16786,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@26.1.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.99.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@26.1.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -16796,7 +16801,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@26.1.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.99.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@26.1.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -16808,13 +16813,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.99.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))':
+  '@vitest/mocker@3.2.4(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.3(@types/node@25.6.0)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.99.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@25.6.0)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -20525,7 +20530,7 @@ snapshots:
 
   history@5.3.0:
     dependencies:
-      '@babel/runtime': 7.23.6
+      '@babel/runtime': 7.29.2
 
   hmac-drbg@1.0.1:
     dependencies:
@@ -23987,7 +23992,7 @@ snapshots:
 
   react-helmet-async@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.23.6
+      '@babel/runtime': 7.29.2
       invariant: 2.2.4
       prop-types: 15.8.1
       react: 18.3.1
@@ -23997,7 +24002,7 @@ snapshots:
 
   react-helmet-async@1.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      '@babel/runtime': 7.23.6
+      '@babel/runtime': 7.29.2
       invariant: 2.2.4
       prop-types: 15.8.1
       react: 19.2.6
@@ -25379,13 +25384,13 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@13.2.0(sass@1.99.0)(webpack@5.106.2):
+  sass-loader@13.2.0(sass@1.54.0)(webpack@5.106.2):
     dependencies:
       klona: 2.0.6
       neo-async: 2.6.2
       webpack: 5.106.2
     optionalDependencies:
-      sass: 1.99.0
+      sass: 1.54.0
 
   sass-loader@16.0.7(sass@1.99.0)(webpack@5.106.2):
     dependencies:
@@ -26986,13 +26991,13 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  vite-node@3.2.4(@types/node@25.6.0)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.99.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4):
+  vite-node@3.2.4(@types/node@25.6.0)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.3(@types/node@25.6.0)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.99.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@25.6.0)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -27020,7 +27025,7 @@ snapshots:
       sass: 1.99.0
       terser: 5.47.1
 
-  vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.99.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4):
+  vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -27034,16 +27039,16 @@ snapshots:
       jiti: 2.7.0
       less: 4.1.3
       lightningcss: 1.22.1
-      sass: 1.99.0
+      sass: 1.54.0
       terser: 5.47.1
       tsx: 4.21.0
       yaml: 2.8.4
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@26.1.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.99.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4):
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(jiti@2.7.0)(jsdom@26.1.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.99.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
+      '@vitest/mocker': 3.2.4(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -27061,8 +27066,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.3(@types/node@25.6.0)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.99.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
-      vite-node: 3.2.4(@types/node@25.6.0)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.99.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 7.3.3(@types/node@25.6.0)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
+      vite-node: 3.2.4(@types/node@25.6.0)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.22.1)(sass@1.54.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.13

--- a/src/Tooltip/TooltipGroup.tsx
+++ b/src/Tooltip/TooltipGroup.tsx
@@ -103,7 +103,7 @@ const TooltipGroup: FC<TooltipGroupProps> = ({
               viewport: resolvedStyleProps?.content,
             };
 
-            const body = layoutAnimation ? (
+            const body = (
               <BaseTooltip.Viewport
                 className={resolvedClassNames.viewport}
                 style={resolvedStyles.viewport}
@@ -114,14 +114,6 @@ const TooltipGroup: FC<TooltipGroupProps> = ({
                   title={item.title}
                 />
               </BaseTooltip.Viewport>
-            ) : (
-              <div className={resolvedClassNames.viewport} style={resolvedStyles.viewport}>
-                <TooltipContent
-                  hotkey={item.hotkey}
-                  hotkeyProps={item.hotkeyProps}
-                  title={item.title}
-                />
-              </div>
             );
 
             const popup = (

--- a/src/Tooltip/TooltipStandalone.tsx
+++ b/src/Tooltip/TooltipStandalone.tsx
@@ -3,7 +3,15 @@
 import { mergeProps } from '@base-ui/react/merge-props';
 import { Tooltip as BaseTooltip } from '@base-ui/react/tooltip';
 import { cx } from 'antd-style';
-import { cloneElement, isValidElement, memo, useCallback, useMemo, useState } from 'react';
+import {
+  cloneElement,
+  isValidElement,
+  memo,
+  type Ref,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
 import { mergeRefs } from 'react-merge-refs';
 
 import { useFloatingLayer } from '@/hooks/useFloatingLayer';
@@ -179,7 +187,10 @@ export const TooltipStandalone = memo<TooltipProps>(
       }
 
       return (
-        <BaseTooltip.Trigger {...baseTriggerProps} ref={mergeRefs([refProp, triggerCallbackRef])}>
+        <BaseTooltip.Trigger
+          {...baseTriggerProps}
+          ref={mergeRefs([refProp, triggerCallbackRef]) as Ref<HTMLButtonElement>}
+        >
           {children}
         </BaseTooltip.Trigger>
       );

--- a/src/Tooltip/TooltipStandalone.tsx
+++ b/src/Tooltip/TooltipStandalone.tsx
@@ -233,9 +233,12 @@ export const TooltipStandalone = memo<TooltipProps>(
                 {TooltipArrowIcon}
               </BaseTooltip.Arrow>
             )}
-            <div className={resolvedClassNames.viewport} style={resolvedStyles.viewport}>
+            <BaseTooltip.Viewport
+              className={resolvedClassNames.viewport}
+              style={resolvedStyles.viewport}
+            >
               <TooltipContent hotkey={hotkey} hotkeyProps={hotkeyProps} title={title} />
-            </div>
+            </BaseTooltip.Viewport>
           </BaseTooltip.Popup>
         </BaseTooltip.Positioner>
       ),

--- a/src/Tooltip/style.ts
+++ b/src/Tooltip/style.ts
@@ -62,9 +62,9 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
 
     background: ${cssVar.colorBgElevated};
     box-shadow:
-      0 1px 2px 0 rgba(0, 0, 0, 3%),
-      0 1px 6px -1px rgba(0, 0, 0, 2%),
-      0 2px 4px 0 rgba(0, 0, 0, 2%);
+      0 1px 2px 0 rgb(0 0 0 / 3%),
+      0 1px 6px -1px rgb(0 0 0 / 2%),
+      0 2px 4px 0 rgb(0 0 0 / 2%);
 
     transition-timing-function: var(--lobe-tooltip-animation-ease-out);
     transition-duration: var(--lobe-tooltip-animation-duration);
@@ -167,11 +167,10 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     gap: 6px;
     align-items: center;
 
-    max-width: var(--available-width);
     padding-block: 4px;
     padding-inline: var(--lobe-tooltip-viewport-inline-padding);
 
-    word-break: break-word;
+    overflow-wrap: break-word;
     white-space: normal;
 
     [data-previous],

--- a/src/base-ui/Popover/PopoverGroup.tsx
+++ b/src/base-ui/Popover/PopoverGroup.tsx
@@ -126,18 +126,12 @@ const PopoverGroup: FC<PopoverGroupProps> = ({
                       {PopoverArrowIcon}
                     </PopoverArrow>
                   )}
-                  {contentLayoutAnimation ? (
-                    <PopoverViewport
-                      className={resolvedClassNames.viewport}
-                      style={resolvedStyles.viewport}
-                    >
-                      {contentNode}
-                    </PopoverViewport>
-                  ) : (
-                    <div className={resolvedClassNames.viewport} style={resolvedStyles.viewport}>
-                      {contentNode}
-                    </div>
-                  )}
+                  <PopoverViewport
+                    className={resolvedClassNames.viewport}
+                    style={resolvedStyles.viewport}
+                  >
+                    {contentNode}
+                  </PopoverViewport>
                 </PopoverPopup>
               </PopoverPositioner>
             );

--- a/src/base-ui/Popover/style.ts
+++ b/src/base-ui/Popover/style.ts
@@ -170,10 +170,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     --lobe-popover-viewport-inline-padding: 12px;
 
     position: relative;
-
     overflow: clip;
-
-    max-width: var(--available-width);
     padding-block: 12px;
     padding-inline: var(--lobe-popover-viewport-inline-padding);
 


### PR DESCRIPTION
## Summary

- Upgrade `@base-ui/react` from **1.0.0** to **1.5.0** (latest).
- The previous block on 1.1+ was a Popover width calc regression: since 1.1, `usePopupAutoResize` moved from `PopoverPopup` into `PopoverViewport`, so `--positioner-width` is only set when `Viewport` is rendered. Our Popover (`src/base-ui/Popover/atoms.tsx`) already renders `PopoverViewport`, so the existing CSS `width: min(var(--positioner-width), var(--available-width))` continues to work.
- One TS-only fix: `BaseTooltip.Trigger`'s ref type was narrowed to `HTMLButtonElement` in 1.5; cast the merged ref accordingly.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `eslint` passes on changed file
- [x] Popover demos render correctly (atoms, placement top/right) — width & positioning verified via dumi dev + agent-browser
- [x] Tooltip hover shows popup with correct width (max-width fallback works for non-Viewport Standalone)
- [x] Select atoms demo dropdown aligns with `--anchor-width`
- [ ] Visual regression check across remaining popover-based components (DropdownMenu, ContextMenu, Modal, etc.) in CI/preview