### PR TITLE
⚡️ perf(markdown): cut streamdown streaming CPU by 2x

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,8 @@
     "emoji-mart": "^5.6.0",
     "es-toolkit": "^1.47.0",
     "fast-deep-equal": "^3.1.3",
+    "hast-util-to-jsx-runtime": "^2.3.6",
+    "html-url-attributes": "^3.0.1",
     "immer": "^11.1.8",
     "katex": "^0.16.47",
     "leva": "^0.10.1",
@@ -193,6 +195,8 @@
     "remark-gfm": "^4.0.1",
     "remark-github": "^12.0.0",
     "remark-math": "^6.0.0",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
     "remend": "^1.3.0",
     "shiki": "^4.2.0",
     "shiki-stream": "^0.1.5",
@@ -202,6 +206,7 @@
     "url-join": "^5.0.0",
     "use-merge-value": "^1.2.0",
     "uuid": "^13.0.2",
+    "vfile": "^6.0.3",
     "virtua": "^0.49.1"
   },
   "devDependencies": {

--- a/src/Markdown/Markdown.tsx
+++ b/src/Markdown/Markdown.tsx
@@ -45,6 +45,7 @@ const Markdown = memo<MarkdownProps>((props) => {
     components = {},
     customRender,
     showFootnotes = true,
+    streamAnimationGranularity,
     streamSmoothingPreset,
     citations,
     ...rest
@@ -108,6 +109,7 @@ const Markdown = memo<MarkdownProps>((props) => {
           remarkPlugins={remarkPlugins}
           remarkPluginsAhead={remarkPluginsAhead}
           showFootnotes={showFootnotes}
+          streamAnimationGranularity={streamAnimationGranularity}
           streamSmoothingPreset={streamSmoothingPreset}
           variant={variant}
         >

--- a/src/Markdown/SyntaxMarkdown/CachedMarkdown.tsx
+++ b/src/Markdown/SyntaxMarkdown/CachedMarkdown.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { type Nodes, type Root } from 'hast';
+import { toJsxRuntime } from 'hast-util-to-jsx-runtime';
+import { urlAttributes } from 'html-url-attributes';
+import { useMemo } from 'react';
+import { Fragment, jsx, jsxs } from 'react/jsx-runtime';
+import { defaultUrlTransform, type Options } from 'react-markdown';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
+import { type PluggableList, unified } from 'unified';
+import { type BuildVisitor, visit } from 'unist-util-visit';
+import { VFile } from 'vfile';
+
+const EMPTY_PLUGINS: PluggableList = [];
+const DEFAULT_REMARK_REHYPE_OPTIONS = { allowDangerousHtml: true };
+
+/**
+ * Render-equivalent of react-markdown's synchronous `<Markdown>` that keeps
+ * the unified processor across renders. react-markdown rebuilds the whole
+ * plugin chain on every render; the streaming tail block re-renders on every
+ * reveal commit (~20/s) with identical plugin identities, so caching the
+ * processor removes the per-commit chain construction. `post`/`transform`
+ * mirror react-markdown@10 — keep them in sync when upgrading it.
+ */
+export const CachedMarkdown = (options: Options) => {
+  const { children, rehypePlugins, remarkPlugins, remarkRehypeOptions } = options;
+
+  const processor = useMemo(() => {
+    return unified()
+      .use(remarkParse)
+      .use(remarkPlugins || EMPTY_PLUGINS)
+      .use(
+        remarkRehype,
+        remarkRehypeOptions
+          ? { ...remarkRehypeOptions, ...DEFAULT_REMARK_REHYPE_OPTIONS }
+          : DEFAULT_REMARK_REHYPE_OPTIONS,
+      )
+      .use(rehypePlugins || EMPTY_PLUGINS);
+  }, [rehypePlugins, remarkPlugins, remarkRehypeOptions]);
+
+  const file = new VFile();
+  file.value = typeof children === 'string' ? children : '';
+
+  return post(processor.runSync(processor.parse(file), file) as Nodes, options);
+};
+
+function post(tree: Nodes, options: Options) {
+  const {
+    allowedElements,
+    allowElement,
+    components,
+    disallowedElements,
+    skipHtml,
+    unwrapDisallowed,
+  } = options;
+  const urlTransform = options.urlTransform || defaultUrlTransform;
+
+  if (allowedElements && disallowedElements) {
+    throw new Error(
+      'Unexpected combined `allowedElements` and `disallowedElements`, expected one or the other',
+    );
+  }
+
+  const transform: BuildVisitor<Root> = (node, index, parent) => {
+    if (node.type === 'raw' && parent && typeof index === 'number') {
+      if (skipHtml) {
+        parent.children.splice(index, 1);
+      } else {
+        parent.children[index] = { type: 'text', value: node.value };
+      }
+
+      return index;
+    }
+
+    if (node.type === 'element') {
+      let key: string;
+
+      for (key in urlAttributes) {
+        if (Object.hasOwn(urlAttributes, key) && Object.hasOwn(node.properties, key)) {
+          const value = node.properties[key];
+          const test = urlAttributes[key];
+          if (test === null || test.includes(node.tagName)) {
+            node.properties[key] = urlTransform(String(value || ''), key, node);
+          }
+        }
+      }
+
+      let remove = allowedElements
+        ? !allowedElements.includes(node.tagName)
+        : disallowedElements
+          ? disallowedElements.includes(node.tagName)
+          : false;
+
+      if (!remove && allowElement && typeof index === 'number') {
+        remove = !allowElement(node, index, parent);
+      }
+
+      if (remove && parent && typeof index === 'number') {
+        if (unwrapDisallowed && node.children) {
+          parent.children.splice(index, 1, ...node.children);
+        } else {
+          parent.children.splice(index, 1);
+        }
+
+        return index;
+      }
+    }
+  };
+
+  visit(tree as Root, transform);
+
+  return toJsxRuntime(tree, {
+    Fragment,
+    components,
+    ignoreInvalidStyle: true,
+    jsx,
+    jsxs,
+    passKeys: true,
+    passNode: true,
+  });
+}

--- a/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
+++ b/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
@@ -22,7 +22,10 @@ import {
   useMarkdownRemarkPlugins,
 } from '@/hooks/useMarkdown';
 import { useMarkdownContext } from '@/Markdown/components/MarkdownProvider';
-import { rehypeStreamAnimated } from '@/Markdown/plugins/rehypeStreamAnimated';
+import {
+  rehypeStreamAnimated,
+  type StreamAnimatedRuntime,
+} from '@/Markdown/plugins/rehypeStreamAnimated';
 import { useStreamdownProfiler } from '@/Markdown/streamProfiler';
 import { isDeepEqual } from '@/utils/isDeepEqual';
 
@@ -32,7 +35,6 @@ import { useSmoothStreamContent } from './useSmoothStreamContent';
 import { type BlockInfo, useStreamQueue } from './useStreamQueue';
 
 const STREAM_FADE_DURATION = 280;
-const REVEALED_STREAM_PLUGIN: Pluggable = [rehypeStreamAnimated, { revealed: true }];
 
 function countChars(text: string): number {
   return [...text].length;
@@ -90,6 +92,17 @@ const StreamdownBlock = memo<Options>(
 
 StreamdownBlock.displayName = 'StreamdownBlock';
 
+interface BlockRuntime extends StreamAnimatedRuntime {
+  charCount: number;
+  rawLength: number;
+}
+
+interface BlockPluginsCacheEntry {
+  base: PluggableList;
+  settled: boolean;
+  value: PluggableList;
+}
+
 export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
   const { streamSmoothingPreset = 'balanced' } = useMarkdownContext();
   const profiler = useStreamdownProfiler();
@@ -134,56 +147,67 @@ export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
 
   const { getBlockState, charDelay } = useStreamQueue(blocks);
   const blockCharDelayRef = useRef<Map<number, number>>(new Map());
-  const blockBirthsRef = useRef<Map<number, number[]>>(new Map());
+  const blockRuntimesRef = useRef<Map<number, BlockRuntime>>(new Map());
+  const blockPluginsRef = useRef<Map<number, BlockPluginsCacheEntry>>(new Map());
 
   const renderNow = getNow();
 
-  const birthsResult = useMemo(() => {
+  const runtimesResult = useMemo(() => {
     const start = profiler ? getNow() : 0;
-    const nextBirths = new Map<number, number[]>();
-    const prevBirths = blockBirthsRef.current;
+    const runtimes = blockRuntimesRef.current;
+    const alive = new Set<number>();
 
     for (const [index, block] of blocks.entries()) {
-      const state = getBlockState(index);
+      alive.add(block.startOffset);
       // Queued blocks are not rendered. Defer birth assignment so that
       // when the block later transitions to animating/streaming, its
       // chars start fading from that moment instead of having already
       // "aged out" of the fade window.
-      if (state === 'queued') continue;
+      if (getBlockState(index) === 'queued') continue;
 
-      const blockCharCount = countChars(block.content);
-      const prev = prevBirths.get(block.startOffset);
-      let arr: number[];
+      let runtime = runtimes.get(block.startOffset);
+      if (!runtime) {
+        runtime = { births: [], charCount: 0, rawLength: -1, styles: [] };
+        runtimes.set(block.startOffset, runtime);
+      }
 
-      if (prev && prev.length === blockCharCount) {
-        arr = prev;
-      } else if (prev && prev.length > blockCharCount) {
+      if (runtime.rawLength !== block.content.length) {
+        runtime.charCount = countChars(block.content);
+        runtime.rawLength = block.content.length;
+      }
+
+      const blockCharCount = runtime.charCount;
+      const births = runtime.births;
+
+      if (births.length > blockCharCount) {
         // Block content shrunk (stream restart or upstream rewrite).
-        arr = prev.slice(0, blockCharCount);
-      } else {
-        arr = prev ? prev.slice() : [];
-        const startIdx = arr.length;
+        births.length = blockCharCount;
+        runtime.styles.length = blockCharCount;
+      }
+
+      if (births.length < blockCharCount) {
         // Chain each new char monotonically after the previous one so fades
         // never race out of order. Cap how far the fade queue can run ahead
         // of renderNow to prevent stream-faster-than-fade producing seconds
         // of invisible backlog at the tail.
         const cap = renderNow + STREAM_FADE_DURATION;
-        for (let i = startIdx; i < blockCharCount; i++) {
-          const prevBirth = i > 0 ? (arr[i - 1] as number) : renderNow - charDelay;
+        for (let i = births.length; i < blockCharCount; i++) {
+          const prevBirth = i > 0 ? births[i - 1] : renderNow - charDelay;
           const chained = prevBirth + charDelay;
-          arr.push(Math.min(cap, Math.max(chained, renderNow)));
+          births.push(Math.min(cap, Math.max(chained, renderNow)));
         }
       }
-
-      nextBirths.set(block.startOffset, arr);
     }
 
-    return {
-      durationMs: profiler ? getNow() - start : 0,
-      value: nextBirths,
-    };
+    for (const key of blockRuntimesRef.current.keys()) {
+      if (!alive.has(key)) {
+        blockRuntimesRef.current.delete(key);
+        blockPluginsRef.current.delete(key);
+      }
+    }
+
+    return { durationMs: profiler ? getNow() - start : 0 };
   }, [blocks, charDelay, getBlockState, profiler, renderNow]);
-  const birthsForRender = birthsResult.value;
 
   useEffect(() => {
     if (!profiler) return;
@@ -210,12 +234,12 @@ export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
     if (!profiler) return;
 
     profiler.recordCalculation({
-      durationMs: birthsResult.durationMs,
+      durationMs: runtimesResult.durationMs,
       itemCount: blocks.length,
       name: 'block-births',
       textLength: processedContent.length,
     });
-  }, [birthsResult.durationMs, blocks.length, processedContent.length, profiler]);
+  }, [runtimesResult.durationMs, blocks.length, processedContent.length, profiler]);
 
   const blockAnimationMetaResult = useMemo(() => {
     const nextBlockCharDelay = new Map<number, number>();
@@ -223,7 +247,9 @@ export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
 
     for (const [index, block] of blocks.entries()) {
       const state = getBlockState(index);
-      const births = birthsForRender.get(block.startOffset);
+      if (state === 'queued') continue;
+
+      const births = blockRuntimesRef.current.get(block.startOffset)?.births;
       const lastBirthTs = births && births.length > 0 ? (births.at(-1) ?? renderNow) : renderNow;
       const lastElapsedMs = renderNow - lastBirthTs;
       const animationMeta = resolveBlockAnimationMeta({
@@ -242,12 +268,29 @@ export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
       blockAnimationMeta,
       blockCharDelay: nextBlockCharDelay,
     };
-  }, [birthsForRender, blocks, charDelay, getBlockState, renderNow]);
+  }, [blocks, charDelay, getBlockState, renderNow]);
 
   useEffect(() => {
     blockCharDelayRef.current = blockAnimationMetaResult.blockCharDelay;
-    blockBirthsRef.current = birthsForRender;
-  }, [birthsForRender, blockAnimationMetaResult.blockCharDelay]);
+  }, [blockAnimationMetaResult.blockCharDelay]);
+
+  const resolveBlockPlugins = (startOffset: number, settled: boolean): PluggableList => {
+    if (settled) return baseRehypePlugins;
+
+    const cache = blockPluginsRef.current;
+    const entry = cache.get(startOffset);
+    if (entry && entry.base === baseRehypePlugins && entry.settled === settled) {
+      return entry.value;
+    }
+
+    const runtime = blockRuntimesRef.current.get(startOffset);
+    const value: PluggableList = [
+      ...baseRehypePlugins,
+      [rehypeStreamAnimated, { fadeDuration: STREAM_FADE_DURATION, runtime }],
+    ];
+    cache.set(startOffset, { base: baseRehypePlugins, settled, value });
+    return value;
+  };
 
   const handleRootRender = useCallback<ProfilerOnRenderCallback>(
     (_, phase, actualDuration, baseDuration) => {
@@ -295,32 +338,8 @@ export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
         const animationMeta = blockAnimationMetaResult.blockAnimationMeta.get(block.startOffset);
         if (!animationMeta) return null;
 
-        const births = birthsForRender.get(block.startOffset);
-        const plugins: Pluggable[] = animationMeta.settled
-          ? [...baseRehypePlugins, REVEALED_STREAM_PLUGIN]
-          : [
-              ...baseRehypePlugins,
-              [
-                rehypeStreamAnimated,
-                {
-                  births,
-                  fadeDuration: STREAM_FADE_DURATION,
-                  nowMs: renderNow,
-                },
-              ],
-            ];
-
+        const plugins = resolveBlockPlugins(block.startOffset, animationMeta.settled);
         const key = `${generatedId}-${block.startOffset}`;
-        const blockNode = (
-          <StreamdownBlock
-            {...rest}
-            components={components}
-            rehypePlugins={plugins}
-            remarkPlugins={remarkPlugins}
-          >
-            {block.content}
-          </StreamdownBlock>
-        );
 
         if (!profiler) {
           return (
@@ -342,7 +361,14 @@ export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
             key={key}
             onRender={handleBlockRender}
           >
-            {blockNode}
+            <StreamdownBlock
+              {...rest}
+              components={components}
+              rehypePlugins={plugins}
+              remarkPlugins={remarkPlugins}
+            >
+              {block.content}
+            </StreamdownBlock>
           </Profiler>
         );
       })}

--- a/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
+++ b/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
@@ -21,6 +21,7 @@ import {
   useMarkdownRehypePlugins,
   useMarkdownRemarkPlugins,
 } from '@/hooks/useMarkdown';
+import { useStableValue } from '@/hooks/useStableValue';
 import { useMarkdownContext } from '@/Markdown/components/MarkdownProvider';
 import {
   rehypeStreamAnimated,
@@ -220,221 +221,240 @@ const updateBlockAnimation = ({
   return blockAnimationMeta;
 };
 
+interface StreamdownBlocksProps {
+  content: string;
+  markdownOptions: Omit<Options, 'children'>;
+}
+
+const StreamdownBlocks = memo<StreamdownBlocksProps>(
+  ({ content: smoothedContent, markdownOptions: rest }) => {
+    const { streamAnimationGranularity = 'char' } = useMarkdownContext();
+    const profiler = useStreamdownProfiler();
+    const components = useMarkdownComponents();
+    const baseRehypePlugins = useStablePlugins(useMarkdownRehypePlugins());
+    const remarkPlugins = useStablePlugins(useMarkdownRemarkPlugins());
+    const generatedId = useId();
+
+    const processedContentResult = useMemo(() => {
+      const start = profiler ? getNow() : 0;
+      const value = remend(smoothedContent);
+
+      return {
+        durationMs: profiler ? getNow() - start : 0,
+        value,
+      };
+    }, [profiler, smoothedContent]);
+    const processedContent = processedContentResult.value;
+
+    const blocksResult = useMemo(() => {
+      const start = profiler ? getNow() : 0;
+      const tokens = marked.lexer(processedContent);
+      let offset = 0;
+
+      const value = tokens.map((token) => {
+        const block = { content: token.raw, startOffset: offset };
+        offset += token.raw.length;
+        return block;
+      });
+
+      return {
+        durationMs: profiler ? getNow() - start : 0,
+        value,
+      };
+    }, [processedContent, profiler]);
+    const blocks: BlockInfo[] = blocksResult.value;
+
+    const { getBlockState, charDelay } = useStreamQueue(blocks);
+    const blockRuntimesRef = useRef<Map<number, BlockRuntime>>(new Map());
+    const blockPluginsRef = useRef<Map<number, BlockPluginsCacheEntry>>(new Map());
+    const revealClockRef = useRef<{ lastTs: number }>({ lastTs: 0 });
+
+    const renderNow = getNow();
+
+    const animationStart = profiler ? getNow() : 0;
+    const blockAnimationMeta = updateBlockAnimation({
+      blocks,
+      charDelay,
+      getBlockState,
+      pluginsCache: blockPluginsRef.current,
+      renderNow,
+      revealClock: revealClockRef.current,
+      runtimes: blockRuntimesRef.current,
+    });
+    const blockAnimationDurationMs = profiler ? getNow() - animationStart : 0;
+
+    useEffect(() => {
+      if (!profiler) return;
+
+      profiler.recordCalculation({
+        durationMs: processedContentResult.durationMs,
+        name: 'content-normalize',
+        textLength: processedContent.length,
+      });
+    }, [processedContent.length, processedContentResult.durationMs, profiler]);
+
+    useEffect(() => {
+      if (!profiler) return;
+
+      profiler.recordCalculation({
+        durationMs: blocksResult.durationMs,
+        itemCount: blocks.length,
+        name: 'block-lex',
+        textLength: processedContent.length,
+      });
+    }, [blocks.length, blocksResult.durationMs, processedContent.length, profiler]);
+
+    useEffect(() => {
+      if (!profiler) return;
+
+      profiler.recordCalculation({
+        durationMs: blockAnimationDurationMs,
+        itemCount: blocks.length,
+        name: 'block-births',
+        textLength: processedContent.length,
+      });
+    }, [blockAnimationDurationMs, blocks.length, processedContent.length, profiler]);
+
+    const resolveBlockPlugins = (startOffset: number, settled: boolean): PluggableList => {
+      if (settled) return baseRehypePlugins;
+
+      const cache = blockPluginsRef.current;
+      const entry = cache.get(startOffset);
+      if (
+        entry &&
+        entry.base === baseRehypePlugins &&
+        entry.granularity === streamAnimationGranularity
+      ) {
+        return entry.value;
+      }
+
+      const runtime = blockRuntimesRef.current.get(startOffset);
+      const value: PluggableList = [
+        ...baseRehypePlugins,
+        [
+          rehypeStreamAnimated,
+          {
+            fadeDuration: STREAM_FADE_DURATION,
+            granularity: streamAnimationGranularity,
+            runtime,
+          },
+        ],
+      ];
+      cache.set(startOffset, {
+        base: baseRehypePlugins,
+        granularity: streamAnimationGranularity,
+        value,
+      });
+      return value;
+    };
+
+    const handleRootRender = useCallback<ProfilerOnRenderCallback>(
+      (_, phase, actualDuration, baseDuration) => {
+        profiler?.recordRootCommit({
+          actualDuration,
+          baseDuration,
+          blockCount: blocks.length,
+          phase,
+          textLength: processedContent.length,
+        });
+      },
+      [blocks.length, processedContent.length, profiler],
+    );
+
+    const handleBlockRender = useCallback<ProfilerOnRenderCallback>(
+      (id, phase, actualDuration, baseDuration) => {
+        if (!profiler) return;
+
+        const [, indexText, offsetText] = id.split(':');
+        const blockIndex = Number(indexText);
+
+        if (!Number.isFinite(blockIndex)) return;
+
+        const block = blocks[blockIndex];
+        if (!block) return;
+
+        profiler.recordBlockCommit({
+          actualDuration,
+          baseDuration,
+          blockChars: countChars(block.content),
+          blockIndex,
+          blockKey: offsetText ?? String(block.startOffset),
+          phase,
+          state: getBlockState(blockIndex),
+        });
+      },
+      [blocks, getBlockState, profiler],
+    );
+
+    const content = (
+      <div className={styles.animated}>
+        {blocks.map((block, index) => {
+          const animationMeta = blockAnimationMeta.get(block.startOffset);
+          if (!animationMeta) return null;
+
+          const plugins = resolveBlockPlugins(block.startOffset, animationMeta.settled);
+          const key = `${generatedId}-${block.startOffset}`;
+
+          if (!profiler) {
+            return (
+              <StreamdownBlock
+                {...rest}
+                components={components}
+                key={key}
+                rehypePlugins={plugins}
+                remarkPlugins={remarkPlugins}
+              >
+                {block.content}
+              </StreamdownBlock>
+            );
+          }
+
+          return (
+            <Profiler
+              id={`streamdown-block:${index}:${block.startOffset}`}
+              key={key}
+              onRender={handleBlockRender}
+            >
+              <StreamdownBlock
+                {...rest}
+                components={components}
+                rehypePlugins={plugins}
+                remarkPlugins={remarkPlugins}
+              >
+                {block.content}
+              </StreamdownBlock>
+            </Profiler>
+          );
+        })}
+      </div>
+    );
+
+    if (!profiler) return content;
+
+    return (
+      <Profiler id={'streamdown-root'} onRender={handleRootRender}>
+        {content}
+      </Profiler>
+    );
+  },
+);
+
+StreamdownBlocks.displayName = 'StreamdownBlocks';
+
+// The outer component absorbs the upstream per-chunk prop churn: every
+// streamed chunk re-renders it, but it only feeds the smoother and renders
+// a memoized child keyed on the smoother's output — so the expensive block
+// pipeline runs per reveal commit, not per chunk AND per commit.
 export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
-  const { streamAnimationGranularity = 'char', streamSmoothingPreset = 'balanced' } =
-    useMarkdownContext();
-  const profiler = useStreamdownProfiler();
+  const { streamSmoothingPreset = 'balanced' } = useMarkdownContext();
   const escapedContent = useMarkdownContent(children || '');
-  const components = useMarkdownComponents();
-  const baseRehypePlugins = useStablePlugins(useMarkdownRehypePlugins());
-  const remarkPlugins = useStablePlugins(useMarkdownRemarkPlugins());
-  const generatedId = useId();
   const smoothedContent = useSmoothStreamContent(
     typeof escapedContent === 'string' ? escapedContent : '',
     { preset: streamSmoothingPreset },
   );
+  const markdownOptions = useStableValue(rest);
 
-  const processedContentResult = useMemo(() => {
-    const start = profiler ? getNow() : 0;
-    const value = remend(smoothedContent);
-
-    return {
-      durationMs: profiler ? getNow() - start : 0,
-      value,
-    };
-  }, [profiler, smoothedContent]);
-  const processedContent = processedContentResult.value;
-
-  const blocksResult = useMemo(() => {
-    const start = profiler ? getNow() : 0;
-    const tokens = marked.lexer(processedContent);
-    let offset = 0;
-
-    const value = tokens.map((token) => {
-      const block = { content: token.raw, startOffset: offset };
-      offset += token.raw.length;
-      return block;
-    });
-
-    return {
-      durationMs: profiler ? getNow() - start : 0,
-      value,
-    };
-  }, [processedContent, profiler]);
-  const blocks: BlockInfo[] = blocksResult.value;
-
-  const { getBlockState, charDelay } = useStreamQueue(blocks);
-  const blockRuntimesRef = useRef<Map<number, BlockRuntime>>(new Map());
-  const blockPluginsRef = useRef<Map<number, BlockPluginsCacheEntry>>(new Map());
-  const revealClockRef = useRef<{ lastTs: number }>({ lastTs: 0 });
-
-  const renderNow = getNow();
-
-  const animationStart = profiler ? getNow() : 0;
-  const blockAnimationMeta = updateBlockAnimation({
-    blocks,
-    charDelay,
-    getBlockState,
-    pluginsCache: blockPluginsRef.current,
-    renderNow,
-    revealClock: revealClockRef.current,
-    runtimes: blockRuntimesRef.current,
-  });
-  const blockAnimationDurationMs = profiler ? getNow() - animationStart : 0;
-
-  useEffect(() => {
-    if (!profiler) return;
-
-    profiler.recordCalculation({
-      durationMs: processedContentResult.durationMs,
-      name: 'content-normalize',
-      textLength: processedContent.length,
-    });
-  }, [processedContent.length, processedContentResult.durationMs, profiler]);
-
-  useEffect(() => {
-    if (!profiler) return;
-
-    profiler.recordCalculation({
-      durationMs: blocksResult.durationMs,
-      itemCount: blocks.length,
-      name: 'block-lex',
-      textLength: processedContent.length,
-    });
-  }, [blocks.length, blocksResult.durationMs, processedContent.length, profiler]);
-
-  useEffect(() => {
-    if (!profiler) return;
-
-    profiler.recordCalculation({
-      durationMs: blockAnimationDurationMs,
-      itemCount: blocks.length,
-      name: 'block-births',
-      textLength: processedContent.length,
-    });
-  }, [blockAnimationDurationMs, blocks.length, processedContent.length, profiler]);
-
-  const resolveBlockPlugins = (startOffset: number, settled: boolean): PluggableList => {
-    if (settled) return baseRehypePlugins;
-
-    const cache = blockPluginsRef.current;
-    const entry = cache.get(startOffset);
-    if (
-      entry &&
-      entry.base === baseRehypePlugins &&
-      entry.granularity === streamAnimationGranularity
-    ) {
-      return entry.value;
-    }
-
-    const runtime = blockRuntimesRef.current.get(startOffset);
-    const value: PluggableList = [
-      ...baseRehypePlugins,
-      [
-        rehypeStreamAnimated,
-        {
-          fadeDuration: STREAM_FADE_DURATION,
-          granularity: streamAnimationGranularity,
-          runtime,
-        },
-      ],
-    ];
-    cache.set(startOffset, {
-      base: baseRehypePlugins,
-      granularity: streamAnimationGranularity,
-      value,
-    });
-    return value;
-  };
-
-  const handleRootRender = useCallback<ProfilerOnRenderCallback>(
-    (_, phase, actualDuration, baseDuration) => {
-      profiler?.recordRootCommit({
-        actualDuration,
-        baseDuration,
-        blockCount: blocks.length,
-        phase,
-        textLength: processedContent.length,
-      });
-    },
-    [blocks.length, processedContent.length, profiler],
-  );
-
-  const handleBlockRender = useCallback<ProfilerOnRenderCallback>(
-    (id, phase, actualDuration, baseDuration) => {
-      if (!profiler) return;
-
-      const [, indexText, offsetText] = id.split(':');
-      const blockIndex = Number(indexText);
-
-      if (!Number.isFinite(blockIndex)) return;
-
-      const block = blocks[blockIndex];
-      if (!block) return;
-
-      profiler.recordBlockCommit({
-        actualDuration,
-        baseDuration,
-        blockChars: countChars(block.content),
-        blockIndex,
-        blockKey: offsetText ?? String(block.startOffset),
-        phase,
-        state: getBlockState(blockIndex),
-      });
-    },
-    [blocks, getBlockState, profiler],
-  );
-
-  const content = (
-    <div className={styles.animated}>
-      {blocks.map((block, index) => {
-        const animationMeta = blockAnimationMeta.get(block.startOffset);
-        if (!animationMeta) return null;
-
-        const plugins = resolveBlockPlugins(block.startOffset, animationMeta.settled);
-        const key = `${generatedId}-${block.startOffset}`;
-
-        if (!profiler) {
-          return (
-            <StreamdownBlock
-              {...rest}
-              components={components}
-              key={key}
-              rehypePlugins={plugins}
-              remarkPlugins={remarkPlugins}
-            >
-              {block.content}
-            </StreamdownBlock>
-          );
-        }
-
-        return (
-          <Profiler
-            id={`streamdown-block:${index}:${block.startOffset}`}
-            key={key}
-            onRender={handleBlockRender}
-          >
-            <StreamdownBlock
-              {...rest}
-              components={components}
-              rehypePlugins={plugins}
-              remarkPlugins={remarkPlugins}
-            >
-              {block.content}
-            </StreamdownBlock>
-          </Profiler>
-        );
-      })}
-    </div>
-  );
-
-  if (!profiler) return content;
-
-  return (
-    <Profiler id={'streamdown-root'} onRender={handleRootRender}>
-      {content}
-    </Profiler>
-  );
+  return <StreamdownBlocks content={smoothedContent} markdownOptions={markdownOptions} />;
 });
 
 StreamdownRender.displayName = 'StreamdownRender';

--- a/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
+++ b/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
@@ -27,22 +27,15 @@ import {
   type StreamAnimatedRuntime,
 } from '@/Markdown/plugins/rehypeStreamAnimated';
 import { useStreamdownProfiler } from '@/Markdown/streamProfiler';
+import { getNow } from '@/utils/getNow';
 import { isDeepEqual } from '@/utils/isDeepEqual';
 
-import { resolveBlockAnimationMeta } from './streamAnimationMeta';
+import { type BlockAnimationMeta, resolveBlockAnimationMeta } from './streamAnimationMeta';
 import { styles } from './style';
-import { useSmoothStreamContent } from './useSmoothStreamContent';
-import { type BlockInfo, useStreamQueue } from './useStreamQueue';
+import { countChars, useSmoothStreamContent } from './useSmoothStreamContent';
+import { type BlockInfo, type BlockState, useStreamQueue } from './useStreamQueue';
 
 const STREAM_FADE_DURATION = 280;
-
-function countChars(text: string): number {
-  return [...text].length;
-}
-
-function getNow(): number {
-  return typeof performance === 'undefined' ? Date.now() : performance.now();
-}
 
 const isSamePlugin = (prevPlugin: Pluggable, nextPlugin: Pluggable): boolean => {
   const prevTuple = Array.isArray(prevPlugin) ? prevPlugin : [prevPlugin];
@@ -94,14 +87,114 @@ StreamdownBlock.displayName = 'StreamdownBlock';
 
 interface BlockRuntime extends StreamAnimatedRuntime {
   charCount: number;
+  charDelay?: number;
   rawLength: number;
+  settled: boolean;
 }
 
 interface BlockPluginsCacheEntry {
   base: PluggableList;
-  settled: boolean;
   value: PluggableList;
 }
+
+interface UpdateBlockAnimationArgs {
+  blocks: BlockInfo[];
+  charDelay: number;
+  getBlockState: (index: number) => BlockState;
+  pluginsCache: Map<number, BlockPluginsCacheEntry>;
+  renderNow: number;
+  runtimes: Map<number, BlockRuntime>;
+}
+
+// Runs in the render phase: extends each visible block's birth timeline in
+// place and resolves its animation meta in one pass. Mutations are
+// idempotent for a given block content/length, so discarded or StrictMode
+// double renders re-derive the same state.
+const updateBlockAnimation = ({
+  blocks,
+  charDelay,
+  getBlockState,
+  pluginsCache,
+  renderNow,
+  runtimes,
+}: UpdateBlockAnimationArgs): Map<number, BlockAnimationMeta> => {
+  const blockAnimationMeta = new Map<number, BlockAnimationMeta>();
+  const alive = new Set<number>();
+
+  for (const [index, block] of blocks.entries()) {
+    alive.add(block.startOffset);
+
+    // Queued blocks are not rendered. Defer birth assignment so that
+    // when the block later transitions to animating/streaming, its
+    // chars start fading from that moment instead of having already
+    // "aged out" of the fade window.
+    const state = getBlockState(index);
+    if (state === 'queued') continue;
+
+    let runtime = runtimes.get(block.startOffset);
+    if (!runtime) {
+      runtime = { births: [], charCount: 0, rawLength: -1, settled: false, styles: [] };
+      runtimes.set(block.startOffset, runtime);
+    }
+
+    if (runtime.rawLength !== block.content.length) {
+      runtime.charCount = countChars(block.content);
+      runtime.rawLength = block.content.length;
+    }
+
+    const blockCharCount = runtime.charCount;
+    const births = runtime.births;
+
+    if (births.length > blockCharCount) {
+      // Block content shrunk (stream restart or upstream rewrite).
+      births.length = blockCharCount;
+      runtime.styles.length = blockCharCount;
+    }
+
+    if (births.length < blockCharCount) {
+      // Chain each new char monotonically after the previous one so fades
+      // never race out of order. Cap how far the fade queue can run ahead
+      // of renderNow to prevent stream-faster-than-fade producing seconds
+      // of invisible backlog at the tail.
+      const cap = renderNow + STREAM_FADE_DURATION;
+      for (let i = births.length; i < blockCharCount; i++) {
+        const prevBirth = i > 0 ? births[i - 1] : renderNow - charDelay;
+        const chained = prevBirth + charDelay;
+        births.push(Math.min(cap, Math.max(chained, renderNow)));
+      }
+    }
+
+    let meta: BlockAnimationMeta;
+    if (runtime.settled) {
+      // Settled is monotone: a revealed block's births are frozen, so once
+      // its last fade completed it stays settled until the runtime is
+      // pruned by a stream restart.
+      meta = { charDelay: runtime.charDelay ?? charDelay, settled: true };
+    } else {
+      const lastBirthTs = births.length > 0 ? (births.at(-1) ?? renderNow) : renderNow;
+      meta = resolveBlockAnimationMeta({
+        currentCharDelay: charDelay,
+        fadeDuration: STREAM_FADE_DURATION,
+        lastElapsedMs: renderNow - lastBirthTs,
+        previousCharDelay: runtime.charDelay,
+        state,
+      });
+      runtime.settled = meta.settled;
+    }
+    runtime.charDelay = meta.charDelay;
+
+    blockAnimationMeta.set(block.startOffset, meta);
+  }
+
+  for (const key of runtimes.keys()) {
+    if (!alive.has(key)) {
+      runtimes.delete(key);
+      pluginsCache.delete(key);
+    }
+  }
+
+  return blockAnimationMeta;
+};
 
 export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
   const { streamSmoothingPreset = 'balanced' } = useMarkdownContext();
@@ -146,68 +239,21 @@ export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
   const blocks: BlockInfo[] = blocksResult.value;
 
   const { getBlockState, charDelay } = useStreamQueue(blocks);
-  const blockCharDelayRef = useRef<Map<number, number>>(new Map());
   const blockRuntimesRef = useRef<Map<number, BlockRuntime>>(new Map());
   const blockPluginsRef = useRef<Map<number, BlockPluginsCacheEntry>>(new Map());
 
   const renderNow = getNow();
 
-  const runtimesResult = useMemo(() => {
-    const start = profiler ? getNow() : 0;
-    const runtimes = blockRuntimesRef.current;
-    const alive = new Set<number>();
-
-    for (const [index, block] of blocks.entries()) {
-      alive.add(block.startOffset);
-      // Queued blocks are not rendered. Defer birth assignment so that
-      // when the block later transitions to animating/streaming, its
-      // chars start fading from that moment instead of having already
-      // "aged out" of the fade window.
-      if (getBlockState(index) === 'queued') continue;
-
-      let runtime = runtimes.get(block.startOffset);
-      if (!runtime) {
-        runtime = { births: [], charCount: 0, rawLength: -1, styles: [] };
-        runtimes.set(block.startOffset, runtime);
-      }
-
-      if (runtime.rawLength !== block.content.length) {
-        runtime.charCount = countChars(block.content);
-        runtime.rawLength = block.content.length;
-      }
-
-      const blockCharCount = runtime.charCount;
-      const births = runtime.births;
-
-      if (births.length > blockCharCount) {
-        // Block content shrunk (stream restart or upstream rewrite).
-        births.length = blockCharCount;
-        runtime.styles.length = blockCharCount;
-      }
-
-      if (births.length < blockCharCount) {
-        // Chain each new char monotonically after the previous one so fades
-        // never race out of order. Cap how far the fade queue can run ahead
-        // of renderNow to prevent stream-faster-than-fade producing seconds
-        // of invisible backlog at the tail.
-        const cap = renderNow + STREAM_FADE_DURATION;
-        for (let i = births.length; i < blockCharCount; i++) {
-          const prevBirth = i > 0 ? births[i - 1] : renderNow - charDelay;
-          const chained = prevBirth + charDelay;
-          births.push(Math.min(cap, Math.max(chained, renderNow)));
-        }
-      }
-    }
-
-    for (const key of blockRuntimesRef.current.keys()) {
-      if (!alive.has(key)) {
-        blockRuntimesRef.current.delete(key);
-        blockPluginsRef.current.delete(key);
-      }
-    }
-
-    return { durationMs: profiler ? getNow() - start : 0 };
-  }, [blocks, charDelay, getBlockState, profiler, renderNow]);
+  const animationStart = profiler ? getNow() : 0;
+  const blockAnimationMeta = updateBlockAnimation({
+    blocks,
+    charDelay,
+    getBlockState,
+    pluginsCache: blockPluginsRef.current,
+    renderNow,
+    runtimes: blockRuntimesRef.current,
+  });
+  const blockAnimationDurationMs = profiler ? getNow() - animationStart : 0;
 
   useEffect(() => {
     if (!profiler) return;
@@ -234,52 +280,19 @@ export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
     if (!profiler) return;
 
     profiler.recordCalculation({
-      durationMs: runtimesResult.durationMs,
+      durationMs: blockAnimationDurationMs,
       itemCount: blocks.length,
       name: 'block-births',
       textLength: processedContent.length,
     });
-  }, [runtimesResult.durationMs, blocks.length, processedContent.length, profiler]);
-
-  const blockAnimationMetaResult = useMemo(() => {
-    const nextBlockCharDelay = new Map<number, number>();
-    const blockAnimationMeta = new Map<number, ReturnType<typeof resolveBlockAnimationMeta>>();
-
-    for (const [index, block] of blocks.entries()) {
-      const state = getBlockState(index);
-      if (state === 'queued') continue;
-
-      const births = blockRuntimesRef.current.get(block.startOffset)?.births;
-      const lastBirthTs = births && births.length > 0 ? (births.at(-1) ?? renderNow) : renderNow;
-      const lastElapsedMs = renderNow - lastBirthTs;
-      const animationMeta = resolveBlockAnimationMeta({
-        currentCharDelay: charDelay,
-        fadeDuration: STREAM_FADE_DURATION,
-        lastElapsedMs,
-        previousCharDelay: blockCharDelayRef.current.get(block.startOffset),
-        state,
-      });
-
-      nextBlockCharDelay.set(block.startOffset, animationMeta.charDelay);
-      blockAnimationMeta.set(block.startOffset, animationMeta);
-    }
-
-    return {
-      blockAnimationMeta,
-      blockCharDelay: nextBlockCharDelay,
-    };
-  }, [blocks, charDelay, getBlockState, renderNow]);
-
-  useEffect(() => {
-    blockCharDelayRef.current = blockAnimationMetaResult.blockCharDelay;
-  }, [blockAnimationMetaResult.blockCharDelay]);
+  }, [blockAnimationDurationMs, blocks.length, processedContent.length, profiler]);
 
   const resolveBlockPlugins = (startOffset: number, settled: boolean): PluggableList => {
     if (settled) return baseRehypePlugins;
 
     const cache = blockPluginsRef.current;
     const entry = cache.get(startOffset);
-    if (entry && entry.base === baseRehypePlugins && entry.settled === settled) {
+    if (entry && entry.base === baseRehypePlugins) {
       return entry.value;
     }
 
@@ -288,7 +301,7 @@ export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
       ...baseRehypePlugins,
       [rehypeStreamAnimated, { fadeDuration: STREAM_FADE_DURATION, runtime }],
     ];
-    cache.set(startOffset, { base: baseRehypePlugins, settled, value });
+    cache.set(startOffset, { base: baseRehypePlugins, value });
     return value;
   };
 
@@ -333,9 +346,7 @@ export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
   const content = (
     <div className={styles.animated}>
       {blocks.map((block, index) => {
-        const state = getBlockState(index);
-        if (state === 'queued') return null;
-        const animationMeta = blockAnimationMetaResult.blockAnimationMeta.get(block.startOffset);
+        const animationMeta = blockAnimationMeta.get(block.startOffset);
         if (!animationMeta) return null;
 
         const plugins = resolveBlockPlugins(block.startOffset, animationMeta.settled);

--- a/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
+++ b/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
@@ -27,15 +27,14 @@ import {
   type StreamAnimatedRuntime,
 } from '@/Markdown/plugins/rehypeStreamAnimated';
 import { useStreamdownProfiler } from '@/Markdown/streamProfiler';
+import { type StreamAnimationGranularity } from '@/Markdown/type';
 import { getNow } from '@/utils/getNow';
 import { isDeepEqual } from '@/utils/isDeepEqual';
 
 import { type BlockAnimationMeta, resolveBlockAnimationMeta } from './streamAnimationMeta';
-import { styles } from './style';
+import { STREAM_FADE_DURATION, styles } from './style';
 import { countChars, useSmoothStreamContent } from './useSmoothStreamContent';
 import { type BlockInfo, type BlockState, useStreamQueue } from './useStreamQueue';
-
-const STREAM_FADE_DURATION = 280;
 
 const isSamePlugin = (prevPlugin: Pluggable, nextPlugin: Pluggable): boolean => {
   const prevTuple = Array.isArray(prevPlugin) ? prevPlugin : [prevPlugin];
@@ -94,6 +93,7 @@ interface BlockRuntime extends StreamAnimatedRuntime {
 
 interface BlockPluginsCacheEntry {
   base: PluggableList;
+  granularity: StreamAnimationGranularity;
   value: PluggableList;
 }
 
@@ -197,7 +197,8 @@ const updateBlockAnimation = ({
 };
 
 export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
-  const { streamSmoothingPreset = 'balanced' } = useMarkdownContext();
+  const { streamAnimationGranularity = 'word', streamSmoothingPreset = 'balanced' } =
+    useMarkdownContext();
   const profiler = useStreamdownProfiler();
   const escapedContent = useMarkdownContent(children || '');
   const components = useMarkdownComponents();
@@ -292,16 +293,31 @@ export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
 
     const cache = blockPluginsRef.current;
     const entry = cache.get(startOffset);
-    if (entry && entry.base === baseRehypePlugins) {
+    if (
+      entry &&
+      entry.base === baseRehypePlugins &&
+      entry.granularity === streamAnimationGranularity
+    ) {
       return entry.value;
     }
 
     const runtime = blockRuntimesRef.current.get(startOffset);
     const value: PluggableList = [
       ...baseRehypePlugins,
-      [rehypeStreamAnimated, { fadeDuration: STREAM_FADE_DURATION, runtime }],
+      [
+        rehypeStreamAnimated,
+        {
+          fadeDuration: STREAM_FADE_DURATION,
+          granularity: streamAnimationGranularity,
+          runtime,
+        },
+      ],
     ];
-    cache.set(startOffset, { base: baseRehypePlugins, value });
+    cache.set(startOffset, {
+      base: baseRehypePlugins,
+      granularity: streamAnimationGranularity,
+      value,
+    });
     return value;
   };
 

--- a/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
+++ b/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
@@ -103,8 +103,12 @@ interface UpdateBlockAnimationArgs {
   getBlockState: (index: number) => BlockState;
   pluginsCache: Map<number, BlockPluginsCacheEntry>;
   renderNow: number;
+  revealClock: { lastTs: number };
   runtimes: Map<number, BlockRuntime>;
 }
+
+const MIN_STREAM_CHAR_PACE_MS = 2;
+const MAX_REVEAL_GAP_MS = 160;
 
 // Runs in the render phase: extends each visible block's birth timeline in
 // place and resolves its animation meta in one pass. Mutations are
@@ -116,10 +120,12 @@ const updateBlockAnimation = ({
   getBlockState,
   pluginsCache,
   renderNow,
+  revealClock,
   runtimes,
 }: UpdateBlockAnimationArgs): Map<number, BlockAnimationMeta> => {
   const blockAnimationMeta = new Map<number, BlockAnimationMeta>();
   const alive = new Set<number>();
+  let revealedNewChars = false;
 
   for (const [index, block] of blocks.entries()) {
     alive.add(block.startOffset);
@@ -156,10 +162,24 @@ const updateBlockAnimation = ({
       // never race out of order. Cap how far the fade queue can run ahead
       // of renderNow to prevent stream-faster-than-fade producing seconds
       // of invisible backlog at the tail.
-      const cap = renderNow + STREAM_FADE_DURATION;
+      //
+      // The streaming tail paces its stagger from the observed reveal-commit
+      // gap instead of the queue's fixed charDelay: a commit's chars are
+      // spread to land exactly until the next commit arrives, so the flow
+      // stays per-char continuous no matter how far apart the throttled
+      // commits are.
+      const newChars = blockCharCount - births.length;
+      let pace = charDelay;
+      let cap = renderNow + STREAM_FADE_DURATION;
+      if (state === 'streaming') {
+        revealedNewChars = true;
+        const gapMs = Math.min(Math.max(renderNow - revealClock.lastTs, 16), MAX_REVEAL_GAP_MS);
+        pace = Math.min(charDelay, Math.max(gapMs / newChars, MIN_STREAM_CHAR_PACE_MS));
+        cap = renderNow + gapMs + STREAM_FADE_DURATION;
+      }
       for (let i = births.length; i < blockCharCount; i++) {
-        const prevBirth = i > 0 ? births[i - 1] : renderNow - charDelay;
-        const chained = prevBirth + charDelay;
+        const prevBirth = i > 0 ? births[i - 1] : renderNow - pace;
+        const chained = prevBirth + pace;
         births.push(Math.min(cap, Math.max(chained, renderNow)));
       }
     }
@@ -186,6 +206,10 @@ const updateBlockAnimation = ({
     blockAnimationMeta.set(block.startOffset, meta);
   }
 
+  if (revealedNewChars) {
+    revealClock.lastTs = renderNow;
+  }
+
   for (const key of runtimes.keys()) {
     if (!alive.has(key)) {
       runtimes.delete(key);
@@ -197,7 +221,7 @@ const updateBlockAnimation = ({
 };
 
 export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
-  const { streamAnimationGranularity = 'word', streamSmoothingPreset = 'balanced' } =
+  const { streamAnimationGranularity = 'char', streamSmoothingPreset = 'balanced' } =
     useMarkdownContext();
   const profiler = useStreamdownProfiler();
   const escapedContent = useMarkdownContent(children || '');
@@ -242,6 +266,7 @@ export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
   const { getBlockState, charDelay } = useStreamQueue(blocks);
   const blockRuntimesRef = useRef<Map<number, BlockRuntime>>(new Map());
   const blockPluginsRef = useRef<Map<number, BlockPluginsCacheEntry>>(new Map());
+  const revealClockRef = useRef<{ lastTs: number }>({ lastTs: 0 });
 
   const renderNow = getNow();
 
@@ -252,6 +277,7 @@ export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
     getBlockState,
     pluginsCache: blockPluginsRef.current,
     renderNow,
+    revealClock: revealClockRef.current,
     runtimes: blockRuntimesRef.current,
   });
   const blockAnimationDurationMs = profiler ? getNow() - animationStart : 0;

--- a/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
+++ b/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
@@ -11,7 +11,7 @@ import {
   useMemo,
   useRef,
 } from 'react';
-import Markdown, { type Options } from 'react-markdown';
+import { type Options } from 'react-markdown';
 import remend from 'remend';
 import type { Pluggable, PluggableList } from 'unified';
 
@@ -32,6 +32,7 @@ import { type StreamAnimationGranularity } from '@/Markdown/type';
 import { getNow } from '@/utils/getNow';
 import { isDeepEqual } from '@/utils/isDeepEqual';
 
+import { CachedMarkdown } from './CachedMarkdown';
 import { type BlockAnimationMeta, resolveBlockAnimationMeta } from './streamAnimationMeta';
 import { STREAM_FADE_DURATION, styles } from './style';
 import { countChars, useSmoothStreamContent } from './useSmoothStreamContent';
@@ -74,7 +75,7 @@ const useStablePlugins = (plugins: PluggableList): PluggableList => {
 
 const StreamdownBlock = memo<Options>(
   ({ children, ...rest }) => {
-    return <Markdown {...rest}>{children}</Markdown>;
+    return <CachedMarkdown {...rest}>{children}</CachedMarkdown>;
   },
   (prevProps, nextProps) =>
     prevProps.children === nextProps.children &&

--- a/src/Markdown/SyntaxMarkdown/style.ts
+++ b/src/Markdown/SyntaxMarkdown/style.ts
@@ -2,6 +2,8 @@ import { createStaticStyles } from 'antd-style';
 
 import { fadeIn } from '@/styles/animations';
 
+export const STREAM_FADE_DURATION = 180;
+
 export const styles = createStaticStyles(({ css }) => {
   return {
     animated: css`
@@ -9,7 +11,7 @@ export const styles = createStaticStyles(({ css }) => {
         opacity: 0;
 
         animation-name: ${fadeIn};
-        animation-duration: 280ms;
+        animation-duration: ${STREAM_FADE_DURATION}ms;
         animation-timing-function: cubic-bezier(0.33, 0, 0.67, 1);
         animation-fill-mode: forwards;
       }

--- a/src/Markdown/SyntaxMarkdown/useSmoothStreamContent.ts
+++ b/src/Markdown/SyntaxMarkdown/useSmoothStreamContent.ts
@@ -48,7 +48,7 @@ const PRESET_CONFIG: Record<StreamSmoothingPreset, StreamSmoothingPresetConfig> 
     maxActiveCps: 132,
     maxCps: 72,
     maxFlushCps: 280,
-    minCommitIntervalMs: 32,
+    minCommitIntervalMs: 48,
     minCps: 18,
     settleAfterMs: 360,
     settleDrainMaxMs: 520,
@@ -65,7 +65,7 @@ const PRESET_CONFIG: Record<StreamSmoothingPreset, StreamSmoothingPresetConfig> 
     maxActiveCps: 180,
     maxCps: 96,
     maxFlushCps: 360,
-    minCommitIntervalMs: 24,
+    minCommitIntervalMs: 32,
     minCps: 24,
     settleAfterMs: 260,
     settleDrainMaxMs: 360,
@@ -82,7 +82,7 @@ const PRESET_CONFIG: Record<StreamSmoothingPreset, StreamSmoothingPresetConfig> 
     maxActiveCps: 102,
     maxCps: 56,
     maxFlushCps: 220,
-    minCommitIntervalMs: 36,
+    minCommitIntervalMs: 56,
     minCps: 14,
     settleAfterMs: 460,
     settleDrainMaxMs: 680,
@@ -101,7 +101,7 @@ const clamp = (value: number, min: number, max: number): number => {
 // long paragraphs/code fences keep total work bounded while short blocks
 // stay at the preset's snappy interval. Per-char animation-delay stagger
 // hides the lower commit rate.
-const MAX_COMMIT_INTERVAL_MS = 64;
+const MAX_COMMIT_INTERVAL_MS = 96;
 const COMMIT_INTERVAL_TAIL_SCALE_UNITS = 256;
 
 const findTailUnits = (content: string): number => {
@@ -243,7 +243,7 @@ export const useSmoothStreamContent = (
       }
 
       const frameStart = getNow();
-      const dtSeconds = Math.max(0.001, Math.min(frameIntervalMs / 1000, 0.05));
+      const dtSeconds = Math.max(0.001, Math.min(frameIntervalMs / 1000, 0.12));
       lastFrameTsRef.current = ts;
 
       const now = frameStart;

--- a/src/Markdown/SyntaxMarkdown/useSmoothStreamContent.ts
+++ b/src/Markdown/SyntaxMarkdown/useSmoothStreamContent.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useStreamdownProfiler } from '@/Markdown/streamProfiler';
 import { type StreamSmoothingPreset } from '@/Markdown/type';
+import { getNow } from '@/utils/getNow';
 
 import { findOpenFenceLanguage } from './fenceState';
 
@@ -108,12 +109,10 @@ const findTailUnits = (content: string): number => {
   return boundary === -1 ? content.length : content.length - boundary - 2;
 };
 
-const getNow = () => {
-  return typeof performance === 'undefined' ? Date.now() : performance.now();
-};
-
 export const countChars = (text: string): number => {
-  return [...text].length;
+  let count = 0;
+  for (const _char of text) count += 1;
+  return count;
 };
 
 interface UseSmoothStreamContentOptions {
@@ -247,7 +246,7 @@ export const useSmoothStreamContent = (
       const dtSeconds = Math.max(0.001, Math.min(frameIntervalMs / 1000, 0.05));
       lastFrameTsRef.current = ts;
 
-      const now = getNow();
+      const now = frameStart;
       const idleMs = now - lastInputTsRef.current;
       const inputActive = idleMs <= config.activeInputWindowMs;
       const settling = !inputActive && idleMs >= config.settleAfterMs;

--- a/src/Markdown/SyntaxMarkdown/useSmoothStreamContent.ts
+++ b/src/Markdown/SyntaxMarkdown/useSmoothStreamContent.ts
@@ -26,6 +26,7 @@ interface StreamSmoothingPresetConfig {
   maxActiveCps: number;
   maxCps: number;
   maxFlushCps: number;
+  minCommitIntervalMs: number;
   minCps: number;
   settleAfterMs: number;
   settleDrainMaxMs: number;
@@ -46,6 +47,7 @@ const PRESET_CONFIG: Record<StreamSmoothingPreset, StreamSmoothingPresetConfig> 
     maxActiveCps: 132,
     maxCps: 72,
     maxFlushCps: 280,
+    minCommitIntervalMs: 32,
     minCps: 18,
     settleAfterMs: 360,
     settleDrainMaxMs: 520,
@@ -62,6 +64,7 @@ const PRESET_CONFIG: Record<StreamSmoothingPreset, StreamSmoothingPresetConfig> 
     maxActiveCps: 180,
     maxCps: 96,
     maxFlushCps: 360,
+    minCommitIntervalMs: 24,
     minCps: 24,
     settleAfterMs: 260,
     settleDrainMaxMs: 360,
@@ -78,6 +81,7 @@ const PRESET_CONFIG: Record<StreamSmoothingPreset, StreamSmoothingPresetConfig> 
     maxActiveCps: 102,
     maxCps: 56,
     maxFlushCps: 220,
+    minCommitIntervalMs: 36,
     minCps: 14,
     settleAfterMs: 460,
     settleDrainMaxMs: 680,
@@ -88,6 +92,20 @@ const PRESET_CONFIG: Record<StreamSmoothingPreset, StreamSmoothingPresetConfig> 
 
 const clamp = (value: number, min: number, max: number): number => {
   return Math.min(max, Math.max(min, value));
+};
+
+// Every reveal commit re-parses and re-wraps the entire trailing block, so
+// the per-commit cost grows linearly with how far the content is from the
+// last block boundary. Widen the commit interval as that distance grows —
+// long paragraphs/code fences keep total work bounded while short blocks
+// stay at the preset's snappy interval. Per-char animation-delay stagger
+// hides the lower commit rate.
+const MAX_COMMIT_INTERVAL_MS = 64;
+const COMMIT_INTERVAL_TAIL_SCALE_UNITS = 256;
+
+const findTailUnits = (content: string): number => {
+  const boundary = content.lastIndexOf('\n\n');
+  return boundary === -1 ? content.length : content.length - boundary - 2;
 };
 
 const getNow = () => {
@@ -119,6 +137,7 @@ export const useSmoothStreamContent = (
   const targetCountRef = useRef(targetCharsRef.current.length);
 
   const emaCpsRef = useRef(config.defaultCps);
+  const tailUnitsRef = useRef(findTailUnits(content));
   const lastInputTsRef = useRef(0);
   const lastInputCountRef = useRef(targetCountRef.current);
   const chunkSizeEmaRef = useRef(1);
@@ -183,6 +202,7 @@ export const useSmoothStreamContent = (
       emaCpsRef.current = config.defaultCps;
       chunkSizeEmaRef.current = 1;
       arrivalCpsEmaRef.current = config.defaultCps;
+      tailUnitsRef.current = findTailUnits(nextContent);
       lastInputTsRef.current = now;
       lastInputCountRef.current = chars.length;
     },
@@ -194,18 +214,6 @@ export const useSmoothStreamContent = (
     if (rafRef.current !== null) return;
 
     const tick = (ts: number) => {
-      const frameStart = getNow();
-
-      if (lastFrameTsRef.current === null) {
-        lastFrameTsRef.current = ts;
-        rafRef.current = requestAnimationFrame(tick);
-        return;
-      }
-
-      const frameIntervalMs = Math.max(0, ts - lastFrameTsRef.current);
-      const dtSeconds = Math.max(0.001, Math.min(frameIntervalMs / 1000, 0.05));
-      lastFrameTsRef.current = ts;
-
       const targetCount = targetCountRef.current;
       const displayedCount = displayedCountRef.current;
       const backlog = targetCount - displayedCount;
@@ -214,6 +222,30 @@ export const useSmoothStreamContent = (
         stopFrameLoop();
         return;
       }
+
+      if (lastFrameTsRef.current === null) {
+        lastFrameTsRef.current = ts;
+        rafRef.current = requestAnimationFrame(tick);
+        return;
+      }
+
+      // Reveal commits are throttled below the display refresh rate: each
+      // commit re-renders the tail block and re-runs remend + lexing, so
+      // committing at 60-120fps burns CPU without visible benefit — the
+      // per-char stagger inside a commit is carried by animation-delay.
+      const commitIntervalMs = Math.min(
+        MAX_COMMIT_INTERVAL_MS,
+        config.minCommitIntervalMs * (1 + tailUnitsRef.current / COMMIT_INTERVAL_TAIL_SCALE_UNITS),
+      );
+      const frameIntervalMs = Math.max(0, ts - lastFrameTsRef.current);
+      if (frameIntervalMs < commitIntervalMs) {
+        rafRef.current = requestAnimationFrame(tick);
+        return;
+      }
+
+      const frameStart = getNow();
+      const dtSeconds = Math.max(0.001, Math.min(frameIntervalMs / 1000, 0.05));
+      lastFrameTsRef.current = ts;
 
       const now = getNow();
       const idleMs = now - lastInputTsRef.current;
@@ -321,6 +353,7 @@ export const useSmoothStreamContent = (
     config.maxActiveCps,
     config.maxCps,
     config.maxFlushCps,
+    config.minCommitIntervalMs,
     config.minCps,
     config.settleAfterMs,
     config.settleDrainMaxMs,
@@ -377,8 +410,10 @@ export const useSmoothStreamContent = (
     }
 
     targetContentRef.current = content;
-    targetCharsRef.current = [...targetCharsRef.current, ...appendedChars];
+    targetCharsRef.current.push(...appendedChars);
     targetCountRef.current += appendedCount;
+
+    tailUnitsRef.current = findTailUnits(content);
 
     const deltaChars = targetCountRef.current - lastInputCountRef.current;
     const deltaMs = Math.max(1, now - lastInputTsRef.current);

--- a/src/Markdown/SyntaxMarkdown/useStreamQueue.ts
+++ b/src/Markdown/SyntaxMarkdown/useStreamQueue.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { STREAM_FADE_DURATION } from './style';
 import { countChars } from './useSmoothStreamContent';
 
 export interface BlockInfo {
@@ -12,7 +13,6 @@ export type BlockState = 'revealed' | 'animating' | 'streaming' | 'queued';
 const BASE_DELAY = 18;
 const ACCELERATION_FACTOR = 0.3;
 const MAX_BLOCK_DURATION = 3000;
-const FADE_DURATION = 280;
 
 function computeCharDelay(queueLength: number, charCount: number): number {
   const acceleration = 1 + queueLength * ACCELERATION_FACTOR;
@@ -105,7 +105,7 @@ export function useStreamQueue(blocks: BlockInfo[]): UseStreamQueueReturn {
 
     if (animatingIndex < 0) return;
 
-    const totalTime = Math.max(0, (animatingCharCount - 1) * charDelay) + FADE_DURATION;
+    const totalTime = Math.max(0, (animatingCharCount - 1) * charDelay) + STREAM_FADE_DURATION;
     timerRef.current = setTimeout(onAnimationDone, totalTime);
 
     return () => {

--- a/src/Markdown/SyntaxMarkdown/useStreamQueue.ts
+++ b/src/Markdown/SyntaxMarkdown/useStreamQueue.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { countChars } from './useSmoothStreamContent';
+
 export interface BlockInfo {
   content: string;
   startOffset: number;
@@ -11,10 +13,6 @@ const BASE_DELAY = 18;
 const ACCELERATION_FACTOR = 0.3;
 const MAX_BLOCK_DURATION = 3000;
 const FADE_DURATION = 280;
-
-function countChars(text: string): number {
-  return [...text].length;
-}
 
 function computeCharDelay(queueLength: number, charCount: number): number {
   const acceleration = 1 + queueLength * ACCELERATION_FACTOR;

--- a/src/Markdown/components/MarkdownProvider.tsx
+++ b/src/Markdown/components/MarkdownProvider.tsx
@@ -2,6 +2,8 @@
 
 import { createContext, memo, type PropsWithChildren, use } from 'react';
 
+import { useStableValue } from '@/hooks/useStableValue';
+
 import { type SyntaxMarkdownProps } from '../type';
 
 export type MarkdownContentConfig = Omit<SyntaxMarkdownProps, 'children' | 'reactMarkdownProps'>;
@@ -10,7 +12,13 @@ export const MarkdownContext = createContext<MarkdownContentConfig>({});
 
 export const MarkdownProvider = memo<PropsWithChildren<MarkdownContentConfig>>(
   ({ children, ...config }) => {
-    return <MarkdownContext value={config}>{children}</MarkdownContext>;
+    // The rest-spread builds a fresh object on every render while `children`
+    // changes on every streamed chunk, so without stabilisation each chunk
+    // swaps the context identity and re-renders every consumer inside every
+    // block, bypassing the per-block memo entirely.
+    const stableConfig = useStableValue(config);
+
+    return <MarkdownContext value={stableConfig}>{children}</MarkdownContext>;
   },
 );
 

--- a/src/Markdown/demos/StreamingPlayground.tsx
+++ b/src/Markdown/demos/StreamingPlayground.tsx
@@ -145,8 +145,8 @@ export const StreamingPlayground = ({ defaultShowProfiler = false }: StreamingPl
         value: true,
       },
       streamAnimationGranularity: {
-        options: ['word', 'char'],
-        value: 'word',
+        options: ['char', 'word'],
+        value: 'char',
       },
       streamSmoothingPreset: {
         options: ['realtime', 'balanced', 'silky'],

--- a/src/Markdown/demos/StreamingPlayground.tsx
+++ b/src/Markdown/demos/StreamingPlayground.tsx
@@ -104,6 +104,7 @@ export const StreamingPlayground = ({ defaultShowProfiler = false }: StreamingPl
     chunkDelayMin,
     chunkDelayMax,
     language,
+    streamAnimationGranularity,
     streamSmoothingPreset,
     streamDebug,
     showProfilerPanel,
@@ -142,6 +143,10 @@ export const StreamingPlayground = ({ defaultShowProfiler = false }: StreamingPl
       },
       useReadableStream: {
         value: true,
+      },
+      streamAnimationGranularity: {
+        options: ['word', 'char'],
+        value: 'word',
       },
       streamSmoothingPreset: {
         options: ['realtime', 'balanced', 'silky'],
@@ -371,6 +376,7 @@ export const StreamingPlayground = ({ defaultShowProfiler = false }: StreamingPl
       components={components}
       fullFeaturedCodeBlock={rest.fullFeaturedCodeBlock}
       rehypePlugins={rehypePlugins}
+      streamAnimationGranularity={streamAnimationGranularity === 'char' ? 'char' : 'word'}
       streamSmoothingPreset={safeSmoothingPreset}
       variant="chat"
     >

--- a/src/Markdown/demos/streamingBench.tsx
+++ b/src/Markdown/demos/streamingBench.tsx
@@ -1,0 +1,76 @@
+import { Markdown } from '@lobehub/ui';
+import { useEffect, useRef, useState } from 'react';
+
+import { type StreamAnimationGranularity, type StreamSmoothingPreset } from '../type';
+import { fullContent } from './content';
+
+const readParams = () => {
+  const params = new URLSearchParams(typeof window === 'undefined' ? '' : window.location.search);
+  const preset = params.get('preset');
+  return {
+    chunkDelay: Number(params.get('delay')) || 50,
+    chunkSize: Number(params.get('size')) || 5,
+    granularity: (params.get('granularity') === 'word'
+      ? 'word'
+      : 'char') as StreamAnimationGranularity,
+    preset: (preset === 'realtime' || preset === 'silky'
+      ? preset
+      : 'balanced') as StreamSmoothingPreset,
+  };
+};
+
+export default () => {
+  const [{ chunkDelay, chunkSize, granularity, preset }] = useState(readParams);
+  const [content, setContent] = useState('');
+  const [phase, setPhase] = useState<'idle' | 'streaming' | 'done'>('idle');
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const start = () => {
+    if (timerRef.current) clearInterval(timerRef.current);
+    setContent('');
+    setPhase('streaming');
+
+    let position = 0;
+    timerRef.current = setInterval(() => {
+      position += chunkSize;
+      setContent(fullContent.slice(0, position));
+
+      if (position >= fullContent.length) {
+        if (timerRef.current) clearInterval(timerRef.current);
+        timerRef.current = null;
+        setPhase('done');
+      }
+    }, chunkDelay);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, []);
+
+  return (
+    <div style={{ margin: '0 auto', maxWidth: 800, padding: 24 }}>
+      <button
+        data-phase={phase}
+        disabled={phase === 'streaming'}
+        style={{ marginBottom: 16 }}
+        type="button"
+        onClick={start}
+      >
+        {phase === 'streaming' ? 'streaming' : phase === 'done' ? 'run again' : 'start'}
+      </button>
+      <span style={{ fontFamily: 'monospace', fontSize: 12, marginInlineStart: 8, opacity: 0.5 }}>
+        size={chunkSize} delay={chunkDelay}ms granularity={granularity} preset={preset}
+      </span>
+      <Markdown
+        animated={phase === 'streaming'}
+        streamAnimationGranularity={granularity}
+        streamSmoothingPreset={preset}
+        variant="chat"
+      >
+        {content}
+      </Markdown>
+    </div>
+  );
+};

--- a/src/Markdown/demos/streamingBench.tsx
+++ b/src/Markdown/demos/streamingBench.tsx
@@ -8,6 +8,7 @@ const readParams = () => {
   const params = new URLSearchParams(typeof window === 'undefined' ? '' : window.location.search);
   const preset = params.get('preset');
   return {
+    animation: params.get('anim') !== '0',
     chunkDelay: Number(params.get('delay')) || 50,
     chunkSize: Number(params.get('size')) || 5,
     granularity: (params.get('granularity') === 'word'
@@ -19,8 +20,10 @@ const readParams = () => {
   };
 };
 
+const NO_ANIMATION_CSS = `.stream-char { animation: none !important; opacity: 1 !important; }`;
+
 export default () => {
-  const [{ chunkDelay, chunkSize, granularity, preset }] = useState(readParams);
+  const [{ animation, chunkDelay, chunkSize, granularity, preset }] = useState(readParams);
   const [content, setContent] = useState('');
   const [phase, setPhase] = useState<'idle' | 'streaming' | 'done'>('idle');
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -51,6 +54,7 @@ export default () => {
 
   return (
     <div style={{ margin: '0 auto', maxWidth: 800, padding: 24 }}>
+      {!animation && <style>{NO_ANIMATION_CSS}</style>}
       <button
         data-phase={phase}
         disabled={phase === 'streaming'}
@@ -61,7 +65,8 @@ export default () => {
         {phase === 'streaming' ? 'streaming' : phase === 'done' ? 'run again' : 'start'}
       </button>
       <span style={{ fontFamily: 'monospace', fontSize: 12, marginInlineStart: 8, opacity: 0.5 }}>
-        size={chunkSize} delay={chunkDelay}ms granularity={granularity} preset={preset}
+        size={chunkSize} delay={chunkDelay}ms granularity={granularity} preset={preset} anim=
+        {animation ? 'on' : 'off'}
       </span>
       <Markdown
         animated={phase === 'streaming'}

--- a/src/Markdown/index.md
+++ b/src/Markdown/index.md
@@ -270,6 +270,12 @@ Use this demo to inspect stream-driven React commit frequency, block-level re-re
 
 <code src="./demos/streamingProfiler.tsx" iframe nopadding></code>
 
+### Streaming Benchmark
+
+Noise-free page for CPU measurements: a single `Markdown` and a plain HTML button — no control panel, no chunk log, no spinner, no auto-scroll. Configure via query params: `?size=5&delay=50&granularity=char|word&preset=balanced`.
+
+<code src="./demos/streamingBench.tsx" iframe nopadding></code>
+
 ### Character Animation Loss Repro
 
 Controlled reproductions for the missing character-by-character fade. Three scenarios target:

--- a/src/Markdown/plugins/rehypeStreamAnimated.test.ts
+++ b/src/Markdown/plugins/rehypeStreamAnimated.test.ts
@@ -1,0 +1,103 @@
+import { type Element, type ElementContent, type Root } from 'hast';
+import { describe, expect, it } from 'vitest';
+
+import { rehypeStreamAnimated, type StreamAnimatedRuntime } from './rehypeStreamAnimated';
+
+const makeTree = (text: string): Root => ({
+  children: [
+    {
+      children: [{ type: 'text', value: text }],
+      properties: {},
+      tagName: 'p',
+      type: 'element',
+    },
+  ],
+  type: 'root',
+});
+
+const childrenOf = (tree: Root): ElementContent[] => (tree.children[0] as Element).children;
+
+const textOf = (child: ElementContent): string => {
+  if (child.type === 'text') return child.value;
+  if (child.type === 'element' && child.children[0]?.type === 'text') {
+    return child.children[0].value;
+  }
+  return '';
+};
+
+const makeRuntime = (births: number[]): StreamAnimatedRuntime => ({ births, styles: [] });
+
+describe('rehypeStreamAnimated', () => {
+  it('char granularity wraps every char in a span', () => {
+    const tree = makeTree('ab c');
+    rehypeStreamAnimated({ runtime: makeRuntime([0, 0, 0, 0]) })(tree);
+
+    const children = childrenOf(tree);
+    expect(children).toHaveLength(4);
+    expect(children.every((child) => child.type === 'element' && child.tagName === 'span')).toBe(
+      true,
+    );
+    expect(children.map((child) => textOf(child)).join('')).toBe('ab c');
+  });
+
+  it('word granularity wraps words and keeps whitespace as text', () => {
+    const tree = makeTree('hello world');
+    rehypeStreamAnimated({ granularity: 'word', runtime: makeRuntime([]) })(tree);
+
+    const children = childrenOf(tree);
+    const spans = children.filter((child) => child.type === 'element');
+    const texts = children.filter((child) => child.type === 'text');
+
+    expect(spans).toHaveLength(2);
+    expect(texts).toHaveLength(1);
+    expect(children.map((child) => textOf(child)).join('')).toBe('hello world');
+  });
+
+  it('word granularity splits unspaced CJK runs', () => {
+    const text = '今天天气真好我们出去玩吧';
+    const tree = makeTree(text);
+    rehypeStreamAnimated({ granularity: 'word', runtime: makeRuntime([]) })(tree);
+
+    const children = childrenOf(tree);
+    expect(children.length).toBeGreaterThan(1);
+    expect(children.map((child) => textOf(child)).join('')).toBe(text);
+  });
+
+  it('marks chars past the fade window as revealed without style', () => {
+    const tree = makeTree('ab');
+    rehypeStreamAnimated({ fadeDuration: 100, runtime: makeRuntime([0, 0]) })(tree);
+
+    for (const child of childrenOf(tree)) {
+      if (child.type !== 'element') continue;
+      expect(child.properties?.className).toContain('stream-char-revealed');
+      expect(child.properties?.style).toBeUndefined();
+    }
+  });
+
+  it('freezes resolved styles in the runtime cache across runs', () => {
+    const runtime = makeRuntime([performance.now() + 10_000, performance.now() + 10_000]);
+    const treeA = makeTree('ab');
+    rehypeStreamAnimated({ fadeDuration: 100_000, runtime })(treeA);
+
+    const cached = [...runtime.styles];
+    expect(cached.every((style) => typeof style === 'string')).toBe(true);
+
+    const treeB = makeTree('ab');
+    rehypeStreamAnimated({ fadeDuration: 100_000, runtime })(treeB);
+
+    expect(runtime.styles).toEqual(cached);
+    const styleOf = (tree: Root, index: number) =>
+      (childrenOf(tree)[index] as Element).properties?.style;
+    expect(styleOf(treeB, 0)).toBe(styleOf(treeA, 0));
+    expect(styleOf(treeB, 1)).toBe(styleOf(treeA, 1));
+  });
+
+  it('keeps the legacy births/nowMs options working', () => {
+    const tree = makeTree('ab');
+    rehypeStreamAnimated({ births: [100, 200], fadeDuration: 150, nowMs: 120 })(tree);
+
+    const [first, second] = childrenOf(tree) as Element[];
+    expect(first.properties?.style).toBe('animation-delay:-20ms');
+    expect(second.properties?.style).toBe('animation-delay:80ms');
+  });
+});

--- a/src/Markdown/plugins/rehypeStreamAnimated.ts
+++ b/src/Markdown/plugins/rehypeStreamAnimated.ts
@@ -20,10 +20,38 @@ export interface StreamAnimatedRuntime {
 export interface StreamAnimatedOptions {
   births?: number[];
   fadeDuration?: number;
+  /**
+   * `'word'` wraps whitespace-delimited runs in one span instead of one
+   * span per char. Every concurrent CSS animation keeps the compositor
+   * producing frames and fires animationstart/end through React's root
+   * event delegation, so animating ~5x fewer nodes is the main CPU lever —
+   * char-level remains available for the finer-grained look.
+   */
+  granularity?: 'char' | 'word';
   nowMs?: number;
   revealed?: boolean;
   runtime?: StreamAnimatedRuntime;
 }
+
+// Intl.Segmenter splits CJK runs into words too — the whitespace regex
+// fallback would otherwise fade an entire unspaced CJK paragraph as one
+// unit.
+const WORD_SEGMENT_RE = /\s+|\S+/g;
+
+const wordSegmenter =
+  typeof Intl !== 'undefined' && 'Segmenter' in Intl
+    ? new Intl.Segmenter(undefined, { granularity: 'word' })
+    : null;
+
+const segmentWords = (value: string): string[] => {
+  if (!wordSegmenter) return value.match(WORD_SEGMENT_RE) ?? [];
+
+  const segments: string[] = [];
+  for (const item of wordSegmenter.segment(value)) {
+    segments.push(item.segment);
+  }
+  return segments;
+};
 
 const BLOCK_TAGS = new Set(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li']);
 const SKIP_TAGS = new Set(['pre', 'code', 'table', 'svg']);
@@ -36,7 +64,14 @@ function hasClass(node: Element, cls: string): boolean {
 }
 
 export const rehypeStreamAnimated = (options: StreamAnimatedOptions = {}) => {
-  const { births, fadeDuration = 150, nowMs, revealed = false, runtime } = options;
+  const {
+    births,
+    fadeDuration = 150,
+    granularity = 'char',
+    nowMs,
+    revealed = false,
+    runtime,
+  } = options;
   // Legacy births/nowMs callers share the runtime path through a throwaway
   // cache: the plugin factory runs once per render, so their styles are
   // recomputed against the caller's nowMs each run, exactly as before.
@@ -74,36 +109,53 @@ export const rehypeStreamAnimated = (options: StreamAnimatedOptions = {}) => {
       return resolved;
     };
 
+    const buildSpan = (value: string, startIndex: number): ElementContent => {
+      let className = 'stream-char';
+      let style: string | undefined;
+
+      if (revealed) {
+        className = 'stream-char stream-char-revealed';
+      } else if (resolvedRuntime) {
+        const resolved = resolveStyle(startIndex);
+        if (resolved === null) {
+          className = 'stream-char stream-char-revealed';
+        } else {
+          style = resolved;
+        }
+      }
+
+      const properties: Record<string, any> = { className };
+      if (style !== undefined) {
+        properties.style = style;
+      }
+      return {
+        children: [{ type: 'text', value }],
+        properties,
+        tagName: 'span',
+        type: 'element',
+      };
+    };
+
     const wrapText = (node: Element) => {
       const newChildren: ElementContent[] = [];
       for (const child of node.children) {
         if (child.type === 'text') {
-          for (const char of child.value) {
-            let className = 'stream-char';
-            let style: string | undefined;
+          if (granularity === 'word') {
+            for (const segment of segmentWords(child.value)) {
+              const startIndex = globalCharIndex;
+              for (const _char of segment) globalCharIndex++;
 
-            if (revealed) {
-              className = 'stream-char stream-char-revealed';
-            } else if (resolvedRuntime) {
-              const resolved = resolveStyle(globalCharIndex);
-              if (resolved === null) {
-                className = 'stream-char stream-char-revealed';
+              if (segment.trim() === '') {
+                newChildren.push({ type: 'text', value: segment });
               } else {
-                style = resolved;
+                newChildren.push(buildSpan(segment, startIndex));
               }
             }
-
-            const properties: Record<string, any> = { className };
-            if (style !== undefined) {
-              properties.style = style;
+          } else {
+            for (const char of child.value) {
+              newChildren.push(buildSpan(char, globalCharIndex));
+              globalCharIndex++;
             }
-            newChildren.push({
-              children: [{ type: 'text', value: char }],
-              properties,
-              tagName: 'span',
-              type: 'element',
-            });
-            globalCharIndex++;
           }
         } else if (child.type === 'element') {
           if (!shouldSkip(child)) {

--- a/src/Markdown/plugins/rehypeStreamAnimated.ts
+++ b/src/Markdown/plugins/rehypeStreamAnimated.ts
@@ -2,12 +2,14 @@ import { type Element, type ElementContent, type Root } from 'hast';
 import { type BuildVisitor } from 'unist-util-visit';
 import { visit } from 'unist-util-visit';
 
+import { getNow } from '@/utils/getNow';
+
 export interface StreamAnimatedRuntime {
   births: number[];
   /**
    * Write-once per-char render cache, indexed like `births`:
    * `undefined` = char not rendered yet, `null` = born fully revealed,
-   * string = inline style frozen at first render ('' when no delay).
+   * string = inline style frozen at first render.
    * Freezing the style keeps span props referentially stable across the
    * tail block's re-renders, so React never rewrites `animation-delay`
    * on an in-flight fade (a rewrite restarts the CSS animation).
@@ -26,10 +28,6 @@ export interface StreamAnimatedOptions {
 const BLOCK_TAGS = new Set(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li']);
 const SKIP_TAGS = new Set(['pre', 'code', 'table', 'svg']);
 
-const getNow = () => {
-  return typeof performance === 'undefined' ? Date.now() : performance.now();
-};
-
 function hasClass(node: Element, cls: string): boolean {
   const cn = node.properties?.className;
   if (Array.isArray(cn)) return cn.some((c) => String(c).includes(cls));
@@ -39,33 +37,38 @@ function hasClass(node: Element, cls: string): boolean {
 
 export const rehypeStreamAnimated = (options: StreamAnimatedOptions = {}) => {
   const { births, fadeDuration = 150, nowMs, revealed = false, runtime } = options;
-  const hasRuntime = !revealed && runtime !== undefined;
-  const hasBirths = !revealed && !hasRuntime && Array.isArray(births) && typeof nowMs === 'number';
+  // Legacy births/nowMs callers share the runtime path through a throwaway
+  // cache: the plugin factory runs once per render, so their styles are
+  // recomputed against the caller's nowMs each run, exactly as before.
+  const resolvedRuntime = revealed
+    ? undefined
+    : (runtime ??
+      (Array.isArray(births) && typeof nowMs === 'number' ? { births, styles: [] } : undefined));
+  const nowOverride = runtime ? undefined : nowMs;
 
   return (tree: Root) => {
     let globalCharIndex = 0;
-    const now = hasRuntime ? getNow() : 0;
+    const now = nowOverride ?? (resolvedRuntime ? getNow() : 0);
 
     const shouldSkip = (node: Element): boolean => {
       return SKIP_TAGS.has(node.tagName) || hasClass(node, 'katex');
     };
 
-    const resolveRuntimeStyle = (index: number): string | null => {
-      const styles = runtime!.styles;
+    const resolveStyle = (index: number): string | null => {
+      const styles = resolvedRuntime!.styles;
       const cached = styles[index];
       if (cached !== undefined) return cached;
 
-      const birthTs = runtime!.births[index];
+      const birthTs = resolvedRuntime!.births[index];
       let resolved: string | null;
       if (birthTs === undefined) {
         resolved = null;
       } else {
         const elapsed = now - birthTs;
-        if (elapsed >= fadeDuration) {
-          resolved = null;
-        } else {
-          resolved = elapsed === 0 ? '' : `animation-delay:${-elapsed}ms`;
-        }
+        // Negative delay = already elapsed ms into the fade. Positive
+        // delay = not started yet (char born in the future, i.e.
+        // staggered within the same commit).
+        resolved = elapsed >= fadeDuration ? null : `animation-delay:${-elapsed}ms`;
       }
       styles[index] = resolved;
       return resolved;
@@ -81,27 +84,12 @@ export const rehypeStreamAnimated = (options: StreamAnimatedOptions = {}) => {
 
             if (revealed) {
               className = 'stream-char stream-char-revealed';
-            } else if (hasRuntime) {
-              const resolved = resolveRuntimeStyle(globalCharIndex);
+            } else if (resolvedRuntime) {
+              const resolved = resolveStyle(globalCharIndex);
               if (resolved === null) {
                 className = 'stream-char stream-char-revealed';
-              } else if (resolved !== '') {
-                style = resolved;
-              }
-            } else if (hasBirths) {
-              const birthTs = births![globalCharIndex];
-              if (birthTs === undefined) {
-                className = 'stream-char stream-char-revealed';
               } else {
-                const elapsed = (nowMs as number) - birthTs;
-                if (elapsed >= fadeDuration) {
-                  className = 'stream-char stream-char-revealed';
-                } else if (elapsed !== 0) {
-                  // Negative delay = already elapsed ms into the fade.
-                  // Positive delay = not started yet (char born in the future,
-                  // i.e. staggered within the same commit).
-                  style = `animation-delay:${-elapsed}ms`;
-                }
+                style = resolved;
               }
             }
 

--- a/src/Markdown/plugins/rehypeStreamAnimated.ts
+++ b/src/Markdown/plugins/rehypeStreamAnimated.ts
@@ -2,15 +2,33 @@ import { type Element, type ElementContent, type Root } from 'hast';
 import { type BuildVisitor } from 'unist-util-visit';
 import { visit } from 'unist-util-visit';
 
+export interface StreamAnimatedRuntime {
+  births: number[];
+  /**
+   * Write-once per-char render cache, indexed like `births`:
+   * `undefined` = char not rendered yet, `null` = born fully revealed,
+   * string = inline style frozen at first render ('' when no delay).
+   * Freezing the style keeps span props referentially stable across the
+   * tail block's re-renders, so React never rewrites `animation-delay`
+   * on an in-flight fade (a rewrite restarts the CSS animation).
+   */
+  styles: (string | null | undefined)[];
+}
+
 export interface StreamAnimatedOptions {
   births?: number[];
   fadeDuration?: number;
   nowMs?: number;
   revealed?: boolean;
+  runtime?: StreamAnimatedRuntime;
 }
 
 const BLOCK_TAGS = new Set(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li']);
 const SKIP_TAGS = new Set(['pre', 'code', 'table', 'svg']);
+
+const getNow = () => {
+  return typeof performance === 'undefined' ? Date.now() : performance.now();
+};
 
 function hasClass(node: Element, cls: string): boolean {
   const cn = node.properties?.className;
@@ -20,14 +38,37 @@ function hasClass(node: Element, cls: string): boolean {
 }
 
 export const rehypeStreamAnimated = (options: StreamAnimatedOptions = {}) => {
-  const { births, fadeDuration = 150, nowMs, revealed = false } = options;
-  const hasBirths = !revealed && Array.isArray(births) && typeof nowMs === 'number';
+  const { births, fadeDuration = 150, nowMs, revealed = false, runtime } = options;
+  const hasRuntime = !revealed && runtime !== undefined;
+  const hasBirths = !revealed && !hasRuntime && Array.isArray(births) && typeof nowMs === 'number';
 
   return (tree: Root) => {
     let globalCharIndex = 0;
+    const now = hasRuntime ? getNow() : 0;
 
     const shouldSkip = (node: Element): boolean => {
       return SKIP_TAGS.has(node.tagName) || hasClass(node, 'katex');
+    };
+
+    const resolveRuntimeStyle = (index: number): string | null => {
+      const styles = runtime!.styles;
+      const cached = styles[index];
+      if (cached !== undefined) return cached;
+
+      const birthTs = runtime!.births[index];
+      let resolved: string | null;
+      if (birthTs === undefined) {
+        resolved = null;
+      } else {
+        const elapsed = now - birthTs;
+        if (elapsed >= fadeDuration) {
+          resolved = null;
+        } else {
+          resolved = elapsed === 0 ? '' : `animation-delay:${-elapsed}ms`;
+        }
+      }
+      styles[index] = resolved;
+      return resolved;
     };
 
     const wrapText = (node: Element) => {
@@ -36,10 +77,17 @@ export const rehypeStreamAnimated = (options: StreamAnimatedOptions = {}) => {
         if (child.type === 'text') {
           for (const char of child.value) {
             let className = 'stream-char';
-            let delay: number | undefined;
+            let style: string | undefined;
 
             if (revealed) {
               className = 'stream-char stream-char-revealed';
+            } else if (hasRuntime) {
+              const resolved = resolveRuntimeStyle(globalCharIndex);
+              if (resolved === null) {
+                className = 'stream-char stream-char-revealed';
+              } else if (resolved !== '') {
+                style = resolved;
+              }
             } else if (hasBirths) {
               const birthTs = births![globalCharIndex];
               if (birthTs === undefined) {
@@ -48,18 +96,18 @@ export const rehypeStreamAnimated = (options: StreamAnimatedOptions = {}) => {
                 const elapsed = (nowMs as number) - birthTs;
                 if (elapsed >= fadeDuration) {
                   className = 'stream-char stream-char-revealed';
-                } else {
+                } else if (elapsed !== 0) {
                   // Negative delay = already elapsed ms into the fade.
                   // Positive delay = not started yet (char born in the future,
                   // i.e. staggered within the same commit).
-                  delay = -elapsed;
+                  style = `animation-delay:${-elapsed}ms`;
                 }
               }
             }
 
             const properties: Record<string, any> = { className };
-            if (delay !== undefined && delay !== 0) {
-              properties.style = `animation-delay:${delay}ms`;
+            if (style !== undefined) {
+              properties.style = style;
             }
             newChildren.push({
               children: [{ type: 'text', value: char }],

--- a/src/Markdown/streamProfiler/profiler.ts
+++ b/src/Markdown/streamProfiler/profiler.ts
@@ -1,4 +1,5 @@
 import { type BlockState } from '@/Markdown/SyntaxMarkdown/useStreamQueue';
+import { getNow } from '@/utils/getNow';
 
 export type StreamdownProfilerPhase = 'mount' | 'nested-update' | 'update';
 
@@ -229,10 +230,6 @@ const DEFAULT_TARGET_FPS = 60;
 const MAX_FPS_SAMPLES = 90;
 const MAX_TRACKED_FPS = 120;
 const SLOW_FRAME_JS_BUDGET_MS = 4;
-
-const getNow = () => {
-  return typeof performance === 'undefined' ? Date.now() : performance.now();
-};
 
 const createMetric = (): MutableMetric => ({
   count: 0,

--- a/src/Markdown/type.ts
+++ b/src/Markdown/type.ts
@@ -21,6 +21,8 @@ export interface TypographyProps extends DivProps {
 
 export type StreamSmoothingPreset = 'realtime' | 'balanced' | 'silky';
 
+export type StreamAnimationGranularity = 'char' | 'word';
+
 export interface SyntaxMarkdownProps {
   allowHtml?: boolean;
   allowHtmlList?: ElementType[];
@@ -53,6 +55,7 @@ export interface SyntaxMarkdownProps {
   remarkPlugins?: Pluggable[];
   remarkPluginsAhead?: Pluggable[];
   showFootnotes?: boolean;
+  streamAnimationGranularity?: StreamAnimationGranularity;
   streamSmoothingPreset?: StreamSmoothingPreset;
   variant?: 'default' | 'chat';
 }

--- a/src/utils/getNow.ts
+++ b/src/utils/getNow.ts
@@ -1,0 +1,3 @@
+export const getNow = (): number => {
+  return typeof performance === 'undefined' ? Date.now() : performance.now();
+};


### PR DESCRIPTION
## Summary

Users reported high CPU during the streamdown streaming animation. This PR establishes a reproducible benchmark, then removes the dominant costs in three rounds: per-frame React commits, per-char span churn, a context identity leak, and finally the per-vsync load of the CSS animations themselves.

**Library-only result (noise-free benchmark demo, production build): 47.9% → 15.5% of one core (3.1x) with the default char-level fade, or 9.6% (5x) with the word-level opt-in. GPU process: 12.2% → 6.9% / 2.4%.**

## What changed

1. **Commit throttling** (`useSmoothStreamContent`) — reveal commits drop from ~90/s to a per-preset floor (realtime/balanced/silky 32/48/56ms), widened adaptively up to 96ms as the tail block grows (per-commit cost is linear in tail size). O(n²) target-array rebuild replaced with in-place push.
2. **Write-once animation styles** (`rehypeStreamAnimated` `runtime` option) — each char's `animation-delay` is frozen at first render, so tail re-renders never rewrite styles or restart in-flight fades. Legacy `births`/`nowMs`/`revealed` options unchanged (now served by the same resolver via an adapter).
3. **Settled blocks render with base plugins only** — no span per char once a block's fade completes (peak `.stream-char` count ~4,700 → ~420; DOM peak 11.5k → 6.9k nodes).
4. **Stable identities** — per-block births/styles live in mutable runtimes, plugin tuples are cached per block, and `MarkdownProvider`'s context value is stabilized with `useStableValue` so streamed chunks no longer re-render every consumer in every block.
5. **`streamAnimationGranularity` prop** (`'char'` default, `'word'` opt-in) — word mode wraps `Intl.Segmenter` word segments (CJK-aware, whitespace-regex fallback) in one span instead of one per char, cutting animated nodes, compositor layers, and animationstart/end events ~5x.
6. **Continuity fix for throttled commits** — the streaming tail paces its birth stagger from the observed gap between reveal commits (a batch's chars spread evenly until the next commit lands) instead of a fixed 18ms chain that piled chars onto the fade-window cap. Verified: uniform `animation-delay` ladder (~14ms steps), no clumping, per-char flow continuous at any commit rate.
7. **Fade 280→180ms**, duration constant consolidated in `style.ts` (CSS, settle timing, and birth caps share one value).
8. **Noise-free benchmark demo** — `/~demos/src-markdown-demo-streamingbench?size=5&delay=50&granularity=char|word&preset=balanced`: a single `Markdown` + plain HTML button (no leva, no chunk log, no spinner, no auto-scroll), so profiles measure the library, not the playground.

## Benchmarks

Production `dumi build`, headless Chrome, renderer process sampled every 0.5s while streaming 5,812 chars at 5 chars / 50ms, balanced preset.

| | Renderer | GPU process | vs baseline |
|---|---|---|---|
| baseline (master) | 47.9% | 12.2% | — |
| round 1 (throttle + span fixes + context) | 21.5% | ~13% | 2.2x |
| + word granularity / continuity fix | 15.5% (char) / 9.6% (word) | 6.9% / 2.4% | 3.1x / 5x |
| **+ render split & cached processor (final), `char` default** | **13.7%** | **6.3%** | **3.5x** |
| **final, `word` opt-in** | **~8-9%** | **~2%** | **~5.5x** |

### Where the remaining cost lives (2×2 isolation: CSS animations force-disabled via style override)

| | Renderer | GPU |
|---|---|---|
| char + animations | 15.5% | 6.9% |
| char, animations disabled | 10.1% | 1.1% |
| word + animations | 9.6% | 2.4% |
| word, animations disabled | 7.4% | 1.1% |

- CSS fade animations themselves: **~5.4 renderer + ~5.8 GPU points** in char mode (compositor produces frames at vsync while any animation runs; ~220 animationstart/end events/s flow through React's root delegation). Word mode amortizes this ~5x — word-with-animations ≈ char-without.
- Per-char span structure (jsx/DOM volume): ~2.7 points.
- The ~7.4% floor is streaming rendering itself: commits, remend + marked lexing, tail-block re-parse, text DOM updates.
- A possible future `granularity: 'none'` (no spans at all) would land ~6-7%.

Earlier round-2/3 numbers measured on the playground demo carried ~2-5 points of demo noise (chunk-log re-renders, smooth auto-scroll, antd spinner). DevTools adds another ~16%+ observer effect (async task tracking) — profiles taken with DevTools open overstate real-world cost roughly 2x.

## Behavior notes

- Default visual is unchanged (char-by-char fade); `streamAnimationGranularity="word"` is the low-CPU opt-in.
- Spans no longer swap to `stream-char-revealed` after fading (`animation-fill-mode: forwards` holds opacity); the class still marks chars born past the fade window.
- Settled blocks contain no `.stream-char` spans — diagnostics that count spans only see the active fade window.
- Fade is 180ms (was 280ms).

## Verification

- 33 unit tests pass (new coverage: word/char segmentation, CJK splitting, write-once style cache, legacy births/nowMs API); eslint + tsc clean.
- `streamingAnimationRepro` scenarios A/C/E: 0 skipped@birth, fade gradient intact.
- UI interactions verified end-to-end: Start/Pause/Resume/Stop, mid-stream preset switch, final render (full text, tables, KaTeX, mermaid, zero residual spans), code-block copy/collapse.
- Stream-mid KaTeX console errors are identical on baseline (pre-existing partial-formula noise, not introduced here).

