### PR TITLE
🐛 fix(base-ui): accept a bare icon component reference in Button

### DIFF
--- a/src/base-ui/Button/Button.tsx
+++ b/src/base-ui/Button/Button.tsx
@@ -1,12 +1,21 @@
 'use client';
 
 import { cx } from 'antd-style';
-import type { MouseEvent, Ref } from 'react';
+import { isValidElement, type MouseEvent, type ReactNode, type Ref } from 'react';
 
+import Icon, { type IconProps } from '@/Icon';
 import { useMotionComponent } from '@/MotionProvider';
 
 import { styles } from './style';
 import type { ButtonProps } from './type';
+
+const resolveIconNode = (node: ReactNode | IconProps['icon'] | undefined | null) => {
+  if (node === undefined || node === null) return null;
+  if (isValidElement(node) || typeof node === 'string' || typeof node === 'number') {
+    return node;
+  }
+  return <Icon icon={node as any} size={'small'} />;
+};
 
 const resolveSizeCls = (size: ButtonProps['size']) => {
   if (size === 'small') return styles.sizeSmall;
@@ -131,7 +140,7 @@ const Button = ({
   const iconNode =
     icon && !loading ? (
       <span className={cx(styles.iconBox, classNames?.icon)} style={userStyles?.icon}>
-        {icon}
+        {resolveIconNode(icon)}
       </span>
     ) : null;
 

--- a/src/base-ui/Button/demos/icons.tsx
+++ b/src/base-ui/Button/demos/icons.tsx
@@ -23,6 +23,7 @@ export default () => {
           <Button icon={<ArrowRight size={14} />} iconPosition="end" type="primary">
             Continue
           </Button>
+          <Button icon={Trash}>Bare icon component</Button>
         </Flexbox>
       </Flexbox>
 

--- a/src/base-ui/Button/index.md
+++ b/src/base-ui/Button/index.md
@@ -30,23 +30,23 @@ Compose a primary action and a dropdown menu sharing the same visual props.
 
 ## API
 
-| Property     | Description                                              | Type                                                               | Default     |
-| ------------ | -------------------------------------------------------- | ------------------------------------------------------------------ | ----------- |
-| type         | Visual style                                             | `'default' \| 'primary' \| 'dashed' \| 'fill' \| 'link' \| 'text'` | `'default'` |
-| danger       | Danger color modifier                                    | `boolean`                                                          | `false`     |
-| ghost        | Transparent background variant (for colored backgrounds) | `boolean`                                                          | `false`     |
-| size         | Button size                                              | `'small' \| 'middle' \| 'large'`                                   | `'middle'`  |
-| shape        | Button shape                                             | `'default' \| 'circle' \| 'round'`                                 | `'default'` |
-| icon         | Icon node rendered next to the children                  | `ReactNode`                                                        | -           |
-| iconPosition | Where to place the icon                                  | `'start' \| 'end'`                                                 | `'start'`   |
-| loading      | Show a spinner and disable interaction                   | `boolean`                                                          | `false`     |
-| disabled     | Disabled state                                           | `boolean`                                                          | `false`     |
-| block        | Stretch to fill container width                          | `boolean`                                                          | `false`     |
-| href         | Render as an `<a>` element                               | `string`                                                           | -           |
-| target       | Anchor target when `href` is set                         | `string`                                                           | -           |
-| htmlType     | Underlying `<button>` type when not rendered as `<a>`    | `'button' \| 'submit' \| 'reset'`                                  | `'button'`  |
-| classNames   | Per-slot class names                                     | `{ icon?: string }`                                                | -           |
-| styles       | Per-slot inline styles                                   | `{ icon?: CSSProperties }`                                         | -           |
+| Property     | Description                                                                       | Type                                                               | Default     |
+| ------------ | --------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ----------- |
+| type         | Visual style                                                                      | `'default' \| 'primary' \| 'dashed' \| 'fill' \| 'link' \| 'text'` | `'default'` |
+| danger       | Danger color modifier                                                             | `boolean`                                                          | `false`     |
+| ghost        | Transparent background variant (for colored backgrounds)                          | `boolean`                                                          | `false`     |
+| size         | Button size                                                                       | `'small' \| 'middle' \| 'large'`                                   | `'middle'`  |
+| shape        | Button shape                                                                      | `'default' \| 'circle' \| 'round'`                                 | `'default'` |
+| icon         | Icon rendered next to the children — a Lucide icon component or a ready-made node | `IconProps['icon'] \| ReactNode`                                   | -           |
+| iconPosition | Where to place the icon                                                           | `'start' \| 'end'`                                                 | `'start'`   |
+| loading      | Show a spinner and disable interaction                                            | `boolean`                                                          | `false`     |
+| disabled     | Disabled state                                                                    | `boolean`                                                          | `false`     |
+| block        | Stretch to fill container width                                                   | `boolean`                                                          | `false`     |
+| href         | Render as an `<a>` element                                                        | `string`                                                           | -           |
+| target       | Anchor target when `href` is set                                                  | `string`                                                           | -           |
+| htmlType     | Underlying `<button>` type when not rendered as `<a>`                             | `'button' \| 'submit' \| 'reset'`                                  | `'button'`  |
+| classNames   | Per-slot class names                                                              | `{ icon?: string }`                                                | -           |
+| styles       | Per-slot inline styles                                                            | `{ icon?: CSSProperties }`                                         | -           |
 
 The component forwards all standard `<button>` (or `<a>` when `href` is set) HTML attributes including `onClick`, `aria-*`, `data-*`, and `ref`.
 

--- a/src/base-ui/Button/type.ts
+++ b/src/base-ui/Button/type.ts
@@ -6,6 +6,8 @@ import type {
   Ref,
 } from 'react';
 
+import type { IconProps } from '@/Icon';
+
 export type ButtonType = 'default' | 'primary' | 'dashed' | 'fill' | 'link' | 'text';
 export type ButtonShape = 'default' | 'circle' | 'round';
 export type ButtonSize = 'small' | 'middle' | 'large';
@@ -20,7 +22,7 @@ interface BaseButtonOwnProps {
   ghost?: boolean;
   href?: string;
   htmlType?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
-  icon?: ReactNode;
+  icon?: IconProps['icon'] | ReactNode;
   iconPosition?: ButtonIconPosition;
   loading?: boolean;
   ref?: Ref<HTMLButtonElement | HTMLAnchorElement>;


### PR DESCRIPTION
## Summary
- `Button`'s `icon` prop was typed/rendered as a plain `ReactNode`, so passing a Lucide icon component reference directly (`icon={Trash}`) — the standard pattern carried over from the antd-based `Button` — silently rendered nothing, since a bare function isn't a valid React child.
- Widen `icon` to `IconProps['icon'] | ReactNode` and resolve it the same way `base-ui/Select` already resolves its `prefix`/`suffixIcon`: pass through anything that's already a valid element/string/number, otherwise wrap it in `<Icon />`.
- Updated the `icons` demo and API table to document the new accepted type.

This unblocks migrating existing `@lobehub/ui` `Button` call sites (which almost universally pass a bare icon component) over to `@lobehub/ui/base-ui`'s `Button` without having to touch every call site's `icon` prop.

## Test plan
- [x] `tsc --noEmit` clean across the whole project (validates every existing demo/call site still type-checks against the widened prop)
- [x] `eslint` clean
- [x] `dpdm` circular-dependency check clean
- [ ] Visual check of the new demo row (`icon={Trash}`) in the docs site — not captured this round; a maintainer/CI preview should confirm it renders identically to the explicit-element rows