### PR TITLE
🐛 fix: resolve base UI migration regressions

### DIFF
--- a/docs/superpowers/plans/2026-07-11-base-ui-regression-demos.md
+++ b/docs/superpowers/plans/2026-07-11-base-ui-regression-demos.md
@@ -1,0 +1,201 @@
+# Base UI Regression Demos Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add five component-local, interactive Dumi demos that make the regressions fixed by PR #560 directly verifiable.
+
+**Architecture:** Each regression receives one focused TSX demo colocated with its base-ui component. Component `index.md` files register the demos as independent sections; local React state exposes externally observable results without application fixtures or network calls.
+
+**Tech Stack:** React 19, TypeScript, Dumi code demos, `@lobehub/ui`, `@lobehub/ui/base-ui`.
+
+## Global Constraints
+
+- Each Case 2–6 has an independent demo.
+- Demos must be manually decidable from visible state.
+- No external services, authentication fixtures, application modules, or snapshots.
+- Existing component behavior and default demos remain unchanged.
+
+---
+
+### Task 1: Switch native form behavior demo
+
+**Files:**
+
+- Create: `src/base-ui/Switch/demos/nativeButton.tsx`
+- Modify: `src/base-ui/Switch/index.md`
+
+**Interfaces:**
+
+- Consumes: `Switch`, `Button`, `Flexbox`, and `Text` public components.
+- Produces: a Dumi section named `Native Button in Form`.
+
+- [ ] **Step 1: Create the interactive form demo**
+
+Implement a component with `submitCount` state, a form `onSubmit` handler that prevents navigation and increments the counter, a `Switch`, and an explicit `Button htmlType="submit"`. Display `Switch type: button` and the submission count. Toggling the Switch must leave the count unchanged.
+
+- [ ] **Step 2: Register the demo**
+
+Append this section before Atom Components in `src/base-ui/Switch/index.md`:
+
+```md
+## Native Button in Form
+
+<code src="./demos/nativeButton.tsx" nopadding></code>
+```
+
+- [ ] **Step 3: Verify lint and rendering inputs**
+
+Run: `npx eslint src/base-ui/Switch/demos/nativeButton.tsx`
+
+Expected: exit 0 with no errors.
+
+---
+
+### Task 2: Select clear contract demo
+
+**Files:**
+
+- Create: `src/base-ui/Select/demos/clearValue.tsx`
+- Modify: `src/base-ui/Select/index.md`
+
+**Interfaces:**
+
+- Consumes: controlled `Select<string>` with `allowClear` and `onChange`.
+- Produces: visible selected value and callback value displays.
+
+- [ ] **Step 1: Create the clear-value demo**
+
+Initialize the selected value to `us-west-2`. Store the latest callback value separately and render it as `undefined`, `null`, or the string value. The Select has two region options and `allowClear`; clearing it must display `Latest onChange value: undefined`.
+
+- [ ] **Step 2: Register the demo**
+
+Add a `Clear Value Contract` section to `src/base-ui/Select/index.md` pointing to `./demos/clearValue.tsx`.
+
+- [ ] **Step 3: Verify lint**
+
+Run: `npx eslint src/base-ui/Select/demos/clearValue.tsx`
+
+Expected: exit 0 with no errors.
+
+---
+
+### Task 3: Select ReactNode search demo
+
+**Files:**
+
+- Create: `src/base-ui/Select/demos/reactNodeSearch.tsx`
+- Modify: `src/base-ui/Select/index.md`
+
+**Interfaces:**
+
+- Consumes: `Select` options with ReactNode `label`, visible string `title`, and opaque string `value`.
+- Produces: a searchable Select that resolves `Claude Code` by visible title.
+
+- [ ] **Step 1: Create the search demo**
+
+Define two options whose labels contain icons and text, titles are `Lobe AI` and `Claude Code`, and values are opaque IDs. Render `Select showSearch` plus an instruction to search for `Claude`; selection state is displayed below.
+
+- [ ] **Step 2: Register the demo**
+
+Add a `ReactNode Label Search` section to `src/base-ui/Select/index.md` pointing to `./demos/reactNodeSearch.tsx`.
+
+- [ ] **Step 3: Verify lint**
+
+Run: `npx eslint src/base-ui/Select/demos/reactNodeSearch.tsx`
+
+Expected: exit 0 with no errors.
+
+---
+
+### Task 4: Select closed-popup tags demo
+
+**Files:**
+
+- Create: `src/base-ui/Select/demos/closedTags.tsx`
+- Modify: `src/base-ui/Select/index.md`
+
+**Interfaces:**
+
+- Consumes: controlled `Select<string>` with `mode="tags"`, `open={false}`, and token separators.
+- Produces: visible tag-array state.
+
+- [ ] **Step 1: Create the tags demo**
+
+Render a controlled tags Select with `open={false}`, placeholder `Type a tag and press Enter`, and separators for comma, Chinese comma, and space. Display the current array as JSON below the control.
+
+- [ ] **Step 2: Register the demo**
+
+Add a `Tags with Closed Popup` section to `src/base-ui/Select/index.md` pointing to `./demos/closedTags.tsx`.
+
+- [ ] **Step 3: Verify lint**
+
+Run: `npx eslint src/base-ui/Select/demos/closedTags.tsx`
+
+Expected: exit 0 with no errors.
+
+---
+
+### Task 5: Tabs implicit initial selection demo
+
+**Files:**
+
+- Create: `src/base-ui/Tabs/demos/implicitDefault.tsx`
+- Modify: `src/base-ui/Tabs/index.md`
+
+**Interfaces:**
+
+- Consumes: vertical `Tabs` with no `activeKey` or `defaultActiveKey`.
+- Produces: an initially visible first-enabled panel.
+
+- [ ] **Step 1: Create the initial-selection demo**
+
+Define a disabled first item followed by `Arguments` and `Response`. Render vertical Tabs without an explicit initial key and state in the instruction that `Arguments panel` must be visible immediately.
+
+- [ ] **Step 2: Register the demo**
+
+Add an `Implicit Initial Selection` section to `src/base-ui/Tabs/index.md` pointing to `./demos/implicitDefault.tsx`.
+
+- [ ] **Step 3: Verify lint**
+
+Run: `npx eslint src/base-ui/Tabs/demos/implicitDefault.tsx`
+
+Expected: exit 0 with no errors.
+
+---
+
+### Task 6: Integrated verification and PR update
+
+**Files:**
+
+- Verify all files created and modified by Tasks 1–5.
+
+**Interfaces:**
+
+- Consumes: all five Dumi registrations and existing component regression tests.
+- Produces: a pushed commit on `codex/fix-base-ui-migration-regressions`.
+
+- [ ] **Step 1: Run targeted regression tests**
+
+Run: `npm test -- --run src/base-ui/Select/__tests__ src/base-ui/Switch/__tests__/Switch.test.tsx src/base-ui/Tabs/__tests__/Tabs.test.tsx src/hooks/useNativeButton.test.tsx`
+
+Expected: 6 test files and 6 tests pass.
+
+- [ ] **Step 2: Run static verification**
+
+Run: `npm run type-check && npx eslint src/base-ui/Select/demos/*.tsx src/base-ui/Switch/demos/*.tsx src/base-ui/Tabs/demos/*.tsx`
+
+Expected: type-check exits 0; lint reports no errors in new demos.
+
+- [ ] **Step 3: Build documentation and packages**
+
+Run: `npm run docs:build && npm run build`
+
+Expected: both commands exit 0 and all referenced Dumi demos resolve.
+
+- [ ] **Step 4: Commit and push**
+
+```bash
+git add src/base-ui/Select/demos src/base-ui/Select/index.md src/base-ui/Switch/demos src/base-ui/Switch/index.md src/base-ui/Tabs/demos src/base-ui/Tabs/index.md docs/superpowers/plans/2026-07-11-base-ui-regression-demos.md
+git commit -m "📚 docs: add base UI regression demos"
+git push
+```

