### PR TITLE
✨ feat(statistic-card): add StatisticCard, Statistic, TitleWithPercentage components

### DIFF
--- a/docs/superpowers/specs/2026-07-17-statistic-card-design.md
+++ b/docs/superpowers/specs/2026-07-17-statistic-card-design.md
@@ -1,0 +1,101 @@
+# StatisticCard Design
+
+Date: 2026-07-17
+Linear: [LOBE-11988](https://linear.app/lobehub/issue/LOBE-11988) — remove legacy `@ant-design/pro-components` references
+
+## Background
+
+lobe-chat wraps `StatisticCard` from `@ant-design/pro-components` (`src/components/StatisticCard`) with ~100 lines of CSS overriding `ant-pro-*` class names. The issue asks to drop the pro-components dependency and move StatisticCard into the component library. This spec covers the lobe-ui side only: build a self-contained StatisticCard family. Replacing the usages in lobe-chat (ProTable, ProDescriptions, StatisticCard) is a separate follow-up outside this spec.
+
+The component must NOT depend on `@ant-design/pro-components` or any antd runtime component. Implementation follows the conventions of this repo's `src/base-ui/` components (self-drawn styles, `cva` variants, `classNames`/`styles` slot props, `cssVar` tokens, `prefers-reduced-motion` support), but lives at top-level `src/` since it is a display component with no `@base-ui/react` primitive.
+
+## Scope
+
+In scope (all in lobe-ui, exported from `@lobehub/ui`):
+
+- `StatisticCard` — the card itself
+- `Statistic` — small label + value pair, used in the card's `description` slot
+- `TitleWithPercentage` — title with a growth-percentage tag, used in the card's `title` slot
+
+Out of scope: any lobe-chat changes; chart/footer features of the pro-components original (no caller uses them).
+
+## File structure
+
+```
+src/StatisticCard/
+  StatisticCard.tsx
+  Statistic.tsx
+  TitleWithPercentage.tsx
+  utils.ts            # calcGrowthPercentage
+  type.ts
+  style.ts            # createStaticStyles + cva variants
+  index.ts
+  index.mdx           # category: Data Display
+  demos/index.tsx     # StoryBook + leva controls
+```
+
+`src/index.ts` adds: `StatisticCard`, `Statistic`, `TitleWithPercentage` and their prop types.
+
+## API
+
+```ts
+type StatisticCardSlot =
+  'root' | 'header' | 'title' | 'extra' | 'content' | 'value' | 'description';
+
+interface StatisticCardProps extends Omit<HTMLAttributes<HTMLDivElement>, 'prefix' | 'title'> {
+  title?: ReactNode; // string is wrapped in Text h2 with single-line ellipsis + tooltip
+  extra?: ReactNode; // top-right slot; replaced by spinner while loading
+  loading?: boolean;
+  value?: ReactNode; // number → toFixed(precision); undefined/null → '--'
+  precision?: number;
+  prefix?: ReactNode;
+  suffix?: ReactNode;
+  description?: ReactNode; // rendered below the value
+  variant?: 'filled' | 'outlined' | 'borderless'; // default 'borderless'
+  classNames?: Partial<Record<StatisticCardSlot, string>>;
+  styles?: Partial<Record<StatisticCardSlot, CSSProperties>>;
+  ref?: Ref<HTMLDivElement>;
+}
+
+interface StatisticProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
+  title: ReactNode;
+  value: ReactNode;
+}
+
+interface TitleWithPercentageProps {
+  title: string;
+  count?: number;
+  prvCount?: number;
+  inverseColor?: boolean; // swap up/down colors (e.g. for spend metrics)
+}
+```
+
+This flat API covers the full set of props actually used by the 8 lobe-chat call sites (`statistic.{value, precision, prefix, description, style}`, `title`, `extra`, `loading`, `variant`). The old `statistic.style` maps to `styles.value`.
+
+## Rendering
+
+- Root: self-drawn `div` (no `Block`), `cva` variants:
+  - `borderless` (default): no border, transparent background
+  - `outlined`: 1px border (`colorFillSecondary` light / `colorFillTertiary` dark), `borderRadiusLG`
+  - `filled`: `colorFillQuaternary` background, `borderRadiusLG`
+- Layout: vertical `Flexbox` — header row (title left, extra right), value row (prefix + value + suffix, 24px bold, line-height 1.2), then description.
+- Loading: `Icon` + `Loader2` with a rotation keyframe (same pattern as base-ui `Switch`), shown in the extra slot; animation duration 0 under `prefers-reduced-motion`.
+- Responsive: under `responsive.sm` the card drops border and radius and uses `colorBgContainer` background (matches current lobe-chat mobile behavior).
+- All colors via `cssVar` tokens; no dark-mode branching in JS except where token pairs differ per variant (handled in `style.ts`).
+
+## Companion components
+
+- `Statistic`: horizontal `Flexbox`, bold value + normal-weight title, 12px, `colorTextDescription`. Logic ported as-is from lobe-chat, inline styles moved to `style.ts`.
+- `TitleWithPercentage`: ports `calcGrowthPercentage` and the Tag rendering from lobe-chat unchanged; percentage tag only renders when `count`, `prvCount`, and a non-zero percentage are all present. Up = `colorSuccess`, down = `colorWarning`, swapped when `inverseColor`.
+
+## Edge cases
+
+- `value` undefined or null → renders `'--'`, precision not applied.
+- `precision` applies only when `value` is a `number`.
+- `title` given as ReactNode is rendered as-is (no Text wrapper).
+
+## Verification
+
+- Demo page: check light/dark themes, mobile viewport, and loading state via the docs dev server.
+- Lint scoped to the new/changed files only.
+- No new runtime dependency; `@ant-design/pro-components` is never added to lobe-ui.

--- a/site/content/navigationSections.json
+++ b/site/content/navigationSections.json
@@ -69,6 +69,7 @@
   "src/SliderWithInput/index.mdx": "Components",
   "src/Snippet/index.mdx": "Components",
   "src/SortableList/index.mdx": "Components",
+  "src/StatisticCard/index.mdx": "Components",
   "src/Tabs/index.mdx": "Components",
   "src/Tag/index.mdx": "Components",
   "src/Text/index.mdx": "Components",

--- a/src/StatisticCard/Statistic.tsx
+++ b/src/StatisticCard/Statistic.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { cx } from 'antd-style';
+import { memo } from 'react';
+
+import { styles } from './style';
+import type { StatisticProps } from './type';
+
+export const Statistic = memo<StatisticProps>(({ className, ref, title, value, ...rest }) => {
+  return (
+    <div className={cx(styles.statistic, className)} ref={ref} {...rest}>
+      <span className={styles.statisticValue}>{value}</span>
+      <span className={styles.statisticTitle}>{title}</span>
+    </div>
+  );
+});
+
+Statistic.displayName = 'Statistic';

--- a/src/StatisticCard/StatisticCard.tsx
+++ b/src/StatisticCard/StatisticCard.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { cx, useThemeMode } from 'antd-style';
+import { Loader2 } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { memo } from 'react';
+
+import Icon from '@/Icon';
+import Text from '@/Text';
+
+import { styles, variants } from './style';
+import type { StatisticCardProps } from './type';
+
+const formatValue = (value: ReactNode, precision?: number): ReactNode => {
+  if (value === undefined || value === null) return '--';
+  if (typeof value === 'number' && precision !== undefined) return value.toFixed(precision);
+  return value;
+};
+
+export const StatisticCard = memo<StatisticCardProps>(
+  ({
+    className,
+    classNames,
+    description,
+    extra,
+    loading,
+    precision,
+    prefix,
+    ref,
+    style,
+    styles: customStyles,
+    suffix,
+    title,
+    value,
+    variant = 'borderless',
+    ...rest
+  }) => {
+    const { isDarkMode } = useThemeMode();
+
+    const showHeader = Boolean(title || extra || loading);
+
+    return (
+      <div
+        className={cx(variants({ isDarkMode, variant }), classNames?.root, className)}
+        ref={ref}
+        style={{ ...style, ...customStyles?.root }}
+        {...rest}
+      >
+        {showHeader && (
+          <div className={cx(styles.header, classNames?.header)} style={customStyles?.header}>
+            <div className={cx(styles.title, classNames?.title)} style={customStyles?.title}>
+              {typeof title === 'string' ? (
+                <Text
+                  as={'h2'}
+                  ellipsis={{ rows: 1, tooltip: true }}
+                  style={{
+                    color: 'inherit',
+                    fontSize: 'inherit',
+                    fontWeight: 'inherit',
+                    lineHeight: 'inherit',
+                    margin: 0,
+                    overflow: 'hidden',
+                  }}
+                >
+                  {title}
+                </Text>
+              ) : (
+                title
+              )}
+            </div>
+            {(loading || extra) && (
+              <div className={cx(styles.extra, classNames?.extra)} style={customStyles?.extra}>
+                {loading ? <Icon spin icon={Loader2} size={16} /> : extra}
+              </div>
+            )}
+          </div>
+        )}
+        <div className={cx(styles.content, classNames?.content)} style={customStyles?.content}>
+          <div className={cx(styles.value, classNames?.value)} style={customStyles?.value}>
+            {prefix}
+            <span>{formatValue(value, precision)}</span>
+            {suffix}
+          </div>
+          {description && (
+            <div
+              className={cx(styles.description, classNames?.description)}
+              style={customStyles?.description}
+            >
+              {description}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  },
+);
+
+StatisticCard.displayName = 'StatisticCard';

--- a/src/StatisticCard/TitleWithPercentage.tsx
+++ b/src/StatisticCard/TitleWithPercentage.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { memo } from 'react';
+
+import { Flexbox } from '@/Flex';
+import Tag from '@/Tag';
+import Text from '@/Text';
+
+import { styles } from './style';
+import type { TitleWithPercentageProps } from './type';
+import { calcGrowthPercentage } from './utils';
+
+export const TitleWithPercentage = memo<TitleWithPercentageProps>(
+  ({ inverseColor, title, prvCount, count }) => {
+    const percentage = calcGrowthPercentage(count || 0, prvCount || 0);
+
+    const isUp = inverseColor ? percentage < 0 : percentage > 0;
+
+    return (
+      <Flexbox
+        horizontal
+        align={'center'}
+        gap={4}
+        justify={'flex-start'}
+        style={{ overflow: 'hidden', position: 'inherit' }}
+      >
+        <Text
+          as={'h2'}
+          ellipsis={{ rows: 1, tooltip: title }}
+          style={{
+            color: 'inherit',
+            fontSize: 'inherit',
+            fontWeight: 'inherit',
+            lineHeight: 'inherit',
+            margin: 0,
+            overflow: 'hidden',
+          }}
+        >
+          {title}
+        </Text>
+        {count && prvCount && percentage && percentage !== 0 ? (
+          <Tag className={isUp ? styles.percentUp : styles.percentDown} variant={'borderless'}>
+            {percentage > 0 ? '↑' : '↓'} {Math.abs(percentage).toFixed(1)}%
+          </Tag>
+        ) : null}
+      </Flexbox>
+    );
+  },
+);
+
+TitleWithPercentage.displayName = 'TitleWithPercentage';

--- a/src/StatisticCard/demos/index.tsx
+++ b/src/StatisticCard/demos/index.tsx
@@ -1,0 +1,37 @@
+import type { StatisticCardProps } from '@lobehub/ui';
+import { Flexbox, Statistic, StatisticCard, TitleWithPercentage } from '@lobehub/ui';
+import { StoryBook, useControls, useCreateStore } from '@lobehub/ui/storybook';
+
+export default () => {
+  const store = useCreateStore();
+  const control = useControls(
+    {
+      loading: false,
+      precision: 2,
+      prefix: '$',
+      value: 1128.93,
+      variant: {
+        options: ['borderless', 'outlined', 'filled'],
+        value: 'outlined',
+      },
+    },
+    { store },
+  ) as StatisticCardProps;
+
+  return (
+    <StoryBook levaStore={store}>
+      <Flexbox horizontal gap={16} style={{ width: '100%' }}>
+        <StatisticCard
+          {...control}
+          description={<Statistic title={'yesterday'} value={'$986.12'} />}
+          title={<TitleWithPercentage count={1128} prvCount={986} title={'Today Spend'} />}
+        />
+        <StatisticCard
+          {...control}
+          description={<Statistic title={'prev month'} value={'2,341'} />}
+          title={'Total Messages'}
+        />
+      </Flexbox>
+    </StoryBook>
+  );
+};

--- a/src/StatisticCard/index.mdx
+++ b/src/StatisticCard/index.mdx
@@ -1,0 +1,15 @@
+---
+title: StatisticCard
+description: StatisticCard displays a key metric with an optional title, extra action, prefix/suffix, and description. Ships with Statistic (a compact label-value pair) and TitleWithPercentage (a title with a growth-percentage tag) as companions for its description and title slots.
+category: Data Display
+---
+
+import DemoIndex from './demos/index.tsx?demo';
+
+## Default
+
+<Demo of={DemoIndex} layout="bare" />
+
+## APIs
+
+<Api name="StatisticCard" migrationKey="unheaded:0" />

--- a/src/StatisticCard/index.ts
+++ b/src/StatisticCard/index.ts
@@ -1,0 +1,4 @@
+export * from './Statistic';
+export * from './StatisticCard';
+export * from './TitleWithPercentage';
+export type * from './type';

--- a/src/StatisticCard/style.ts
+++ b/src/StatisticCard/style.ts
@@ -1,0 +1,137 @@
+import { createStaticStyles, responsive } from 'antd-style';
+import { cva } from 'class-variance-authority';
+
+export const styles = createStaticStyles(({ css, cssVar }) => ({
+  content: css`
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  `,
+  description: css`
+    font-size: 12px;
+    color: ${cssVar.colorTextDescription};
+  `,
+  extra: css`
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+  `,
+  filled: css`
+    background: ${cssVar.colorFillQuaternary};
+  `,
+  header: css`
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    justify-content: space-between;
+  `,
+  percentDown: css`
+    color: ${cssVar.colorWarning};
+  `,
+  percentUp: css`
+    color: ${cssVar.colorSuccess};
+  `,
+  outlinedDark: css`
+    border: 1px solid ${cssVar.colorFillTertiary};
+
+    &:hover {
+      border-color: ${cssVar.colorFillSecondary};
+    }
+  `,
+  outlinedLight: css`
+    border: 1px solid ${cssVar.colorFillSecondary};
+
+    &:hover {
+      border-color: ${cssVar.colorFill};
+    }
+  `,
+  root: css`
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: 12px;
+
+    padding-block: 16px;
+    padding-inline: 20px;
+    border-radius: ${cssVar.borderRadiusLG};
+
+    transition: border-color 160ms cubic-bezier(0.32, 0.72, 0, 1);
+
+    ${responsive.sm} {
+      border: none;
+      border-radius: 0;
+      background: ${cssVar.colorBgContainer};
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      transition-duration: 0s;
+    }
+  `,
+  statistic: css`
+    display: flex;
+    gap: 4px;
+    align-items: center;
+
+    font-size: 12px;
+    color: ${cssVar.colorTextDescription};
+  `,
+  statisticTitle: css`
+    font-weight: normal;
+  `,
+  statisticValue: css`
+    font-weight: 600;
+  `,
+  title: css`
+    overflow: hidden;
+    display: flex;
+    flex: 1;
+    gap: 6px;
+    align-items: center;
+
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 1.5;
+    color: ${cssVar.colorTextSecondary};
+  `,
+  value: css`
+    display: flex;
+    gap: 2px;
+    align-items: baseline;
+
+    font-size: 28px;
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.25;
+    letter-spacing: -0.01em;
+  `,
+}));
+
+export const variants = cva(styles.root, {
+  compoundVariants: [
+    {
+      class: styles.outlinedDark,
+      isDarkMode: true,
+      variant: 'outlined',
+    },
+    {
+      class: styles.outlinedLight,
+      isDarkMode: false,
+      variant: 'outlined',
+    },
+  ],
+  defaultVariants: {
+    isDarkMode: false,
+    variant: 'borderless',
+  },
+  variants: {
+    isDarkMode: {
+      false: null,
+      true: null,
+    },
+    variant: {
+      borderless: null,
+      filled: styles.filled,
+      outlined: null,
+    },
+  },
+});

--- a/src/StatisticCard/type.ts
+++ b/src/StatisticCard/type.ts
@@ -1,0 +1,35 @@
+import type { CSSProperties, HTMLAttributes, ReactNode, Ref } from 'react';
+
+export type StatisticCardSlot =
+  'root' | 'header' | 'title' | 'extra' | 'content' | 'value' | 'description';
+
+export interface StatisticCardProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'prefix' | 'title'
+> {
+  classNames?: Partial<Record<StatisticCardSlot, string>>;
+  description?: ReactNode;
+  extra?: ReactNode;
+  loading?: boolean;
+  precision?: number;
+  prefix?: ReactNode;
+  ref?: Ref<HTMLDivElement>;
+  styles?: Partial<Record<StatisticCardSlot, CSSProperties>>;
+  suffix?: ReactNode;
+  title?: ReactNode;
+  value?: ReactNode;
+  variant?: 'filled' | 'outlined' | 'borderless';
+}
+
+export interface StatisticProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
+  ref?: Ref<HTMLDivElement>;
+  title: ReactNode;
+  value: ReactNode;
+}
+
+export interface TitleWithPercentageProps {
+  count?: number;
+  inverseColor?: boolean;
+  prvCount?: number;
+  title: string;
+}

--- a/src/StatisticCard/utils.ts
+++ b/src/StatisticCard/utils.ts
@@ -1,0 +1,8 @@
+export const calcGrowthPercentage = (currentCount: number, previousCount: number) => {
+  if (typeof currentCount !== 'number') return 0;
+  return previousCount !== 0
+    ? ((currentCount - previousCount) / previousCount) * 100
+    : currentCount > 0
+      ? 100
+      : 0;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -320,6 +320,15 @@ export {
 export { default as SliderWithInput, type SliderWithInputProps } from './SliderWithInput';
 export { default as Snippet, type SnippetProps } from './Snippet';
 export { default as SortableList, type SortableListProps } from './SortableList';
+export {
+  Statistic,
+  StatisticCard,
+  type StatisticCardProps,
+  type StatisticCardSlot,
+  type StatisticProps,
+  TitleWithPercentage,
+  type TitleWithPercentageProps,
+} from './StatisticCard';
 export * from './styles';
 export { CLASSNAMES } from './styles/classNames';
 export { default as Tabs, type TabsProps } from './Tabs';


### PR DESCRIPTION
## Summary

Adds a self-contained `StatisticCard` component family to lobe-ui, so lobe-chat can drop its `@ant-design/pro-components`-based wrapper.

Linear: [LOBE-11988](https://linear.app/lobehub/issue/LOBE-11988)

### Components (all exported from `@lobehub/ui`)

- **`StatisticCard`** — metric card with flat API: `title / extra / loading / value / precision / prefix / suffix / description / variant`, plus `classNames` / `styles` slot overrides (root/header/title/extra/content/value/description)
- **`Statistic`** — compact label + value pair for the `description` slot
- **`TitleWithPercentage`** — title with growth-percentage tag (`↑ 14.4%` / `↓ 3.2%`) for the `title` slot

### Design

- Zero antd / pro-components dependency; self-drawn styles following the `base-ui` conventions (`cva` variants, `cssVar` tokens, `prefers-reduced-motion`)
- Typography ported from antd Statistic then refined: muted 14/500 title (`colorTextSecondary`), hero 28/500 value with `tabular-nums` and −1% tracking, 12px description 4px below
- `variant`: `borderless` (default) / `outlined` / `filled`; outlined hover brightens the border only (160ms `cubic-bezier(0.32,0.72,0,1)`), matching base-ui Button
- Mobile (`responsive.sm`): drops border/radius, uses `colorBgContainer`
- Loading: `Loader2` spin icon in the extra slot

### Docs

- `src/StatisticCard/index.mdx` (Data Display) + StoryBook demo with leva controls
- Registered in `site/content/navigationSections.json`
- Design spec: `docs/superpowers/specs/2026-07-17-statistic-card-design.md`

## Testing

- Verified in the docs site via browser automation: light/dark demo themes, loading state, API table rendering; no console errors
- `eslint` clean on changed files; `tsc --noEmit` passes

## Follow-up (separate PR in lobe-chat)

Replace the three pro-components usages (`StatisticCard` wrapper, `ProTable` in ApiKey, `ProDescriptions` in AgentInfoDescription) and remove the dependency.