### PR TITLE
🐛 fix(button): preserve form submission while loading

### DIFF
--- a/src/base-ui/Button/Button.tsx
+++ b/src/base-ui/Button/Button.tsx
@@ -98,7 +98,7 @@ const Button = ({
   ...rest
 }: ButtonProps) => {
   const Motion = useMotionComponent();
-  const isDisabled = disabled || loading;
+  const isInteractionDisabled = disabled || loading;
   const sizeCls = resolveSizeCls(size);
   const variantCls = resolveVariantCls({ danger, ghost, type });
   const shapeCls =
@@ -152,11 +152,13 @@ const Button = ({
     </>
   );
 
-  const motionGestures = isDisabled ? {} : { transition: motionTransition, whileTap: tapAnim };
+  const motionGestures = isInteractionDisabled
+    ? {}
+    : { transition: motionTransition, whileTap: tapAnim };
 
   if (href !== undefined) {
     const handleAnchorClick = (e: MouseEvent<HTMLAnchorElement>) => {
-      if (isDisabled) {
+      if (isInteractionDisabled) {
         e.preventDefault();
         return;
       }
@@ -165,8 +167,9 @@ const Button = ({
 
     return (
       <Motion.a
-        aria-disabled={isDisabled || undefined}
-        href={isDisabled ? undefined : href}
+        aria-busy={loading || undefined}
+        aria-disabled={isInteractionDisabled || undefined}
+        href={disabled ? undefined : href}
         target={target}
         {...(rest as any)}
         className={composedClassName}
@@ -179,14 +182,24 @@ const Button = ({
     );
   }
 
+  const handleButtonClick = (e: MouseEvent<HTMLButtonElement>) => {
+    if (isInteractionDisabled) {
+      e.preventDefault();
+      return;
+    }
+    onClick?.(e);
+  };
+
   return (
     <Motion.button
       type={htmlType}
       {...(rest as any)}
+      aria-busy={loading || undefined}
+      aria-disabled={isInteractionDisabled || undefined}
       className={composedClassName}
-      disabled={isDisabled}
+      disabled={disabled}
       ref={ref as Ref<HTMLButtonElement>}
-      onClick={onClick}
+      onClick={handleButtonClick}
       {...motionGestures}
     >
       {inner}

--- a/src/base-ui/Button/__tests__/Button.test.tsx
+++ b/src/base-ui/Button/__tests__/Button.test.tsx
@@ -1,23 +1,116 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { motion } from 'motion/react';
+import { type ReactNode, useState } from 'react';
 
 import ConfigProvider from '@/ConfigProvider';
 
 import Button from '../Button';
 
+const renderButton = (children: ReactNode) =>
+  render(<ConfigProvider motion={motion}>{children}</ConfigProvider>);
+
 describe('Button', () => {
   test('provides a positioning context for absolutely positioned content', () => {
-    render(
-      <ConfigProvider motion={motion}>
-        <Button>
-          Continue
-          <span style={{ position: 'absolute' }}>Provider icon</span>
-        </Button>
-      </ConfigProvider>,
+    renderButton(
+      <Button>
+        Continue
+        <span style={{ position: 'absolute' }}>Provider icon</span>
+      </Button>,
     );
 
     const button = screen.getByRole('button', { name: /continue/i });
 
     expect(getComputedStyle(button).position).toBe('relative');
+  });
+
+  test('preserves native submission and submitter data when the first click starts loading', () => {
+    const handleClick = vi.fn();
+    const handleSubmit = vi.fn();
+
+    const TestForm = () => {
+      const [loading, setLoading] = useState(false);
+
+      return (
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            const submitter = (event.nativeEvent as SubmitEvent).submitter;
+            handleSubmit(submitter, new FormData(event.currentTarget, submitter).get('consent'));
+          }}
+        >
+          <Button
+            htmlType={'submit'}
+            loading={loading}
+            name={'consent'}
+            value={'accept'}
+            onClick={() => {
+              handleClick();
+              setLoading(true);
+            }}
+          >
+            Accept
+          </Button>
+        </form>
+      );
+    };
+
+    renderButton(<TestForm />);
+
+    const button = screen.getByRole('button', { name: 'Accept' }) as HTMLButtonElement;
+
+    fireEvent.click(button);
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+    expect(handleSubmit).toHaveBeenCalledWith(button, 'accept');
+    expect(button.disabled).toBe(false);
+    expect(button.getAttribute('aria-busy')).toBe('true');
+    expect(button.getAttribute('aria-disabled')).toBe('true');
+
+    fireEvent.click(button);
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  test('preserves a loading anchor address while preventing its activation', () => {
+    const handleClick = vi.fn();
+
+    renderButton(
+      <Button loading href={'/docs'} onClick={handleClick}>
+        Open docs
+      </Button>,
+    );
+
+    const link = screen.getByRole('link', { name: 'Open docs' });
+
+    expect(link.getAttribute('href')).toBe('/docs');
+    expect(link.getAttribute('aria-busy')).toBe('true');
+    expect(link.getAttribute('aria-disabled')).toBe('true');
+    expect(fireEvent.click(link)).toBe(false);
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  test('retains native disabled semantics for explicitly disabled buttons', () => {
+    const handleSubmit = vi.fn();
+
+    renderButton(
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          handleSubmit();
+        }}
+      >
+        <Button disabled htmlType={'submit'}>
+          Submit
+        </Button>
+      </form>,
+    );
+
+    const button = screen.getByRole('button', { name: 'Submit' }) as HTMLButtonElement;
+
+    fireEvent.click(button);
+
+    expect(button.disabled).toBe(true);
+    expect(handleSubmit).not.toHaveBeenCalled();
   });
 });

--- a/src/base-ui/Button/index.md
+++ b/src/base-ui/Button/index.md
@@ -39,7 +39,7 @@ Compose a primary action and a dropdown menu sharing the same visual props.
 | shape        | Button shape                                                                      | `'default' \| 'circle' \| 'round'`                                 | `'default'` |
 | icon         | Icon rendered next to the children — a Lucide icon component or a ready-made node | `IconProps['icon'] \| ReactNode`                                   | -           |
 | iconPosition | Where to place the icon                                                           | `'start' \| 'end'`                                                 | `'start'`   |
-| loading      | Show a spinner and disable interaction                                            | `boolean`                                                          | `false`     |
+| loading      | Show a spinner and prevent repeated interaction                                   | `boolean`                                                          | `false`     |
 | disabled     | Disabled state                                                                    | `boolean`                                                          | `false`     |
 | block        | Stretch to fill container width                                                   | `boolean`                                                          | `false`     |
 | href         | Render as an `<a>` element                                                        | `string`                                                           | -           |
@@ -49,6 +49,8 @@ Compose a primary action and a dropdown menu sharing the same visual props.
 | styles       | Per-slot inline styles                                                            | `{ icon?: CSSProperties }`                                         | -           |
 
 The component forwards all standard `<button>` (or `<a>` when `href` is set) HTML attributes including `onClick`, `aria-*`, `data-*`, and `ref`.
+
+`loading` preserves the native state of the underlying element while blocking new user activations. In particular, setting `loading` during the first click of an `htmlType="submit"` button does not cancel that form submission or remove its submitter data. Use `disabled` when native disabled semantics are required.
 
 ## Migrating from `antd`'s `Button`
 


### PR DESCRIPTION
## Summary

- decouple Base Button `loading` state from native `disabled`
- preserve the current form submission and anchor destination while blocking subsequent activations
- expose `aria-busy` and `aria-disabled`, document the contract, and add behavioral regressions

## Root cause

Base Button previously mapped `loading` directly to native `disabled` and removed an anchor's `href`. When a click handler synchronously entered the loading state, React could commit the disabled state before the browser completed the click's default action. A submit button could therefore cancel the submission or lose its submitter name/value.

## Impact

Form consumers can use `loading` on submit buttons without a manual `requestSubmit` workaround. Explicit `disabled` continues to provide native disabled semantics.

## Validation

- `npx vitest run --silent='passed-only' src/base-ui/Button/__tests__/Button.test.tsx` — 4 tests passed
- `npm run type-check`
- `npx eslint src/base-ui/Button/Button.tsx src/base-ui/Button/__tests__/Button.test.tsx`
- `npx prettier --check src/base-ui/Button/Button.tsx src/base-ui/Button/__tests__/Button.test.tsx src/base-ui/Button/index.md`
- `npm run lint:circular`
- `npm run build`