--- a/docs/superpowers/plans/2026-07-11-base-ui-regression-demos.md
+++ b/docs/superpowers/plans/2026-07-11-base-ui-regression-demos.md
@@ -199,3 +199,45 @@ git add src/base-ui/Select/demos src/base-ui/Select/index.md src/base-ui/Switch/
 git commit -m "📚 docs: add base UI regression demos"
 git push
 ```
+
+---
+
+### Task 7: Select popup search list spacing
+
+**Files:**
+
+- Modify: `src/base-ui/Select/Select.tsx`
+- Modify: `src/base-ui/Select/parts.tsx`
+- Modify: `src/base-ui/Select/style.ts`
+- Test: `src/base-ui/Select/__tests__/Select.searchSpacing.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `shouldShowSearch` from `useSelectSearch` and `SelectListSection`.
+- Produces: conditional `4px` block-start padding on lists that follow a popup search field.
+
+- [ ] **Step 1: Write the failing spacing test**
+
+Render an open searchable Select, locate its listbox, and assert that `getComputedStyle(listbox).paddingTop` is `4px`. Render a second open Select without `showSearch` and assert its listbox padding-top remains `0px`.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `npm test -- --run src/base-ui/Select/__tests__/Select.searchSpacing.test.tsx`
+
+Expected: the searchable Select assertion fails with received padding `0px`.
+
+- [ ] **Step 3: Implement conditional list spacing**
+
+Add a `hasSearch` boolean to `SelectListSection`, compose a `listWithSearch` class when true, define `padding-block-start: 4px`, and pass `shouldShowSearch && !isTags` from `Select.tsx`.
+
+- [ ] **Step 4: Verify GREEN and regressions**
+
+Run: `npm test -- --run src/base-ui/Select/__tests__`
+
+Expected: all Select regression tests pass.
+
+- [ ] **Step 5: Run static and build verification**
+
+Run: `npm run type-check && npx eslint src/base-ui/Select/Select.tsx src/base-ui/Select/parts.tsx src/base-ui/Select/style.ts src/base-ui/Select/__tests__/Select.searchSpacing.test.tsx && npm run build`
+
+Expected: all commands exit 0; existing Select lint warnings may remain unchanged.

--- a/docs/superpowers/specs/2026-07-11-base-ui-regression-demos-design.md
+++ b/docs/superpowers/specs/2026-07-11-base-ui-regression-demos-design.md
@@ -1,0 +1,50 @@
+# Base UI Regression Demos Design
+
+## Objective
+
+Add one interactive documentation demo for each confirmed migration regression fixed by PR #560. The demos provide direct manual verification without requiring the LobeHub application, authentication, or seeded product data.
+
+## Placement
+
+The demos remain next to the component whose contract they verify:
+
+| Case | Component page | Demo behavior                                                                                                                    |
+| ---- | -------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| 2    | Switch         | Render a Switch inside a form and expose its native button type and form submission count                                        |
+| 3    | Select         | Select a value, clear it, and display the latest external value including `undefined`                                            |
+| 4    | Select         | Search options whose labels are React nodes and whose visible names come from `title`                                            |
+| 5    | Select         | Enter tags while `open={false}` and display the resulting tag array                                                              |
+| 6    | Tabs           | Render vertical Tabs without an explicit initial key, with the first item disabled, and show the first enabled panel immediately |
+
+Select receives three separate demos because each case verifies an independent public contract. Switch and Tabs each receive one demo. Existing default and atom demos remain unchanged.
+
+## Interaction Design
+
+Each demo includes a short instruction and a visible result area. A reviewer must be able to determine success from the rendered page alone:
+
+- Switch toggling must not submit its surrounding form; an explicit submit action remains available to prove the counter works.
+- Select clear must visibly report `undefined`, distinguishing it from `null`.
+- ReactNode search must return the expected visible option when its title is entered.
+- Tags input must accept Enter and configured separators while the popup is forced closed.
+- Tabs must show the first enabled panel on initial render without a preliminary click.
+
+The demos use existing Lobe UI layout and typography components and local React state. They do not call external services or depend on application-specific modules.
+
+## Alternatives Considered
+
+1. **Component-local demos (selected):** discoverable beside the API and independently reusable during component development.
+2. **One consolidated regression page:** convenient for a single verification pass, but disconnected from component documentation and harder to maintain.
+3. **Storybook-only fixtures:** suitable for visual regression infrastructure, but this repository already exposes these base-ui components through Dumi documentation.
+
+## Validation
+
+- Run targeted lint over all new demo and documentation registration files.
+- Run the existing regression tests for Select, Switch, and Tabs.
+- Run TypeScript type checking.
+- Run the complete documentation/package build to confirm every Dumi code block resolves.
+
+## Non-goals
+
+- Reproducing LobeHub application screens or product data.
+- Adding network requests, authentication fixtures, or visual snapshot tests.
+- Changing the component fixes already included in PR #560.

--- a/docs/superpowers/specs/2026-07-11-base-ui-regression-demos-design.md
+++ b/docs/superpowers/specs/2026-07-11-base-ui-regression-demos-design.md
@@ -30,6 +30,12 @@ Each demo includes a short instruction and a visible result area. A reviewer mus
 
 The demos use existing Lobe UI layout and typography components and local React state. They do not call external services or depend on application-specific modules.
 
+## Select Search List Spacing
+
+The ReactNode search demo exposed a missing separation between the popup search field and the first option. When a popup search field is rendered, the Select list receives `4px` of block-start padding. This matches the existing DropdownMenu spacing scale while preserving the search divider and individual option heights.
+
+The spacing is conditional: Select popups without a search field keep their existing list geometry. The inline tags input is not a popup search field and does not activate this padding.
+
 ## Alternatives Considered
 
 1. **Component-local demos (selected):** discoverable beside the API and independently reusable during component development.
@@ -48,3 +54,4 @@ The demos use existing Lobe UI layout and typography components and local React 
 - Reproducing LobeHub application screens or product data.
 - Adding network requests, authentication fixtures, or visual snapshot tests.
 - Changing the component fixes already included in PR #560.
+- Changing popup spacing for Select instances without a search field.

--- a/src/base-ui/Select/Select.tsx
+++ b/src/base-ui/Select/Select.tsx
@@ -294,6 +294,7 @@ const Select = memo<SelectProps<any>>(
               )}
               <SelectListSection
                 classNames={classNames}
+                hasSearch={shouldShowSearch && !isTags}
                 isEmpty={isEmpty}
                 listContent={listContent}
                 listItemHeight={listItemHeight}

--- a/src/base-ui/Select/Select.tsx
+++ b/src/base-ui/Select/Select.tsx
@@ -239,7 +239,9 @@ const Select = memo<SelectProps<any>>(
           {prefixNode !== null && prefixNode !== undefined && (
             <span className={cx(styles.prefix, classNames?.prefix)}>{prefixNode}</span>
           )}
-          <BaseSelect.Value className={cx(styles.value, classNames?.value)}>
+          <BaseSelect.Value
+            className={cx(styles.value, isTags && styles.tagsValue, classNames?.value)}
+          >
             {renderValue}
           </BaseSelect.Value>
           {isTags && (

--- a/src/base-ui/Select/Select.tsx
+++ b/src/base-ui/Select/Select.tsx
@@ -90,6 +90,7 @@ const Select = memo<SelectProps<any>>(
       handleValueChange,
       normalizedValue,
       normalizeValue,
+      removeLastTagValue,
       resolvedOptions,
       valueArray,
     } = useSelectValue({
@@ -105,6 +106,19 @@ const Select = memo<SelectProps<any>>(
 
     const { handleOpenChange, mergedOpen } = useSelectOpen({ defaultOpen, onOpenChange, open });
 
+    const handleRootValueChange = useCallback(
+      (nextValue: any) => {
+        const isClosedTagsReset =
+          isTags &&
+          !mergedOpen &&
+          Array.isArray(nextValue) &&
+          nextValue.length === 0 &&
+          valueArray.length > 0;
+        if (!isClosedTagsReset) handleValueChange(nextValue);
+      },
+      [handleValueChange, isTags, mergedOpen, valueArray.length],
+    );
+
     const {
       filteredOptions,
       handleSearchChange,
@@ -117,6 +131,7 @@ const Select = memo<SelectProps<any>>(
       handleOpenChange,
       mergedOpen,
       mode,
+      removeLastTagValue,
       resolvedOptions,
       showSearch,
       tokenSeparators,
@@ -226,7 +241,7 @@ const Select = memo<SelectProps<any>>(
         required={required}
         value={normalizedValue}
         onOpenChange={handleOpenChange}
-        onValueChange={handleValueChange}
+        onValueChange={handleRootValueChange}
       >
         <BaseSelect.Trigger
           autoFocus={!isTags && autoFocus}

--- a/src/base-ui/Select/Select.tsx
+++ b/src/base-ui/Select/Select.tsx
@@ -108,15 +108,15 @@ const Select = memo<SelectProps<any>>(
 
     const handleRootValueChange = useCallback(
       (nextValue: any) => {
-        const isClosedTagsReset =
-          isTags &&
-          !mergedOpen &&
-          Array.isArray(nextValue) &&
-          nextValue.length === 0 &&
-          valueArray.length > 0;
-        if (!isClosedTagsReset) handleValueChange(nextValue);
+        if (!(isTags && !mergedOpen)) handleValueChange(nextValue);
       },
-      [handleValueChange, isTags, mergedOpen, valueArray.length],
+      [handleValueChange, isTags, mergedOpen],
+    );
+
+    const handleRemoveTag = useCallback(
+      (index: number) =>
+        handleValueChange(valueArray.filter((_, itemIndex) => itemIndex !== index)),
+      [handleValueChange, valueArray],
     );
 
     const {
@@ -152,11 +152,13 @@ const Select = memo<SelectProps<any>>(
         createTriggerValueRenderer({
           getOption,
           isMultiple,
+          isTags,
           labelRender,
           normalizeValue,
+          onRemoveValue: handleRemoveTag,
           placeholder: isTags ? undefined : placeholder,
         }),
-      [getOption, isMultiple, isTags, labelRender, normalizeValue, placeholder],
+      [getOption, handleRemoveTag, isMultiple, isTags, labelRender, normalizeValue, placeholder],
     );
 
     const hasValue = isMultiple ? valueArray.length > 0 : !isValueEmpty(normalizedValue);

--- a/src/base-ui/Select/Select.tsx
+++ b/src/base-ui/Select/Select.tsx
@@ -72,6 +72,7 @@ const Select = memo<SelectProps<any>>(
   }) => {
     const { isDarkMode } = useThemeMode();
     const resolvedVariant = variant ?? (isDarkMode ? 'filled' : 'outlined');
+    const isTags = mode === 'tags';
     const isMultiple = mode === 'multiple' || mode === 'tags';
     const isItemAligned = behaviorVariant === 'item-aligned';
 
@@ -138,9 +139,9 @@ const Select = memo<SelectProps<any>>(
           isMultiple,
           labelRender,
           normalizeValue,
-          placeholder,
+          placeholder: isTags ? undefined : placeholder,
         }),
-      [getOption, isMultiple, labelRender, normalizeValue, placeholder],
+      [getOption, isMultiple, isTags, labelRender, normalizeValue, placeholder],
     );
 
     const hasValue = isMultiple ? valueArray.length > 0 : !isValueEmpty(normalizedValue);
@@ -228,9 +229,11 @@ const Select = memo<SelectProps<any>>(
         onValueChange={handleValueChange}
       >
         <BaseSelect.Trigger
-          autoFocus={autoFocus}
+          autoFocus={!isTags && autoFocus}
           className={triggerClassName}
           disabled={disabled}
+          nativeButton={!isTags}
+          render={isTags ? <div /> : undefined}
           style={style}
         >
           {prefixNode !== null && prefixNode !== undefined && (
@@ -239,6 +242,20 @@ const Select = memo<SelectProps<any>>(
           <BaseSelect.Value className={cx(styles.value, classNames?.value)}>
             {renderValue}
           </BaseSelect.Value>
+          {isTags && (
+            <SelectSearchInput
+              inline
+              autoFocus={autoFocus}
+              classNames={classNames}
+              disabled={disabled}
+              placeholder={valueArray.length === 0 ? placeholder : undefined}
+              readOnly={readOnly}
+              stopPropagation={stopSearchPropagation}
+              value={searchValue}
+              onChange={handleSearchChange}
+              onKeyDown={handleSearchKeyDown}
+            />
+          )}
           <SelectTriggerSuffix
             classNames={classNames}
             showClear={showClear}
@@ -265,7 +282,7 @@ const Select = memo<SelectProps<any>>(
                 classNames?.dropdown,
               )}
             >
-              {shouldShowSearch && (
+              {shouldShowSearch && !isTags && (
                 <SelectSearchInput
                   classNames={classNames}
                   placeholder={placeholder}

--- a/src/base-ui/Select/__tests__/Select.searchSpacing.test.tsx
+++ b/src/base-ui/Select/__tests__/Select.searchSpacing.test.tsx
@@ -1,0 +1,30 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { motion } from 'motion/react';
+
+import ConfigProvider from '@/ConfigProvider';
+
+import Select from '../Select';
+
+const options = [{ label: 'Lobe AI', value: 'lobe-ai' }];
+
+describe('Select popup search spacing', () => {
+  test('adds top padding only when the popup search field is present', () => {
+    render(
+      <ConfigProvider motion={motion}>
+        <Select open showSearch options={options} placeholder="Search agents" />
+      </ConfigProvider>,
+    );
+
+    expect(getComputedStyle(screen.getByRole('listbox')).paddingBlockStart).toBe('4px');
+
+    cleanup();
+
+    render(
+      <ConfigProvider motion={motion}>
+        <Select open options={options} />
+      </ConfigProvider>,
+    );
+
+    expect(getComputedStyle(screen.getByRole('listbox')).paddingBlockStart).not.toBe('4px');
+  });
+});

--- a/src/base-ui/Select/__tests__/Select.tags.test.tsx
+++ b/src/base-ui/Select/__tests__/Select.tags.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { motion } from 'motion/react';
+
+import ConfigProvider from '@/ConfigProvider';
+
+import Select from '../Select';
+
+describe('Select tags mode', () => {
+  test('accepts a tag while the popup is controlled closed', () => {
+    const onChange = vi.fn();
+
+    render(
+      <ConfigProvider motion={motion}>
+        <Select mode="tags" open={false} placeholder="Add tags" onChange={onChange} />
+      </ConfigProvider>,
+    );
+
+    const input = screen.getByPlaceholderText('Add tags');
+    fireEvent.change(input, { target: { value: 'benchmark' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onChange).toHaveBeenCalledWith(
+      ['benchmark'],
+      [expect.objectContaining({ label: 'benchmark', value: 'benchmark' })],
+    );
+  });
+});

--- a/src/base-ui/Select/__tests__/Select.tags.test.tsx
+++ b/src/base-ui/Select/__tests__/Select.tags.test.tsx
@@ -6,6 +6,18 @@ import ConfigProvider from '@/ConfigProvider';
 import Select from '../Select';
 
 describe('Select tags mode', () => {
+  test('lets the inline input use the full width when there are no tags', () => {
+    render(
+      <ConfigProvider motion={motion}>
+        <Select mode="tags" open={false} placeholder="Add tags" />
+      </ConfigProvider>,
+    );
+
+    const value = screen.getByRole('combobox').querySelector('span[data-placeholder]');
+
+    expect(getComputedStyle(value!).flex).toBe('0 0 auto');
+  });
+
   test('accepts a tag while the popup is controlled closed', () => {
     const onChange = vi.fn();
 

--- a/src/base-ui/Select/__tests__/Select.tags.test.tsx
+++ b/src/base-ui/Select/__tests__/Select.tags.test.tsx
@@ -48,6 +48,47 @@ describe('Select tags mode', () => {
     expect(screen.getByRole('combobox').textContent).not.toContain('second');
   });
 
+  test('keeps tag order when adding a duplicate and removes a tag from its close control', () => {
+    const ControlledTags = () => {
+      const [value, setValue] = useState<string[]>([]);
+
+      return (
+        <>
+          <ConfigProvider motion={motion}>
+            <Select
+              mode="tags"
+              open={false}
+              value={value}
+              onChange={(nextValue) => setValue(Array.isArray(nextValue) ? nextValue : [])}
+            />
+          </ConfigProvider>
+          <output data-testid="tags-value">{JSON.stringify(value)}</output>
+        </>
+      );
+    };
+
+    render(<ControlledTags />);
+
+    const input = screen.getByRole('textbox');
+    for (const tag of ['first', 'second', 'third', 'second']) {
+      fireEvent.change(input, { target: { value: tag } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+    }
+
+    const trigger = screen.getByRole('combobox');
+    expect(screen.getByTestId('tags-value').textContent).toBe('["first","second","third"]');
+    expect(trigger.querySelectorAll('[data-role="lobe-select-tag"]')).toHaveLength(3);
+    expect(trigger.textContent).toContain('first');
+    expect(trigger.textContent).toContain('second');
+    expect(trigger.textContent).toContain('third');
+
+    fireEvent.click(trigger.querySelectorAll('[data-role="lobe-select-tag-remove"]')[1]);
+
+    expect(trigger.textContent).toContain('first');
+    expect(trigger.textContent).not.toContain('second');
+    expect(trigger.textContent).toContain('third');
+  });
+
   test('lets the inline input use the full width when there are no tags', () => {
     render(
       <ConfigProvider motion={motion}>

--- a/src/base-ui/Select/__tests__/Select.tags.test.tsx
+++ b/src/base-ui/Select/__tests__/Select.tags.test.tsx
@@ -1,11 +1,53 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { motion } from 'motion/react';
+import { useState } from 'react';
 
 import ConfigProvider from '@/ConfigProvider';
 
 import Select from '../Select';
 
 describe('Select tags mode', () => {
+  test('adds multiple tags and removes the last tag with Backspace', () => {
+    const onChange = vi.fn();
+    const ControlledTags = () => {
+      const [value, setValue] = useState<string[]>([]);
+
+      return (
+        <ConfigProvider motion={motion}>
+          <Select
+            mode="tags"
+            open={false}
+            value={value}
+            onChange={(nextValue) => {
+              onChange(nextValue);
+              setValue(Array.isArray(nextValue) ? nextValue : []);
+            }}
+          />
+        </ConfigProvider>
+      );
+    };
+
+    render(<ControlledTags />);
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'first' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    fireEvent.change(input, { target: { value: 'second' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onChange.mock.calls.map(([nextValue]) => nextValue)).toEqual([
+      ['first'],
+      ['first', 'second'],
+    ]);
+    expect(screen.getByRole('combobox').textContent).toContain('first');
+    expect(screen.getByRole('combobox').textContent).toContain('second');
+
+    fireEvent.keyDown(input, { key: 'Backspace' });
+
+    expect(screen.getByRole('combobox').textContent).toContain('first');
+    expect(screen.getByRole('combobox').textContent).not.toContain('second');
+  });
+
   test('lets the inline input use the full width when there are no tags', () => {
     render(
       <ConfigProvider motion={motion}>

--- a/src/base-ui/Select/__tests__/helpers.test.tsx
+++ b/src/base-ui/Select/__tests__/helpers.test.tsx
@@ -1,0 +1,13 @@
+import { getOptionSearchText } from '../helpers';
+
+describe('getOptionSearchText', () => {
+  test('uses the visible title when the label is a React node', () => {
+    expect(
+      getOptionSearchText({
+        label: <span>Claude Code</span>,
+        title: 'Claude Code',
+        value: 'opaque-agent-id',
+      }),
+    ).toBe('Claude Code');
+  });
+});

--- a/src/base-ui/Select/__tests__/useSelectValue.test.tsx
+++ b/src/base-ui/Select/__tests__/useSelectValue.test.tsx
@@ -1,0 +1,26 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useSelectValue } from '../hooks';
+
+describe('useSelectValue', () => {
+  test('emits undefined when a single select is cleared', () => {
+    const onChange = vi.fn();
+    const setExtraOptions = vi.fn();
+    const { result } = renderHook(() =>
+      useSelectValue({
+        defaultValue: undefined,
+        extraOptions: [],
+        isMultiple: false,
+        onChange,
+        onSelect: undefined,
+        options: [{ label: 'US West', value: 'us-west-2' }],
+        setExtraOptions,
+        value: 'us-west-2',
+      }),
+    );
+
+    act(() => result.current.handleValueChange(null));
+
+    expect(onChange).toHaveBeenCalledWith(undefined, undefined);
+  });
+});

--- a/src/base-ui/Select/demos/clearValue.tsx
+++ b/src/base-ui/Select/demos/clearValue.tsx
@@ -1,0 +1,31 @@
+import { Flexbox, Text } from '@lobehub/ui';
+import { Select } from '@lobehub/ui/base-ui';
+import { useState } from 'react';
+
+const options = [
+  { label: 'US East', value: 'us-east-1' },
+  { label: 'US West', value: 'us-west-2' },
+];
+
+export default () => {
+  const [latestValue, setLatestValue] = useState<string | undefined>('us-west-2');
+  const [value, setValue] = useState<string | undefined>('us-west-2');
+
+  return (
+    <Flexbox gap={12}>
+      <Text>Select a region, then clear it. The callback value must become undefined.</Text>
+      <Select
+        allowClear
+        options={options}
+        placeholder="Select a region"
+        style={{ width: '100%' }}
+        value={value}
+        onChange={(nextValue) => {
+          setValue(nextValue as string | undefined);
+          setLatestValue(nextValue as string | undefined);
+        }}
+      />
+      <Text code>Latest onChange value: {String(latestValue)}</Text>
+    </Flexbox>
+  );
+};

--- a/src/base-ui/Select/demos/closedTags.tsx
+++ b/src/base-ui/Select/demos/closedTags.tsx
@@ -1,0 +1,23 @@
+import { Flexbox, Text } from '@lobehub/ui';
+import { Select } from '@lobehub/ui/base-ui';
+import { useState } from 'react';
+
+export default () => {
+  const [tags, setTags] = useState<string[]>([]);
+
+  return (
+    <Flexbox gap={12}>
+      <Text>The popup is forced closed. Type a tag and press Enter, comma, or space.</Text>
+      <Select
+        mode="tags"
+        open={false}
+        placeholder="Type a tag and press Enter"
+        style={{ width: '100%' }}
+        tokenSeparators={[',', '，', ' ']}
+        value={tags}
+        onChange={(nextValue) => setTags(Array.isArray(nextValue) ? nextValue : [])}
+      />
+      <Text code>Tags: {JSON.stringify(tags)}</Text>
+    </Flexbox>
+  );
+};

--- a/src/base-ui/Select/demos/reactNodeSearch.tsx
+++ b/src/base-ui/Select/demos/reactNodeSearch.tsx
@@ -1,0 +1,48 @@
+import { Flexbox, Text } from '@lobehub/ui';
+import { Select } from '@lobehub/ui/base-ui';
+import { BotIcon, TerminalIcon } from 'lucide-react';
+import { useState } from 'react';
+
+const options = [
+  {
+    label: (
+      <Flexbox horizontal align="center" gap={8}>
+        <BotIcon size={16} />
+        Lobe AI
+      </Flexbox>
+    ),
+    title: 'Lobe AI',
+    value: 'agent_7f13b6',
+  },
+  {
+    label: (
+      <Flexbox horizontal align="center" gap={8}>
+        <TerminalIcon size={16} />
+        Claude Code
+      </Flexbox>
+    ),
+    title: 'Claude Code',
+    value: 'agent_91ac42',
+  },
+];
+
+export default () => {
+  const [value, setValue] = useState<string>();
+
+  return (
+    <Flexbox gap={12}>
+      <Text>
+        Open the Select and search for “Claude”. The Claude Code option must remain visible.
+      </Text>
+      <Select
+        showSearch
+        options={options}
+        placeholder="Search agents"
+        style={{ width: '100%' }}
+        value={value}
+        onChange={(nextValue) => setValue(nextValue as string | undefined)}
+      />
+      <Text code>Selected opaque value: {value ?? 'undefined'}</Text>
+    </Flexbox>
+  );
+};

--- a/src/base-ui/Select/helpers.ts
+++ b/src/base-ui/Select/helpers.ts
@@ -8,10 +8,10 @@ export const getOptionSearchText = <Value>(option: SelectOption<Value>) => {
   if (typeof option.label === 'string' || typeof option.label === 'number') {
     return String(option.label);
   }
+  if (option.title) return option.title;
   if (typeof option.value === 'string' || typeof option.value === 'number') {
     return String(option.value);
   }
-  if (option.title) return option.title;
   return '';
 };
 

--- a/src/base-ui/Select/hooks.tsx
+++ b/src/base-ui/Select/hooks.tsx
@@ -143,7 +143,7 @@ export function useSelectValue({
         }
         if (value === undefined) setUncontrolledValue(normalizedNextValue);
         onChange?.(
-          normalizedNextValue,
+          isValueEmpty(normalizedNextValue) ? undefined : normalizedNextValue,
           isValueEmpty(normalizedNextValue) ? undefined : getOption(normalizedNextValue),
         );
       }

--- a/src/base-ui/Select/hooks.tsx
+++ b/src/base-ui/Select/hooks.tsx
@@ -158,7 +158,10 @@ export function useSelectValue({
       const valuesToAdd = rawValues.map((val) => val.trim()).filter(Boolean);
       if (!valuesToAdd.length) return;
 
-      const nextValues = [...valueArray];
+      const currentValues = Array.isArray(previousValueRef.current)
+        ? previousValueRef.current
+        : valueArray;
+      const nextValues = [...currentValues];
       const newOptionValues = valuesToAdd.filter((val) => !optionMap.has(val));
 
       if (newOptionValues.length > 0) {
@@ -187,6 +190,13 @@ export function useSelectValue({
     [handleValueChange, optionMap, setExtraOptions, valueArray],
   );
 
+  const removeLastTagValue = useCallback(() => {
+    const currentValues = Array.isArray(previousValueRef.current)
+      ? previousValueRef.current
+      : valueArray;
+    if (currentValues.length > 0) handleValueChange(currentValues.slice(0, -1));
+  }, [handleValueChange, valueArray]);
+
   return {
     appendTagValues,
     getOption,
@@ -195,6 +205,7 @@ export function useSelectValue({
     normalizeValue,
     optionMap,
     resolvedOptions,
+    removeLastTagValue,
     valueArray,
   };
 }
@@ -230,6 +241,7 @@ interface UseSelectSearchParams {
   handleOpenChange: (nextOpen: boolean) => void;
   mergedOpen: boolean;
   mode: SelectProps['mode'];
+  removeLastTagValue: () => void;
   resolvedOptions: SelectOptions;
   showSearch: boolean | undefined;
   tokenSeparators: string[] | undefined;
@@ -240,6 +252,7 @@ export function useSelectSearch({
   handleOpenChange,
   mergedOpen,
   mode,
+  removeLastTagValue,
   resolvedOptions,
   showSearch,
   tokenSeparators,
@@ -278,6 +291,12 @@ export function useSelectSearch({
       }
       if (mode !== 'tags') return;
 
+      if (event.key === 'Backspace' && !searchValue) {
+        event.preventDefault();
+        removeLastTagValue();
+        return;
+      }
+
       const isSeparator = tokenSeparators?.includes(event.key);
       if (event.key === 'Enter' || isSeparator) {
         event.preventDefault();
@@ -286,7 +305,7 @@ export function useSelectSearch({
         setSearchValue('');
       }
     },
-    [appendTagValues, handleOpenChange, mode, searchValue, tokenSeparators],
+    [appendTagValues, handleOpenChange, mode, removeLastTagValue, searchValue, tokenSeparators],
   );
 
   // Stop propagation in capture phase + on keyup to block base-ui Popup-level

--- a/src/base-ui/Select/index.md
+++ b/src/base-ui/Select/index.md
@@ -14,6 +14,18 @@ apiHeader:
 
 <code src="./demos/index.tsx" nopadding></code>
 
+## Clear Value Contract
+
+<code src="./demos/clearValue.tsx" nopadding></code>
+
+## ReactNode Label Search
+
+<code src="./demos/reactNodeSearch.tsx" nopadding></code>
+
+## Tags with Closed Popup
+
+<code src="./demos/closedTags.tsx" nopadding></code>
+
 ## Atom Components
 
 <code src="./demos/atoms.tsx" nopadding></code>

--- a/src/base-ui/Select/parts.tsx
+++ b/src/base-ui/Select/parts.tsx
@@ -58,16 +58,20 @@ export function resolveSuffixIcon(
 interface TriggerValueRendererParams {
   getOption: (value: any) => SelectOption<any>;
   isMultiple: boolean;
+  isTags: boolean;
   labelRender: SelectProps['labelRender'];
   normalizeValue: (value: any) => any;
+  onRemoveValue: (index: number) => void;
   placeholder: ReactNode;
 }
 
 export function createTriggerValueRenderer({
   getOption,
   isMultiple,
+  isTags,
   labelRender,
   normalizeValue,
+  onRemoveValue,
   placeholder,
 }: TriggerValueRendererParams) {
   return function renderValue(currentValue: any): ReactNode {
@@ -84,8 +88,32 @@ export function createTriggerValueRenderer({
             const option = getOption(val);
             const content = labelRender ? labelRender(option) : (option.label ?? String(val));
             return (
-              <span className={styles.tag} key={`${String(val)}-${index}`}>
+              <span
+                className={styles.tag}
+                data-role="lobe-select-tag"
+                key={`${String(val)}-${index}`}
+              >
                 {content}
+                {isTags && (
+                  <span
+                    aria-label={`Remove ${String(val)}`}
+                    className={styles.tagClose}
+                    data-role="lobe-select-tag-remove"
+                    role="button"
+                    tabIndex={0}
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      onRemoveValue(index);
+                    }}
+                    onPointerDown={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                    }}
+                  >
+                    <X size={12} />
+                  </span>
+                )}
               </span>
             );
           })}

--- a/src/base-ui/Select/parts.tsx
+++ b/src/base-ui/Select/parts.tsx
@@ -164,31 +164,41 @@ export function EmptyContent({ classNames }: EmptyContentProps) {
 }
 
 interface SelectSearchInputProps {
+  autoFocus?: boolean;
   classNames: SelectClassNames | undefined;
+  disabled?: boolean;
+  inline?: boolean;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   onKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
   placeholder: ReactNode;
+  readOnly?: boolean;
   stopPropagation: (event: KeyboardEvent<HTMLInputElement>) => void;
   value: string;
 }
 
 export function SelectSearchInput({
+  autoFocus,
   classNames,
+  disabled,
+  inline,
   onChange,
   onKeyDown,
   placeholder,
+  readOnly,
   stopPropagation,
   value,
 }: SelectSearchInputProps) {
   return (
-    <div className={cx(styles.search, classNames?.search)}>
+    <div className={cx(inline ? styles.tagsSearch : styles.search, classNames?.search)}>
       <input
+        autoFocus={autoFocus}
         className={styles.searchInput}
+        disabled={disabled}
         placeholder={typeof placeholder === 'string' ? placeholder : undefined}
+        readOnly={readOnly}
         value={value}
         onChange={onChange}
-        onKeyDown={onKeyDown}
-        onKeyDownCapture={stopPropagation}
+        onKeyDownCapture={onKeyDown}
         onKeyUp={stopPropagation}
         onKeyUpCapture={stopPropagation}
       />

--- a/src/base-ui/Select/parts.tsx
+++ b/src/base-ui/Select/parts.tsx
@@ -104,6 +104,7 @@ type SelectVirtualReturn = ReturnType<typeof useSelectVirtual>;
 
 interface SelectListSectionProps {
   classNames: SelectClassNames | undefined;
+  hasSearch: boolean;
   isEmpty: boolean;
   listContent: ReactNode;
   listItemHeight: number | undefined;
@@ -113,13 +114,14 @@ interface SelectListSectionProps {
 
 export function SelectListSection({
   classNames,
+  hasSearch,
   isEmpty,
   listContent,
   listItemHeight,
   virtual,
   virtualState,
 }: SelectListSectionProps) {
-  const listClassName = cx(styles.list, classNames?.list);
+  const listClassName = cx(styles.list, hasSearch && styles.listWithSearch, classNames?.list);
 
   if (!virtual || isEmpty) {
     return (

--- a/src/base-ui/Select/style.ts
+++ b/src/base-ui/Select/style.ts
@@ -194,6 +194,11 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     gap: 4px;
     align-items: center;
   `,
+  tagsSearch: css`
+    display: flex;
+    flex: 1;
+    min-width: 48px;
+  `,
   trigger: css`
     cursor: pointer;
     user-select: none;

--- a/src/base-ui/Select/style.ts
+++ b/src/base-ui/Select/style.ts
@@ -197,6 +197,9 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     gap: 4px;
     align-items: center;
   `,
+  tagsValue: css`
+    flex: none;
+  `,
   tagsSearch: css`
     display: flex;
     flex: 1;

--- a/src/base-ui/Select/style.ts
+++ b/src/base-ui/Select/style.ts
@@ -190,6 +190,25 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     color: ${cssVar.colorText};
 
     background: ${cssVar.colorFillTertiary};
+
+    &:hover [data-role='lobe-select-tag-remove'] {
+      opacity: 1;
+    }
+  `,
+  tagClose: css`
+    cursor: pointer;
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    margin-inline-start: 4px;
+
+    color: ${cssVar.colorTextSecondary};
+
+    opacity: 0;
+
+    transition: opacity 150ms ${cssVar.motionEaseOut};
   `,
   tags: css`
     display: flex;

--- a/src/base-ui/Select/style.ts
+++ b/src/base-ui/Select/style.ts
@@ -82,6 +82,9 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     max-height: var(--lobe-select-available-height, var(--available-height));
     padding-block: 0;
   `,
+  listWithSearch: css`
+    padding-block-start: 4px;
+  `,
   outlined: cx(
     lobeStaticStylish.variantOutlined,
     css`

--- a/src/base-ui/Select/type.ts
+++ b/src/base-ui/Select/type.ts
@@ -82,7 +82,7 @@ export interface SelectProps<Value = string> {
   mode?: 'multiple' | 'tags';
   name?: string;
   onChange?: (
-    value: Value | Value[] | null,
+    value: Value | Value[] | null | undefined,
     option?: SelectOption<Value> | SelectOption<Value>[],
   ) => void;
   onOpenChange?: (open: boolean, eventDetails?: SelectRootChangeEventDetails) => void;

--- a/src/base-ui/Switch/__tests__/Switch.test.tsx
+++ b/src/base-ui/Switch/__tests__/Switch.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { motion } from 'motion/react';
+
+import ConfigProvider from '@/ConfigProvider';
+
+import Switch from '../Switch';
+
+describe('Switch', () => {
+  test('uses native button semantics without Base UI composition errors', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <ConfigProvider motion={motion}>
+        <form>
+          <Switch />
+        </form>
+      </ConfigProvider>,
+    );
+
+    expect(screen.getByRole('switch').getAttribute('type')).toBe('button');
+    expect(consoleError.mock.calls.flat().join(' ')).not.toContain('nativeButton');
+
+    consoleError.mockRestore();
+  });
+});

--- a/src/base-ui/Switch/atoms.tsx
+++ b/src/base-ui/Switch/atoms.tsx
@@ -93,6 +93,7 @@ export const SwitchRoot = ({
   return (
     <SwitchContext value={contextValue}>
       <Switch.Root
+        nativeButton
         checked={isChecked}
         defaultChecked={defaultChecked}
         disabled={disabled}

--- a/src/base-ui/Switch/demos/nativeButton.tsx
+++ b/src/base-ui/Switch/demos/nativeButton.tsx
@@ -1,0 +1,33 @@
+import { Button, Flexbox, Text } from '@lobehub/ui';
+import { Switch } from '@lobehub/ui/base-ui';
+import { useState } from 'react';
+
+export default () => {
+  const [checked, setChecked] = useState(false);
+  const [submitCount, setSubmitCount] = useState(0);
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        setSubmitCount((count) => count + 1);
+      }}
+    >
+      <Flexbox gap={12}>
+        <Text>
+          Toggle the Switch. The submission count must remain unchanged because its native type is
+          button.
+        </Text>
+        <Flexbox horizontal align="center" gap={8}>
+          <Switch checked={checked} onChange={setChecked} />
+          <Text>Switch state: {checked ? 'on' : 'off'}</Text>
+        </Flexbox>
+        <Text code>Switch type: button</Text>
+        <Text code>Form submissions: {submitCount}</Text>
+        <Button htmlType="submit" style={{ alignSelf: 'flex-start' }}>
+          Submit form explicitly
+        </Button>
+      </Flexbox>
+    </form>
+  );
+};

--- a/src/base-ui/Switch/index.md
+++ b/src/base-ui/Switch/index.md
@@ -14,6 +14,10 @@ apiHeader:
 
 <code src="./demos/index.tsx" nopadding></code>
 
+## Native Button in Form
+
+<code src="./demos/nativeButton.tsx" nopadding></code>
+
 ## Atom Components
 
 <code src="./demos/atoms.tsx" nopadding></code>

--- a/src/base-ui/Tabs/Tabs.tsx
+++ b/src/base-ui/Tabs/Tabs.tsx
@@ -22,8 +22,9 @@ const Tabs: FC<TabsProps> = ({
   styles: customStyles,
   variant = 'rounded',
 }) => {
-  const [value, setValue] = useControlledState<string | null>(defaultActiveKey ?? null, {
-    defaultValue: defaultActiveKey,
+  const initialActiveKey = defaultActiveKey ?? items?.find((item) => !item.disabled)?.key ?? null;
+  const [value, setValue] = useControlledState<string | null>(initialActiveKey, {
+    defaultValue: initialActiveKey,
     onChange: (next) => {
       if (next != null) onChange?.(next);
     },

--- a/src/base-ui/Tabs/__tests__/Tabs.test.tsx
+++ b/src/base-ui/Tabs/__tests__/Tabs.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+
+import Tabs from '../Tabs';
+
+describe('Tabs', () => {
+  test('selects the first enabled item when no initial key is provided', () => {
+    render(
+      <Tabs
+        orientation="vertical"
+        items={[
+          { children: 'Unavailable panel', disabled: true, key: 'disabled', label: 'Unavailable' },
+          { children: 'Arguments panel', key: 'arguments', label: 'Arguments' },
+          { children: 'Response panel', key: 'response', label: 'Response' },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole('tab', { name: 'Arguments' }).getAttribute('aria-selected')).toBe(
+      'true',
+    );
+    expect(screen.getByRole('tabpanel').textContent).toBe('Arguments panel');
+  });
+});

--- a/src/base-ui/Tabs/demos/implicitDefault.tsx
+++ b/src/base-ui/Tabs/demos/implicitDefault.tsx
@@ -1,0 +1,31 @@
+import { Flexbox, Text } from '@lobehub/ui';
+import { Tabs } from '@lobehub/ui/base-ui';
+
+const items = [
+  {
+    children: <Flexbox padding={16}>Unavailable panel</Flexbox>,
+    disabled: true,
+    key: 'unavailable',
+    label: 'Unavailable',
+  },
+  {
+    children: <Flexbox padding={16}>Arguments panel</Flexbox>,
+    key: 'arguments',
+    label: 'Arguments',
+  },
+  {
+    children: <Flexbox padding={16}>Response panel</Flexbox>,
+    key: 'response',
+    label: 'Response',
+  },
+];
+
+export default () => (
+  <Flexbox gap={12}>
+    <Text>
+      No initial key is provided. Arguments is the first enabled item and its panel must be visible
+      immediately.
+    </Text>
+    <Tabs items={items} orientation="vertical" />
+  </Flexbox>
+);

--- a/src/base-ui/Tabs/index.md
+++ b/src/base-ui/Tabs/index.md
@@ -14,6 +14,10 @@ apiHeader:
 
 <code src="./demos/index.tsx" nopadding></code>
 
+## Implicit Initial Selection
+
+<code src="./demos/implicitDefault.tsx" nopadding></code>
+
 ## Atom Components
 
 <code src="./demos/atoms.tsx" nopadding></code>

--- a/src/hooks/useNativeButton.test.tsx
+++ b/src/hooks/useNativeButton.test.tsx
@@ -1,0 +1,13 @@
+import { renderHook } from '@testing-library/react';
+
+import Button from '@/base-ui/Button';
+
+import { useNativeButton } from './useNativeButton';
+
+describe('useNativeButton', () => {
+  test('recognizes the base-ui Button as a native button trigger', () => {
+    const { result } = renderHook(() => useNativeButton({ children: <Button>Open menu</Button> }));
+
+    expect(result.current.resolvedNativeButton).toBe(true);
+  });
+});

--- a/src/hooks/useNativeButton.ts
+++ b/src/hooks/useNativeButton.ts
@@ -38,6 +38,7 @@ const NATIVE_BUTTON_MAP: Record<string, boolean> = {
   Alert: false,
   Avatar: false,
   AvatarGroup: false,
+  BaseButton: true,
   Block: false,
   BottomGradientButton: true,
   Burger: false,


### PR DESCRIPTION
## Summary

Fix five regressions exposed while migrating product call sites to the base-ui components:

- align Switch and composed Button triggers with native button semantics
- emit undefined when clearing a single Select
- search ReactNode-labelled options by their visible title
- keep tags Select editable when its popup is controlled closed
- select the first enabled Tab when no initial key is provided

## Interactive verification demos

Each regression now has a component-local Dumi demo:

- Switch: native button behavior inside a form
- Select: clear value contract
- Select: ReactNode label search
- Select: tags input with a controlled-closed popup
- Tabs: implicit first-enabled initial selection

## Root causes

The base-ui compatibility wrappers diverged from the previous component contracts around empty values, default tab selection, searchable option metadata, tags input placement, and native trigger detection.

## User impact

These changes restore configuration clearing, agent search, tag entry, initial debug panel rendering, and safe button behavior in forms and dropdown compositions.

## Validation

- 39 test files / 323 tests passed
- TypeScript type-check passed
- circular dependency check passed
- complete package build passed
- Dumi documentation build passed with all five demos registered
- targeted regression suite: 6 files / 6 tests passed after commit formatting
- targeted demo ESLint: 0 errors and 0 warnings