### PR TITLE
✨ feat(docs-kit): improve lobedocs consumer integration

### DIFF
--- a/docs.config.ts
+++ b/docs.config.ts
@@ -5,6 +5,9 @@ import { defineDocsConfig } from './packages/docs-kit/src/config';
 export default defineDocsConfig({
   alias: {
     '@': 'src',
+    // docs-kit consumes published `es/*` subpaths. Resolve those imports back
+    // to source while developing @lobehub/ui itself.
+    '@lobehub/ui/es': 'src',
     '@lobehub/ui': 'src',
   },
   atomDirs: [{ dir: 'src' }],

--- a/packages/docs-kit/README.md
+++ b/packages/docs-kit/README.md
@@ -17,15 +17,21 @@ A repo adopting the kit needs:
   CHANGELOG.md            # rendered at "/changelog" when docs/changelog.mdx is absent — see "Changelog" below
 ```
 
-No `vite.config.ts` in the consumer repo — the `lobedocs` CLI drives react-router dev/build programmatically using kit-internal config, with the consumer repo as cwd/root. A 1-line `react-router.config.ts` shell must still exist at the consumer root:
+No `vite.config.ts` or `react-router.config.ts` is required in the consumer repo. The `lobedocs` CLI keeps the consumer repo as the React Router/Vite root and supplies the kit-owned React Router config automatically for the lifetime of each command.
+
+Consumers that need to override React Router settings may add an optional `react-router.config.ts` based on the exported defaults:
 
 ```ts
-export { default } from './packages/docs-kit/site/react-router.config';
+import { defineLobeDocsReactRouterConfig } from '@lobehub/docs-kit/react-router-config';
+
+export default defineLobeDocsReactRouterConfig({
+  basename: '/docs',
+});
 ```
 
-This is required because react-router 8.2 resolves `rootDirectory` and Vite's `root` to the same value with no way to split them via the public CLI, so `react-router.config.ts` discovery can't be redirected into the kit.
+React Router 8.2 does not expose a separate config-file argument, so the CLI provides its default through a process-scoped generated config. The file is removed when the command exits, guarded by cross-process leases when multiple `lobedocs` commands run concurrently. Any consumer-authored `react-router.config.{js,jsx,ts,tsx,mjs,mts}` takes precedence and is never modified.
 
-The package is published as `@lobehub/docs-kit` alongside `@lobehub/ui`. Its `lobedocs` CLI is the supported public entry point; JavaScript package exports remain intentionally unstabilized while the first consumers are migrated.
+The package is published as `@lobehub/docs-kit` alongside `@lobehub/ui`. Its supported public entry points are the `lobedocs` CLI and `@lobehub/docs-kit/react-router-config` for optional React Router overrides; other JavaScript deep imports remain intentionally unstabilized while the first consumers are migrated.
 
 ### CLI
 

--- a/packages/docs-kit/package.json
+++ b/packages/docs-kit/package.json
@@ -15,6 +15,7 @@
   },
   "files": [
     "bin",
+    "react-router-config.ts",
     "site",
     "src",
     "vite.config.ts"

--- a/packages/docs-kit/react-router-config.ts
+++ b/packages/docs-kit/react-router-config.ts
@@ -1,0 +1,5 @@
+export {
+  default,
+  defineLobeDocsReactRouterConfig,
+  lobeDocsReactRouterConfig,
+} from './site/react-router.config';

--- a/packages/docs-kit/site/app/antdStaticCss.server.tsx
+++ b/packages/docs-kit/site/app/antdStaticCss.server.tsx
@@ -1,4 +1,5 @@
 import { createCache, extractStyle as extractCssinjsStyle } from '@ant-design/cssinjs';
+import { createLobeAntdTheme } from '@lobehub/ui/es/styles/theme/antdTheme';
 import {
   Alert,
   Anchor,
@@ -45,9 +46,6 @@ import {
 import { StyleProvider } from 'antd-style';
 import type { ReactElement } from 'react';
 import { renderToString } from 'react-dom/server';
-
-import { createLobeAntdTheme } from '@/styles/theme/antdTheme';
-import LobeAntdConfigProvider from '@/ThemeProvider/ConfigProvider';
 
 const themeConfig = (() => {
   const config = createLobeAntdTheme({ appearance: 'light' });
@@ -148,9 +146,7 @@ const build = () => {
     try {
       renderToString(
         <StyleProvider cache={cache}>
-          <ConfigProvider theme={themeConfig}>
-            <LobeAntdConfigProvider>{probe()}</LobeAntdConfigProvider>
-          </ConfigProvider>
+          <ConfigProvider theme={themeConfig}>{probe()}</ConfigProvider>
         </StyleProvider>,
       );
     } catch {

--- a/packages/docs-kit/site/app/content/registry.test.ts
+++ b/packages/docs-kit/site/app/content/registry.test.ts
@@ -30,4 +30,4 @@ it('caches one React-compatible import promise per document pathname', async () 
   await first;
 
   expect(first).toMatchObject({ status: 'fulfilled' });
-}, 60_000);
+}, 120_000);

--- a/packages/docs-kit/site/app/content/registry.test.ts
+++ b/packages/docs-kit/site/app/content/registry.test.ts
@@ -30,4 +30,4 @@ it('caches one React-compatible import promise per document pathname', async () 
   await first;
 
   expect(first).toMatchObject({ status: 'fulfilled' });
-});
+}, 60_000);

--- a/packages/docs-kit/site/app/providers/SiteProviders.tsx
+++ b/packages/docs-kit/site/app/providers/SiteProviders.tsx
@@ -1,5 +1,4 @@
-import ConfigProvider from '@lobehub/ui/ConfigProvider';
-import LobeThemeProvider from '@lobehub/ui/ThemeProvider';
+import { ConfigProvider, ThemeProvider as LobeThemeProvider } from '@lobehub/ui';
 import type { ThemeMode } from 'antd-style';
 import { motion } from 'motion/react';
 import { ThemeProvider as NextThemeProvider, useTheme } from 'next-themes';
@@ -22,11 +21,19 @@ export interface SiteThemeValue {
 }
 
 export function useSiteTheme(): SiteThemeValue {
-  const { resolvedTheme, setTheme, theme } = useTheme();
+  const { forcedTheme, resolvedTheme, setTheme, theme } = useTheme();
+  const configuredTheme = siteConfig.themeConfig?.prefersColor;
+  const configuredAppearance =
+    configuredTheme === 'dark' || configuredTheme === 'light' ? configuredTheme : undefined;
+  const fallbackAppearance =
+    forcedTheme === 'dark' || forcedTheme === 'light'
+      ? forcedTheme
+      : (configuredAppearance ?? 'light');
 
   return {
-    appearance: resolvedTheme === 'dark' ? 'dark' : 'light',
-    preference: theme === 'light' || theme === 'dark' ? theme : 'system',
+    appearance:
+      resolvedTheme === 'dark' || resolvedTheme === 'light' ? resolvedTheme : fallbackAppearance,
+    preference: theme === 'light' || theme === 'dark' ? theme : (configuredAppearance ?? 'system'),
     setPreference: setTheme,
   };
 }

--- a/packages/docs-kit/site/app/providers/themeTokens.ts
+++ b/packages/docs-kit/site/app/providers/themeTokens.ts
@@ -1,6 +1,5 @@
+import { createLobeAntdTheme } from '@lobehub/ui/es/styles/theme/antdTheme';
 import { theme as antdTheme } from 'antd';
-
-import { createLobeAntdTheme } from '@/styles/theme/antdTheme';
 
 type ThemeAppearance = 'dark' | 'light';
 

--- a/packages/docs-kit/site/compiler/api/buttonPilot.test.ts
+++ b/packages/docs-kit/site/compiler/api/buttonPilot.test.ts
@@ -42,7 +42,7 @@ it('migrates the Button guide once while preserving both demos and the generated
   expect(JSON.stringify(extractComponentApi({ documentPath, name: 'Button' }))).not.toContain(
     repositoryRoot,
   );
-}, 60_000);
+}, 120_000);
 
 it('renders serialized Button properties and both canonical demo frames through Vite MDX', async () => {
   server = await createServer({
@@ -56,4 +56,4 @@ it('renders serialized Button properties and both canonical demo frames through 
   expect(html).toContain('Button properties');
   expect(html).toContain('loading');
   expect(html.match(new RegExp(`class="${demoStyles.frame}"`, 'g'))).toHaveLength(2);
-}, 60_000);
+}, 120_000);

--- a/packages/docs-kit/site/compiler/content/changelog.test.ts
+++ b/packages/docs-kit/site/compiler/content/changelog.test.ts
@@ -26,4 +26,4 @@ it('renders a stable target for every changelog back-to-top link', async () => {
 
   expect(html).toContain('id="readme-top"');
   expect(html).toContain('href="#readme-top"');
-}, 60_000);
+}, 120_000);

--- a/packages/docs-kit/site/compiler/content/changelogFallbackRoute.test.ts
+++ b/packages/docs-kit/site/compiler/content/changelogFallbackRoute.test.ts
@@ -102,4 +102,4 @@ it('renders the realistic CHANGELOG.md fallback content for a fixture consumer w
   expect(html).toContain('<details');
   expect(html).toContain('<summary');
   expect(html).toContain('strict: true');
-}, 30_000);
+}, 120_000);

--- a/packages/docs-kit/site/compiler/content/changelogFixtureCompile.test.ts
+++ b/packages/docs-kit/site/compiler/content/changelogFixtureCompile.test.ts
@@ -34,4 +34,4 @@ it('compiles a realistic changelog excerpt through the production mdx pipeline',
   expect(html).toContain(`Version${nonBreakingSpace}4.20.2`);
   expect(html).toContain('strict: true');
   expect(html).toContain('Replace underline');
-}, 30_000);
+}, 120_000);

--- a/packages/docs-kit/site/compiler/content/createManifest.test.ts
+++ b/packages/docs-kit/site/compiler/content/createManifest.test.ts
@@ -76,6 +76,32 @@ describe('content manifest', () => {
     expect(manifest.documents.some(({ source }) => source.includes('superpowers'))).toBe(false);
   });
 
+  it('includes explicitly configured public guide documents without adding sidebar entries', () => {
+    const root = createProjectFixture({
+      'docs/components.mdx': `---
+title: Components
+description: Component documentation index.
+---
+`,
+      'docs/superpowers/internal.mdx': `---
+title: Internal
+description: Internal specification.
+---
+`,
+    });
+
+    const manifest = createContentManifest(root, defaultAtomDirs, {}, ['docs/components.mdx']);
+
+    expect(manifest.documents).toEqual([
+      expect.objectContaining({
+        pathname: '/components',
+        source: 'docs/components.mdx',
+        title: 'Components',
+      }),
+    ]);
+    expect(manifest.navigation).toEqual([]);
+  });
+
   it('falls back to a root CHANGELOG.md when docs/changelog.mdx is absent', () => {
     const root = createProjectFixture({
       'CHANGELOG.md': '# 1.0.0\n\n- Initial release.\n',

--- a/packages/docs-kit/site/compiler/content/createManifest.ts
+++ b/packages/docs-kit/site/compiler/content/createManifest.ts
@@ -57,6 +57,13 @@ const derivePathname = (
   if (frontmatter.route) return { pathname: canonicalizePathname(frontmatter.route) };
   if (document.kind === 'home') return { pathname: '/' };
   if (document.kind === 'changelog') return { pathname: '/changelog' };
+  if (document.kind === 'guide') {
+    const guidePath = document.source
+      .slice('docs/'.length)
+      .replace(/\.mdx?$/, '')
+      .replace(/\/index$/, '');
+    return { pathname: canonicalizePathname(`/${guidePath}`) };
+  }
 
   const atomDir = resolveAtomDir(document.source, atomDirs);
   const componentPath = document.source.slice(atomDir.dir.length + 1, -'/index.mdx'.length);
@@ -88,12 +95,13 @@ export function createContentManifest(
   root: string,
   atomDirs: readonly AtomDirConfig[],
   navSections: Record<string, string>,
+  publicDocs: readonly string[] = [],
 ): ContentManifest {
   const documents: DocumentManifestEntry[] = [];
   const diagnostics: string[] = [];
   const pathnames = new Map<string, string>();
 
-  for (const document of discoverDocuments(root, atomDirs)) {
+  for (const document of discoverDocuments(root, atomDirs, publicDocs)) {
     const parsed = parseDocumentFrontmatter(document);
     const validation = validateFrontmatter(parsed.value, {
       requireCategory: document.kind === 'component',

--- a/packages/docs-kit/site/compiler/content/discoverDocuments.ts
+++ b/packages/docs-kit/site/compiler/content/discoverDocuments.ts
@@ -4,7 +4,7 @@ import { basename, extname, relative, resolve } from 'node:path';
 import type { AtomDirConfig } from '../../../src/config';
 import { shouldUseChangelogFallback } from './changelogFallback';
 
-export type DocumentKind = 'home' | 'changelog' | 'component';
+export type DocumentKind = 'home' | 'changelog' | 'component' | 'guide';
 
 export interface DiscoveredDocument {
   absolutePath: string;
@@ -17,6 +17,7 @@ export const defaultAtomDirs: AtomDirConfig[] = [{ dir: 'src' }];
 const inferKind = (source: string): DocumentKind => {
   if (source === 'docs/index.mdx') return 'home';
   if (source === 'docs/changelog.mdx' || source === 'CHANGELOG.md') return 'changelog';
+  if (source.startsWith('docs/')) return 'guide';
   return 'component';
 };
 
@@ -29,6 +30,10 @@ const inferStandaloneSource = (
   const normalizedPath = normalizePath(absolutePath);
   if (normalizedPath.endsWith('/docs/index.mdx')) return 'docs/index.mdx';
   if (normalizedPath.endsWith('/docs/changelog.mdx')) return 'docs/changelog.mdx';
+
+  const docsMarker = '/docs/';
+  const docsIndex = normalizedPath.lastIndexOf(docsMarker);
+  if (docsIndex >= 0) return normalizedPath.slice(docsIndex + 1);
 
   for (const { dir } of atomDirs) {
     const sourceMarker = `/${dir}/`;
@@ -55,6 +60,7 @@ const collectComponentDocuments = (directory: string): string[] => {
 export function discoverDocuments(
   root: string,
   atomDirs: readonly AtomDirConfig[] = defaultAtomDirs,
+  publicDocs: readonly string[] = [],
 ): DiscoveredDocument[] {
   const absoluteRoot = resolve(root);
   const stat = statSync(absoluteRoot);
@@ -76,10 +82,11 @@ export function discoverDocuments(
     resolve(absoluteRoot, 'docs/index.mdx'),
     changelogPath,
     ...(useChangelogFallback ? [changelogFallbackPath] : []),
+    ...publicDocs.map((source) => resolve(absoluteRoot, source)),
     ...atomDirs.flatMap(({ dir }) => collectComponentDocuments(resolve(absoluteRoot, dir))),
   ].filter((path) => existsSync(path) && statSync(path).isFile());
 
-  return absolutePaths.map((absolutePath) => {
+  return [...new Set(absolutePaths)].map((absolutePath) => {
     const source = normalizePath(relative(absoluteRoot, absolutePath));
     return { absolutePath, kind: inferKind(source), source };
   });

--- a/packages/docs-kit/site/compiler/content/gfmTables.test.ts
+++ b/packages/docs-kit/site/compiler/content/gfmTables.test.ts
@@ -34,7 +34,7 @@ it('compiles GFM markdown tables in component docs into real table markup', asyn
   expect(html).toContain('contentLayoutAnimation');
   expect(html).toContain('disableDestroyOnInvalidTrigger');
   expect(html).not.toMatch(/\| Property\s+\| Description/);
-}, 90_000);
+}, 120_000);
 
 it('preserves escaped pipes inside GFM table cells', async () => {
   const html = await renderDocument('/src/base-ui/Popover/index.mdx');
@@ -42,4 +42,4 @@ it('preserves escaped pipes inside GFM table cells', async () => {
   expect(html).toContain('Omit&lt;PopoverProps, &#x27;children&#x27;');
   expect(html).toMatch(/defaultOpen/);
   expect(html).not.toMatch(/\| `Omit/);
-}, 90_000);
+}, 120_000);

--- a/packages/docs-kit/site/compiler/content/mdxPlugin.ts
+++ b/packages/docs-kit/site/compiler/content/mdxPlugin.ts
@@ -1,9 +1,11 @@
+import { resolve } from 'node:path';
+
 import mdx from '@mdx-js/rollup';
 import rehypeRaw from 'rehype-raw';
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkGfm from 'remark-gfm';
 import remarkMdxFrontmatter from 'remark-mdx-frontmatter';
-import type { Plugin } from 'vite';
+import { normalizePath, type Plugin } from 'vite';
 
 import { remarkApi } from '../api/remarkApi';
 import { rehypeHeadingIds } from './rehypeHeadingIds';
@@ -25,7 +27,7 @@ const mdxPassThroughNodeTypes = [
 export function createMdxPlugin(): Plugin {
   return mdx({
     include: /\.(md|mdx)$/,
-    providerImportSource: '/packages/docs-kit/site/app/mdx-components',
+    providerImportSource: normalizePath(resolve(import.meta.dirname, '../../app/mdx-components')),
     // rehype-raw expands the raw HTML nodes that `.md` format keeps around
     // (details/summary/kbd/div, entities); without it @mdx-js/mdx's
     // rehypeRemoveRaw silently drops that markup for `format: 'md'` files

--- a/packages/docs-kit/site/compiler/demo/demoPlugin.test.ts
+++ b/packages/docs-kit/site/compiler/demo/demoPlugin.test.ts
@@ -239,7 +239,7 @@ export const loadHelper = () => import('./secondary');
       const timeout = setTimeout(() => {
         server!.watcher.off('change', onChange);
         rejectObserved(new Error(`Timed out waiting for Vite watcher: ${path}`));
-      }, 30_000);
+      }, 120_000);
       const onChange = (changedPath: string) => {
         if (resolve(changedPath) !== resolve(path)) return;
         clearTimeout(timeout);

--- a/packages/docs-kit/site/compiler/demo/demoPlugin.test.ts
+++ b/packages/docs-kit/site/compiler/demo/demoPlugin.test.ts
@@ -108,8 +108,11 @@ it('loads the editable scope without evaluating the selected demo entry', async 
 it('resolves repository aliases from virtual editable scope modules', async () => {
   const root = createTemporaryProject({
     'compatibility.json': compatibilitySource('legacy-alias', 'docs/alias'),
-    'demo.tsx': "import { Flexbox } from '@/Flex';\nexport default () => Flexbox;\n",
+    'demo.tsx':
+      "import { Flexbox } from '@/Flex';\nimport { SelfFlexbox } from '@example/editor/SelfFlex';\nexport default () => [Flexbox, SelfFlexbox];\n",
+    'package.json': '{"name":"@example/editor","type":"module"}\n',
     'src/Flex.ts': "export const Flexbox = () => 'flexbox';\n",
+    'src/SelfFlex.ts': "export const SelfFlexbox = () => 'self-flexbox';\n",
   });
   server = await createServer({
     configFile: false,
@@ -123,6 +126,7 @@ it('resolves repository aliases from virtual editable scope modules', async () =
   const scope = await descriptor.loadScope();
 
   expect(scope.Flexbox).toBeTypeOf('function');
+  expect(scope.SelfFlexbox).toBeTypeOf('function');
 });
 
 it('preserves empty JavaScript imports as editable-scope side effects', async () => {

--- a/packages/docs-kit/site/compiler/demo/demoPlugin.ts
+++ b/packages/docs-kit/site/compiler/demo/demoPlugin.ts
@@ -57,11 +57,28 @@ const decodeVirtualPath = (path: string): string => decodeURIComponent(path);
 const scopeModuleId = (sourcePath: string): string =>
   `${scopePrefix}${encodeVirtualPath(sourcePath)}`;
 
-const resolveRepositoryAlias = (root: string, source: string): string | undefined => {
+const readRepositoryPackageName = (root: string): string | undefined => {
+  const packagePath = resolve(root, 'package.json');
+  if (!existsSync(packagePath)) return;
+
+  try {
+    const packageJson = JSON.parse(readFileSync(packagePath, 'utf8')) as { name?: unknown };
+    return typeof packageJson.name === 'string' ? packageJson.name : undefined;
+  } catch {
+    return;
+  }
+};
+
+const resolveRepositoryAlias = (
+  root: string,
+  packageName: string | undefined,
+  source: string,
+): string | undefined => {
   if (source.startsWith('@/')) return resolve(root, 'src', source.slice(2));
-  if (source === '@lobehub/ui') return resolve(root, 'src');
-  if (source.startsWith('@lobehub/ui/')) {
-    return resolve(root, 'src', source.slice('@lobehub/ui/'.length));
+  if (!packageName) return;
+  if (source === packageName) return resolve(root, 'src');
+  if (source.startsWith(`${packageName}/`)) {
+    return resolve(root, 'src', source.slice(packageName.length + 1));
   }
 };
 
@@ -163,6 +180,7 @@ const formatDiagnostic = (analysis: DemoAnalysis): string[] =>
 
 export function demoPlugin(options: DemoPluginOptions = {}): Plugin {
   let root = canonicalPath(options.root ?? process.cwd());
+  let packageName = readRepositoryPackageName(root);
   const resolveCompatibilityPath = () =>
     options.compatibilityPath
       ? canonicalPath(resolve(root, options.compatibilityPath))
@@ -233,6 +251,7 @@ export function demoPlugin(options: DemoPluginOptions = {}): Plugin {
     configResolved(config) {
       if (options.root) return;
       root = canonicalPath(config.root);
+      packageName = readRepositoryPackageName(root);
       compatibilityPath = resolveCompatibilityPath();
       compatibility = undefined;
     },
@@ -285,7 +304,7 @@ export function demoPlugin(options: DemoPluginOptions = {}): Plugin {
     name: 'lobe-docs-demo',
     async resolveId(source, importer) {
       if (importer?.startsWith(scopePrefix)) {
-        const aliasPath = resolveRepositoryAlias(root, source);
+        const aliasPath = resolveRepositoryAlias(root, packageName, source);
         if (aliasPath) {
           return (await this.resolve(aliasPath, undefined, { skipSelf: true }))?.id ?? aliasPath;
         }

--- a/packages/docs-kit/site/compiler/demo/i18nDynamicImport.test.ts
+++ b/packages/docs-kit/site/compiler/demo/i18nDynamicImport.test.ts
@@ -35,4 +35,4 @@ it('renders the production dynamic-import demo through the read-only source cont
   expect(frame.attr('data-demo-editable')).toBe('false');
   expect(toolbarLabels).toContain('Show source');
   expect(toolbarLabels).not.toContain('Show source editor');
-}, 30_000);
+}, 120_000);

--- a/packages/docs-kit/site/compiler/finalizeBuild.ts
+++ b/packages/docs-kit/site/compiler/finalizeBuild.ts
@@ -109,7 +109,7 @@ export async function finalizeDocumentationBuild(
   { clientDirectory, outputDirectory, repositoryRoot }: FinalizeBuildOptions,
   dependencies: FinalizeBuildDependencies = {},
 ): Promise<MigrationCoverageResult> {
-  const root = path.resolve(repositoryRoot ?? path.resolve(import.meta.dirname, '../../../..'));
+  const root = path.resolve(repositoryRoot ?? process.cwd());
   const client = path.resolve(clientDirectory);
   const output = path.resolve(outputDirectory);
   const outputParent = path.dirname(output);
@@ -129,6 +129,7 @@ export async function finalizeDocumentationBuild(
         root,
         docsConfig?.atomDirs ?? defaultAtomDirs,
         docsConfig?.navSections ?? {},
+        docsConfig?.publicDocs ?? [],
       ).documents;
     const expectedStandalonePaths =
       dependencies.expectedStandalonePaths ?? getStandaloneDemoPaths(compatibility);

--- a/packages/docs-kit/site/compiler/inventory.test.ts
+++ b/packages/docs-kit/site/compiler/inventory.test.ts
@@ -13,6 +13,7 @@ const buildRealInventory = (): DocumentationInventory =>
     atomDirs: realConfig.atomDirs,
     legacyRedirects: realConfig.legacyRedirects,
     navSections: realConfig.navSections,
+    publicDocs: realConfig.publicDocs,
   });
 
 const temporaryRoots: string[] = [];
@@ -248,6 +249,33 @@ title: Fixture
     expect(sections['src/i18n/index.md']).toBe('Hooks & Providers');
     expect(sections['docs/index.md']).toBe('Home');
     expect(sections['docs/changelog.md']).toBe('Changelog');
+  });
+
+  it('freezes explicitly configured public guides without discovering internal docs', () => {
+    const root = createFixture({
+      'docs/components.md': `---
+title: Components
+description: Component documentation index.
+route: /components/
+---
+`,
+      'docs/internal.md': '---\ntitle: Internal\n---\n',
+      'src/Fixture/index.md': '---\ntitle: Fixture\n---\n',
+    });
+
+    const inventory = buildDocumentationInventory(root, {
+      publicDocs: ['docs/components.mdx'],
+    });
+
+    expect(inventory.documents).toContainEqual({
+      description: 'Component documentation index.',
+      legacyRouteId: 'docs/components',
+      pathname: '/components',
+      section: 'Guides',
+      source: 'docs/components.md',
+      title: 'Components',
+    });
+    expect(inventory.documents.some(({ source }) => source === 'docs/internal.md')).toBe(false);
   });
 
   it('retains the home page description from its hero metadata', () => {

--- a/packages/docs-kit/site/compiler/inventory.ts
+++ b/packages/docs-kit/site/compiler/inventory.ts
@@ -6,8 +6,9 @@ import remarkParse from 'remark-parse';
 import { unified } from 'unified';
 import type { Node, Parent } from 'unist';
 
-import { packageNamespaces } from '../../../../config/packageNamespaces';
 import { type AtomDirConfig } from '../../src/config';
+import { packageNamespaces } from '../../src/packageNamespaces';
+import { canonicalizePathname } from '../content/pathname';
 import { deriveComponentRoute, resolveAtomDir } from './content/atomRouting';
 import { defaultAtomDirs } from './content/discoverDocuments';
 import { createLegacyDemoId } from './legacyDumiIds';
@@ -189,12 +190,20 @@ const parseCodeTag = (value: string, document: string): ParsedCodeTag | undefine
 
 const deriveDocumentLocation = (
   source: string,
+  frontmatter: FrontmatterRecord,
   atomDirs: readonly AtomDirConfig[],
 ): Pick<DocumentRecord, 'legacyRouteId' | 'pathname'> => {
   const stem = documentStem(source);
   if (stem === 'docs/index') return { legacyRouteId: 'docs/index', pathname: '/' };
   if (stem === 'docs/changelog') {
     return { legacyRouteId: 'docs/changelog', pathname: '/changelog' };
+  }
+  if (stem.startsWith('docs/')) {
+    const route = getString(frontmatter, 'route');
+    const pathname = route
+      ? canonicalizePathname(route)
+      : canonicalizePathname(`/${stem.slice('docs/'.length).replace(/\/index$/, '')}`);
+    return { legacyRouteId: stem, pathname };
   }
 
   const atomDir = resolveAtomDir(stem, atomDirs);
@@ -211,6 +220,7 @@ const deriveDocumentSection = (source: string, navSections: Record<string, strin
   const stem = documentStem(source);
   if (stem === 'docs/index') return 'Home';
   if (stem === 'docs/changelog') return 'Changelog';
+  if (stem.startsWith('docs/')) return 'Guides';
 
   const override = navSections[`${stem}.mdx`] ?? navSections[`${stem}.md`];
   if (override) return override;
@@ -275,7 +285,7 @@ const createDocumentRecord = (
   atomDirs: readonly AtomDirConfig[],
   navSections: Record<string, string>,
 ): DocumentRecord => {
-  const location = deriveDocumentLocation(source, atomDirs);
+  const location = deriveDocumentLocation(source, frontmatter, atomDirs);
   const category =
     getString(frontmatter, 'group') ?? getNestedString(frontmatter, 'group', 'title');
   const description =
@@ -377,6 +387,7 @@ export interface BuildDocumentationInventoryOptions {
   atomDirs?: readonly AtomDirConfig[];
   legacyRedirects?: DocumentationInventory;
   navSections?: Record<string, string>;
+  publicDocs?: readonly string[];
 }
 
 export function buildDocumentationInventory(
@@ -386,21 +397,26 @@ export function buildDocumentationInventory(
   const absoluteRoot = resolve(root);
   const atomDirs = options.atomDirs ?? defaultAtomDirs;
   const navSections = options.navSections ?? {};
+  const publicDocs = options.publicDocs ?? [];
   const frozenInventory = options.legacyRedirects;
   const requiredStems = new Set<string>([
     ...publicDocumentationStems,
+    ...publicDocs.map(documentStem),
     ...(frozenInventory?.documents.map(({ source }) => documentStem(source)) ?? []),
   ]);
 
   for (const stem of requiredStems) selectDocumentFormat(absoluteRoot, stem);
 
   const sources = [
-    ...atomDirs.flatMap(({ dir }) =>
-      collectSourceDocuments(resolve(absoluteRoot, dir)).map((path) =>
-        normalizePath(relative(absoluteRoot, path)),
+    ...new Set([
+      ...atomDirs.flatMap(({ dir }) =>
+        collectSourceDocuments(resolve(absoluteRoot, dir)).map((path) =>
+          normalizePath(relative(absoluteRoot, path)),
+        ),
       ),
-    ),
-    ...publicDocumentationStems.map((stem) => selectDocumentFormat(absoluteRoot, stem)),
+      ...publicDocumentationStems.map((stem) => selectDocumentFormat(absoluteRoot, stem)),
+      ...publicDocs.map((source) => selectDocumentFormat(absoluteRoot, documentStem(source))),
+    ]),
   ].sort(sortStrings);
 
   const documents: DocumentRecord[] = [];

--- a/packages/docs-kit/site/compiler/manifests.ts
+++ b/packages/docs-kit/site/compiler/manifests.ts
@@ -1,11 +1,9 @@
-import path from 'node:path';
-
 import { emptyLegacyRedirects, getDocsConfig } from '../../src/config';
 import { createContentManifest } from './content/createManifest';
 import { defaultAtomDirs } from './content/discoverDocuments';
 import { getStandaloneDemoPaths } from './demo/readLegacyMap';
 
-const repositoryRoot = path.resolve(import.meta.dirname, '../../../..');
+const repositoryRoot = process.cwd();
 
 export function getPrerenderPaths(): string[] {
   const config = getDocsConfig(repositoryRoot);
@@ -16,6 +14,7 @@ export function getPrerenderPaths(): string[] {
       repositoryRoot,
       config.atomDirs ?? defaultAtomDirs,
       config.navSections ?? {},
+      config.publicDocs ?? [],
     ).documents.map(({ pathname }) => pathname),
     '/404',
     '/antd.css',

--- a/packages/docs-kit/site/compiler/search/devPagefindPlugin.ts
+++ b/packages/docs-kit/site/compiler/search/devPagefindPlugin.ts
@@ -268,6 +268,7 @@ export function devPagefindPlugin(options: DevPagefindPluginOptions = {}): Plugi
               root,
               docsConfig.atomDirs ?? defaultAtomDirs,
               docsConfig.navSections ?? {},
+              docsConfig.publicDocs ?? [],
             ).documents.map(({ pathname }) => pathname);
           return buildDevPagefindFiles({
             api: await getApi(),

--- a/packages/docs-kit/site/compiler/vitePlugin.ts
+++ b/packages/docs-kit/site/compiler/vitePlugin.ts
@@ -90,8 +90,11 @@ export function lobeDocsDocumentModulesPlugin(root: string = process.cwd()): Plu
       const publicPatterns = [
         '/docs/index.mdx',
         '/docs/changelog.mdx',
+        ...(config.publicDocs ?? []).map(
+          (source) => `/${source.replace(/^\.\//, '').replace(/^\//, '')}`,
+        ),
         ...(useChangelogFallback ? ['/CHANGELOG.md'] : []),
-      ];
+      ].filter((source, index, sources) => sources.indexOf(source) === index);
 
       return `export const componentMetadata = import.meta.glob(${JSON.stringify(componentPatterns)}, {
   eager: true,
@@ -130,6 +133,7 @@ export function lobeDocs(root: string = process.cwd()): Plugin[] {
           path,
           docsConfig.atomDirs ?? defaultAtomDirs,
           docsConfig.navSections ?? {},
+          docsConfig.publicDocs ?? [],
         ).documents[0];
         if (!document) throw new Error(`No public document metadata found for ${path}`);
 

--- a/packages/docs-kit/site/components/Demo/Demo.tsx
+++ b/packages/docs-kit/site/components/Demo/Demo.tsx
@@ -1,6 +1,4 @@
-import ActionIcon from '@lobehub/ui/ActionIcon';
-import type { DropdownItem } from '@lobehub/ui/DropdownMenu';
-import DropdownMenu from '@lobehub/ui/DropdownMenu';
+import { ActionIcon, type DropdownItem, DropdownMenu } from '@lobehub/ui';
 import {
   Code,
   Copy,

--- a/packages/docs-kit/site/components/Demo/DemoEnvironment.tsx
+++ b/packages/docs-kit/site/components/Demo/DemoEnvironment.tsx
@@ -1,8 +1,6 @@
+import { ConfigProvider, ThemeProvider } from '@lobehub/ui';
 import { motion } from 'motion/react';
 import type { CSSProperties, PropsWithChildren } from 'react';
-
-import ConfigProvider from '@/ConfigProvider';
-import ThemeProvider from '@/ThemeProvider';
 
 import type { DemoAppearance } from '../../types/demo';
 

--- a/packages/docs-kit/site/components/DocsLayout/DocsLayout.tsx
+++ b/packages/docs-kit/site/components/DocsLayout/DocsLayout.tsx
@@ -1,5 +1,5 @@
-import { GithubIcon } from '@lobehub/ui/icons/lucideExtra';
-import { ScrollArea } from '@lobehub/ui/ScrollArea';
+import { ScrollArea } from '@lobehub/ui';
+import { GithubIcon } from '@lobehub/ui/icons';
 import { ArrowLeft, ArrowRight, ArrowUpRight, PencilLine } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { Link } from 'react-router';

--- a/packages/docs-kit/site/components/Feedback/PageEndActions.tsx
+++ b/packages/docs-kit/site/components/Feedback/PageEndActions.tsx
@@ -1,5 +1,5 @@
-import ActionIcon from '@lobehub/ui/ActionIcon';
-import { GithubIcon } from '@lobehub/ui/icons/lucideExtra';
+import { ActionIcon } from '@lobehub/ui';
+import { GithubIcon } from '@lobehub/ui/icons';
 import { MessageCircle, ThumbsDown, ThumbsUp } from 'lucide-react';
 import type { ComponentType } from 'react';
 import { useCallback, useEffect, useId, useRef, useState } from 'react';

--- a/packages/docs-kit/site/components/Header/Header.test.tsx
+++ b/packages/docs-kit/site/components/Header/Header.test.tsx
@@ -5,7 +5,7 @@ import siteConfig from 'virtual:lobedocs/site-config';
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 
 import { SiteProviders, THEME_STORAGE_KEY } from '../../app/providers/SiteProviders';
-import type { DocumentManifestEntry } from '../../types/content';
+import type { DocumentManifestEntry, NavigationSection } from '../../types/content';
 import { Header } from './Header';
 
 if (!Element.prototype.getAnimations) {
@@ -27,6 +27,39 @@ const alphaDocument: DocumentManifestEntry = {
   source: 'src/Alpha/index.mdx',
   title: 'Alpha',
 };
+
+const createSection = (title: string, pathname: string): NavigationSection => ({
+  categories: [
+    {
+      documents: [{ ...alphaDocument, pathname, title: `${title} entry` }],
+      title: 'General',
+    },
+  ],
+  title,
+});
+
+const createRect = ({
+  height,
+  left,
+  top,
+  width,
+}: {
+  height: number;
+  left: number;
+  top: number;
+  width: number;
+}): DOMRect =>
+  ({
+    bottom: top + height,
+    height,
+    left,
+    right: left + width,
+    toJSON: () => ({}),
+    top,
+    width,
+    x: left,
+    y: top,
+  }) as DOMRect;
 
 const createMatchMedia =
   (matchesQuery?: string) =>
@@ -71,6 +104,7 @@ afterEach(() => {
   cleanup();
   localStorage.clear();
   delete document.documentElement.dataset.theme;
+  vi.restoreAllMocks();
 });
 
 it('selects theme preference through a dropdown menu with a system option', async () => {
@@ -108,19 +142,12 @@ it('marks the active section tab and lists overflow sections in the more menu', 
   renderHeader(
     <Header
       navigation={[
-        {
-          categories: [{ documents: [alphaDocument], title: 'General' }],
-          title: 'Components',
-        },
-        {
-          categories: [
-            {
-              documents: [{ ...alphaDocument, pathname: '/components/color-a', title: 'ColorA' }],
-              title: 'General',
-            },
-          ],
-          title: 'Color',
-        },
+        createSection('Components', alphaDocument.pathname),
+        createSection('Base UI', '/components/base-ui/alpha'),
+        createSection('Chat', '/components/chat/alpha'),
+        createSection('Icons', '/components/icons/alpha'),
+        createSection('Brand', '/components/brand/alpha'),
+        createSection('Color', '/components/color-a'),
       ]}
       onSearchOpen={vi.fn()}
     />,
@@ -132,7 +159,7 @@ it('marks the active section tab and lists overflow sections in the more menu', 
   expect(componentsTab.getAttribute('aria-current')).toBe('true');
   expect(componentsTab.getAttribute('href')).toBe(alphaDocument.pathname);
 
-  openMenu(within(nav).getByRole('button', { name: 'More documentation sections' }));
+  openMenu(within(nav).getByRole('button', { name: 'More navigation links' }));
   const menu = await screen.findByRole('menu');
   expect(within(menu).getByRole('menuitem', { name: 'Changelog' })).toBeTruthy();
 
@@ -141,6 +168,73 @@ it('marks the active section tab and lists overflow sections in the more menu', 
   await waitFor(() =>
     expect(screen.getByTestId('location').textContent).toBe('/components/color-a'),
   );
+});
+
+it('keeps one indicator positioned relative to the navigation across route and viewport offsets', async () => {
+  let navLeft = 80;
+  let navTop = -1400;
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+    this: HTMLElement,
+  ) {
+    if (this.getAttribute('aria-label') === 'Documentation sections') {
+      return createRect({ height: 55, left: navLeft, top: navTop, width: 480 });
+    }
+
+    if (this.getAttribute('href') === '/') {
+      return createRect({ height: 55, left: navLeft + 20, top: navTop, width: 64 });
+    }
+
+    if (this.getAttribute('href') === alphaDocument.pathname) {
+      return createRect({ height: 55, left: navLeft + 92, top: navTop, width: 112 });
+    }
+
+    return createRect({ height: 0, left: 0, top: 0, width: 0 });
+  });
+
+  const { container } = renderHeader(
+    <Header
+      navigation={[createSection('Components', alphaDocument.pathname)]}
+      onSearchOpen={vi.fn()}
+    />,
+    ['/'],
+  );
+
+  const initialIndicator = container.querySelector<HTMLElement>('[data-header-nav-indicator]');
+  expect(initialIndicator?.style.transform).toBe('translate3d(20px, 0, 0)');
+  expect(initialIndicator?.style.width).toBe('64px');
+
+  navLeft = 260;
+  navTop = 0;
+  fireEvent.click(screen.getByRole('link', { name: 'Components' }));
+
+  await waitFor(() => {
+    const indicator = container.querySelector<HTMLElement>('[data-header-nav-indicator]');
+    expect(indicator).toBe(initialIndicator);
+    expect(indicator?.style.transform).toBe('translate3d(92px, 0, 0)');
+    expect(indicator?.style.width).toBe('112px');
+  });
+
+  expect(container.querySelectorAll('[data-header-nav-indicator]')).toHaveLength(1);
+});
+
+it('keeps consumer-specific documentation sections visible in the primary navigation', () => {
+  renderHeader(
+    <Header
+      navigation={[
+        createSection('React', '/components/react/editor'),
+        createSection('Plugins', '/components/plugins/common'),
+        createSection('Renderer', '/components/renderer/lexical-renderer'),
+      ]}
+      onSearchOpen={vi.fn()}
+    />,
+  );
+
+  const nav = screen.getByRole('navigation', { name: 'Documentation sections' });
+  expect(
+    within(nav)
+      .getAllByRole('link')
+      .map((link) => link.textContent),
+  ).toEqual(['Home', 'React', 'Plugins', 'Renderer']);
 });
 
 it('exposes enabled desktop and mobile search entry points with their invoking controls', () => {
@@ -227,6 +321,8 @@ it('preserves the active nested link and closes the mobile sheet after navigatio
 
 it('renders the GitHub icon link and theme switcher from themeConfig', () => {
   renderHeader(<Header navigation={[]} onSearchOpen={vi.fn()} />);
+
+  expect(screen.getByRole('link', { name: `${siteConfig.title} documentation home` })).toBeTruthy();
 
   const githubLink = siteConfig.themeConfig?.socialLinks?.find((link) => link.icon === 'github');
   expect(githubLink).toBeDefined();

--- a/packages/docs-kit/site/components/Header/Header.themeConfig.test.tsx
+++ b/packages/docs-kit/site/components/Header/Header.themeConfig.test.tsx
@@ -1,8 +1,8 @@
-import { cleanup, render, screen, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 
-import { SiteProviders } from '../../app/providers/SiteProviders';
+import { SiteProviders, useSiteTheme } from '../../app/providers/SiteProviders';
 import { Header } from './Header';
 
 vi.mock('virtual:lobedocs/site-config', () => ({
@@ -54,10 +54,36 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
-it('renders configured navItems as internal and external links, and configured actions', () => {
+const openMenu = (trigger: HTMLElement) => {
+  fireEvent.pointerDown(trigger);
+  fireEvent.mouseDown(trigger);
+  fireEvent.click(trigger);
+};
+
+const ThemeProbe = () => {
+  const { appearance, preference } = useSiteTheme();
+
+  return <output data-preference={preference}>{appearance}</output>;
+};
+
+it('exposes the configured forced theme during the initial render', () => {
+  render(
+    <SiteProviders>
+      <ThemeProbe />
+    </SiteProviders>,
+  );
+
+  const probe = screen.getByText('dark');
+  expect(probe.getAttribute('data-preference')).toBe('dark');
+});
+
+it('keeps internal navItems visible and moves external ecosystem links into the more menu', async () => {
+  const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+
   render(
     <SiteProviders>
       <MemoryRouter>
@@ -71,10 +97,14 @@ it('renders configured navItems as internal and external links, and configured a
   expect(guidesLink.getAttribute('href')).toBe('/guides/getting-started');
   expect(guidesLink.getAttribute('target')).toBeNull();
 
-  const blogLink = within(nav).getByRole('link', { name: 'Blog' });
-  expect(blogLink.getAttribute('href')).toBe('https://example.com/blog');
-  expect(blogLink.getAttribute('target')).toBe('_blank');
-  expect(blogLink.getAttribute('rel')).toBe('noreferrer');
+  expect(within(nav).queryByRole('link', { name: 'Blog' })).toBeNull();
+
+  openMenu(within(nav).getByRole('button', { name: 'More navigation links' }));
+  const menu = await screen.findByRole('menu');
+  const blogItem = within(menu).getByRole('menuitem', { name: 'Blog' });
+  fireEvent.click(blogItem);
+  expect(open).toHaveBeenCalledWith('https://example.com/blog', '_blank', 'noopener,noreferrer');
+  expect(within(menu).getByRole('menuitem', { name: 'Changelog' })).toBeTruthy();
 
   const sponsorLink = screen.getByRole('link', { name: 'Sponsor' });
   expect(sponsorLink.getAttribute('href')).toBe('https://example.com/sponsor');
@@ -82,5 +112,8 @@ it('renders configured navItems as internal and external links, and configured a
   expect(sponsorLink.getAttribute('rel')).toBe('noreferrer');
 
   const navLinks = within(nav).getAllByRole('link');
-  expect(navLinks.map((link) => link.textContent)).toEqual(['Home', 'Guides', 'Blog']);
+  expect(navLinks.map((link) => link.textContent)).toEqual(['Home', 'Guides']);
+
+  const homeLink = screen.getByRole('link', { name: 'Test Docs documentation home' });
+  expect(homeLink.textContent).toContain('Test Docs');
 });

--- a/packages/docs-kit/site/components/Header/Header.tsx
+++ b/packages/docs-kit/site/components/Header/Header.tsx
@@ -1,12 +1,8 @@
+import { type DropdownItem, DropdownMenu, Hotkey, ScrollArea } from '@lobehub/ui';
 import { LobeHubText } from '@lobehub/ui/brand';
-import type { DropdownItem } from '@lobehub/ui/DropdownMenu';
-import DropdownMenu from '@lobehub/ui/DropdownMenu';
-import Hotkey from '@lobehub/ui/Hotkey';
-import { GithubIcon } from '@lobehub/ui/icons/lucideExtra';
-import { ScrollArea } from '@lobehub/ui/ScrollArea';
+import { GithubIcon } from '@lobehub/ui/icons';
 import { Ellipsis, Menu, Search, X } from 'lucide-react';
-import { motion } from 'motion/react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Link, useLocation, useNavigate } from 'react-router';
 import siteConfig from 'virtual:lobedocs/site-config';
@@ -29,16 +25,16 @@ const LOGO_URL =
 // be larger than the 3d logo for letter ink to optically match the icon.
 const LOGO_SIZE = 20;
 
-const primarySectionTitles = ['Components', 'Base UI', 'Chat', 'Icons', 'Brand'];
+const MAX_PRIMARY_SECTIONS = 5;
+const preferredSectionTitles = ['Components', 'Base UI', 'Chat', 'Icons', 'Brand'];
 
-const NavIndicator = () => (
-  <motion.span
-    aria-hidden
-    className={styles.navIndicator}
-    layoutId="site-header-nav-indicator"
-    transition={{ bounce: 0.25, duration: 0.4, type: 'spring' }}
-  />
-);
+interface IndicatorGeometry {
+  width: number;
+  x: number;
+}
+
+const isSameGeometry = (left: IndicatorGeometry, right: IndicatorGeometry) =>
+  left.width === right.width && left.x === right.x;
 
 const SHEET_EXIT_DURATION = 180;
 
@@ -53,19 +49,29 @@ const prefersReducedMotion = () => {
 export function Header({ navigation, onSearchOpen }: HeaderProps) {
   const [sheetState, setSheetState] = useState<'closed' | 'closing' | 'open'>('closed');
   const [atTop, setAtTop] = useState(true);
+  const [isAppleShortcut, setIsAppleShortcut] = useState(false);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const closeTimerRef = useRef<number | undefined>(undefined);
+  const indicatorGeometryRef = useRef<IndicatorGeometry>(undefined);
+  const indicatorRef = useRef<HTMLSpanElement>(null);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
+  const navRef = useRef<HTMLElement>(null);
   const { pathname } = useLocation();
   const navigate = useNavigate();
 
   const activeSection = findSectionByPathname(navigation, pathname);
-  const primarySections = primarySectionTitles
+  const preferredSections = preferredSectionTitles
     .map((title) => navigation.find((section) => section.title === title))
     .filter((section) => section !== undefined);
-  const overflowSections = navigation.filter(
-    (section) => !primarySectionTitles.includes(section.title),
+  const remainingSections = navigation.filter(
+    (section) => !preferredSectionTitles.includes(section.title),
   );
+  const primarySections = [...preferredSections, ...remainingSections].slice(
+    0,
+    MAX_PRIMARY_SECTIONS,
+  );
+  const primarySectionSet = new Set(primarySections);
+  const overflowSections = navigation.filter((section) => !primarySectionSet.has(section));
 
   const openNavigation = useCallback(() => {
     window.clearTimeout(closeTimerRef.current);
@@ -120,6 +126,10 @@ export function Header({ navigation, onSearchOpen }: HeaderProps) {
     return () => window.removeEventListener('scroll', handleScroll);
   }, [pathname]);
 
+  useEffect(() => {
+    setIsAppleShortcut(/mac|iphone|ipod|ipad|ios/i.test(navigator.userAgent));
+  }, []);
+
   const handleSheetKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
     if (event.key !== 'Tab') return;
     const controls = Array.from(
@@ -142,21 +152,85 @@ export function Header({ navigation, onSearchOpen }: HeaderProps) {
 
   const isHome = pathname === '/';
   const navItems = siteConfig.themeConfig?.navItems ?? [];
+  const directNavItems = navItems.filter((item) => !item.external);
+  const externalNavItems = navItems.filter((item) => item.external);
   const actions = siteConfig.themeConfig?.actions ?? [];
   const githubSocialLink = siteConfig.themeConfig?.socialLinks?.find(
     (link) => link.icon === 'github',
   );
+  const productName = siteConfig.title.replace(/^Lobe(?:Hub)?\s+/i, '') || siteConfig.title;
   const showThemeMenu = (siteConfig.themeConfig?.prefersColor ?? 'auto') === 'auto';
 
+  const secondaryItems: DropdownItem[] = [
+    ...externalNavItems.map((item) => ({
+      key: `nav:${item.label}`,
+      label: item.label,
+      onClick: () => window.open(item.href, '_blank', 'noopener,noreferrer'),
+    })),
+    ...(navItems.some((item) => item.href === '/changelog')
+      ? []
+      : [{ key: 'changelog', label: 'Changelog', onClick: () => navigate('/changelog') }]),
+  ];
   const moreItems: DropdownItem[] = [
     ...overflowSections.map((section) => ({
-      key: section.title,
+      key: `section:${section.title}`,
       label: section.title,
       onClick: () => navigate(sectionLandingPathname(section)),
     })),
-    { type: 'divider' as const },
-    { key: 'changelog', label: 'Changelog', onClick: () => navigate('/changelog') },
+    ...(overflowSections.length > 0 && secondaryItems.length > 0
+      ? [{ type: 'divider' as const }]
+      : []),
+    ...secondaryItems,
   ];
+  const isMoreActive =
+    (activeSection ? overflowSections.includes(activeSection) : false) ||
+    (!navItems.some((item) => item.href === '/changelog') && pathname === '/changelog');
+
+  const measureIndicator = useCallback(() => {
+    const nav = navRef.current;
+    const indicator = indicatorRef.current;
+    const activeTab = nav?.querySelector<HTMLElement>('[aria-current]');
+
+    if (!nav || !indicator || !activeTab) {
+      indicatorGeometryRef.current = undefined;
+      indicator?.removeAttribute('data-positioned');
+      return;
+    }
+
+    const navRect = nav.getBoundingClientRect();
+    const activeRect = activeTab.getBoundingClientRect();
+    const nextGeometry = {
+      width: activeRect.width,
+      x: activeRect.left - navRect.left,
+    };
+
+    if (indicatorGeometryRef.current && isSameGeometry(indicatorGeometryRef.current, nextGeometry))
+      return;
+
+    indicatorGeometryRef.current = nextGeometry;
+    indicator.style.transform = `translate3d(${nextGeometry.x}px, 0, 0)`;
+    indicator.style.width = `${nextGeometry.width}px`;
+    indicator.setAttribute('data-positioned', '');
+
+    if (!indicator.hasAttribute('data-animated')) {
+      indicator.getBoundingClientRect();
+      indicator.setAttribute('data-animated', '');
+    }
+  }, []);
+
+  useLayoutEffect(() => {
+    measureIndicator();
+
+    const nav = navRef.current;
+    const activeTab = nav?.querySelector<HTMLElement>('[aria-current]');
+    if (!nav || !activeTab || typeof ResizeObserver === 'undefined') return;
+
+    const resizeObserver = new ResizeObserver(measureIndicator);
+    resizeObserver.observe(nav);
+    resizeObserver.observe(activeTab);
+
+    return () => resizeObserver.disconnect();
+  }, [measureIndicator, navigation, pathname]);
 
   return (
     <>
@@ -174,7 +248,11 @@ export function Header({ navigation, onSearchOpen }: HeaderProps) {
             <Menu aria-hidden size={18} strokeWidth={1.8} />
           </button>
 
-          <Link aria-label="Lobe UI documentation home" className={styles.brand} to="/">
+          <Link
+            aria-label={`${siteConfig.title} documentation home`}
+            className={styles.brand}
+            to="/"
+          >
             <img
               aria-hidden
               alt=""
@@ -187,13 +265,18 @@ export function Header({ navigation, onSearchOpen }: HeaderProps) {
             <span aria-hidden className={styles.brandDivider}>
               /
             </span>
-            <span className={styles.productName}>UI</span>
+            <span className={styles.productName}>{productName}</span>
           </Link>
 
-          <nav aria-label="Documentation sections" className={styles.nav}>
+          <nav aria-label="Documentation sections" className={styles.nav} ref={navRef}>
+            <span
+              aria-hidden
+              className={styles.navIndicator}
+              data-header-nav-indicator=""
+              ref={indicatorRef}
+            />
             <Link aria-current={isHome ? 'page' : undefined} className={styles.navLink} to="/">
               Home
-              {isHome ? <NavIndicator /> : null}
             </Link>
             {primarySections.map((section) => (
               <Link
@@ -203,13 +286,13 @@ export function Header({ navigation, onSearchOpen }: HeaderProps) {
                 to={sectionLandingPathname(section)}
               >
                 {section.title}
-                {section === activeSection ? <NavIndicator /> : null}
               </Link>
             ))}
-            {overflowSections.length > 0 ? (
+            {moreItems.length > 0 ? (
               <DropdownMenu items={moreItems} placement="bottomLeft">
                 <button
-                  aria-label="More documentation sections"
+                  aria-current={isMoreActive ? 'true' : undefined}
+                  aria-label="More navigation links"
                   className={`${styles.navLink} ${styles.moreButton}`}
                   type="button"
                 >
@@ -217,23 +300,16 @@ export function Header({ navigation, onSearchOpen }: HeaderProps) {
                 </button>
               </DropdownMenu>
             ) : null}
-            {navItems.map((item) =>
-              item.external ? (
-                <a
-                  className={styles.navLink}
-                  href={item.href}
-                  key={item.label}
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  {item.label}
-                </a>
-              ) : (
-                <Link className={styles.navLink} key={item.label} to={item.href}>
-                  {item.label}
-                </Link>
-              ),
-            )}
+            {directNavItems.map((item) => (
+              <Link
+                aria-current={pathname === item.href ? 'page' : undefined}
+                className={styles.navLink}
+                key={item.label}
+                to={item.href}
+              >
+                {item.label}
+              </Link>
+            ))}
           </nav>
 
           <div className={styles.actions}>
@@ -246,7 +322,12 @@ export function Header({ navigation, onSearchOpen }: HeaderProps) {
             >
               <Search aria-hidden size={15} strokeWidth={1.8} />
               <span>Search</span>
-              <Hotkey compact className={styles.searchHotkey} keys="mod+k" />
+              <Hotkey
+                compact
+                className={styles.searchHotkey}
+                isApple={isAppleShortcut}
+                keys="mod+k"
+              />
             </button>
             <button
               aria-keyshortcuts="Meta+K Control+K"

--- a/packages/docs-kit/site/components/Header/ThemeMenu.tsx
+++ b/packages/docs-kit/site/components/Header/ThemeMenu.tsx
@@ -1,5 +1,4 @@
-import type { DropdownItem } from '@lobehub/ui/DropdownMenu';
-import DropdownMenu from '@lobehub/ui/DropdownMenu';
+import { type DropdownItem, DropdownMenu } from '@lobehub/ui';
 import { Monitor, Moon, Sun } from 'lucide-react';
 import { useEffect, useState } from 'react';
 

--- a/packages/docs-kit/site/components/Header/style.ts
+++ b/packages/docs-kit/site/components/Header/style.ts
@@ -276,6 +276,8 @@ export const styles = createStaticStyles(({ css }) => {
     `,
 
     nav: css`
+      position: relative;
+
       display: flex;
       gap: 0.25rem;
       align-items: center;
@@ -289,14 +291,45 @@ export const styles = createStaticStyles(({ css }) => {
     `,
 
     navIndicator: css`
+      pointer-events: none;
+      will-change: transform, width;
+
       position: absolute;
+      z-index: 1;
       inset-block: auto -1px;
-      inset-inline: 0.75rem;
+      inset-inline: 0 auto;
 
+      width: 0;
       height: 2px;
-      border-radius: 1px;
 
-      background: var(--docs-text-primary);
+      opacity: 0;
+
+      &::after {
+        content: '';
+
+        position: absolute;
+        inset-block: 0;
+        inset-inline: 0.75rem;
+
+        border-radius: 1px;
+
+        background: var(--docs-text-primary);
+      }
+
+      &[data-positioned] {
+        opacity: 1;
+      }
+
+      &[data-animated] {
+        transition:
+          opacity 120ms ease,
+          transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1),
+          width 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        transition-duration: 0.01ms;
+      }
     `,
 
     navLink,

--- a/packages/docs-kit/site/components/Home/homeStyle.ts
+++ b/packages/docs-kit/site/components/Home/homeStyle.ts
@@ -319,7 +319,6 @@ export const styles = createStaticStyles(({ css }) => ({
   `,
 
   root: css`
-    overflow-x: clip;
     display: flex;
     flex-direction: column;
 

--- a/packages/docs-kit/site/components/Mdx/CodeBlock.test.tsx
+++ b/packages/docs-kit/site/components/Mdx/CodeBlock.test.tsx
@@ -2,8 +2,8 @@ import { render, screen } from '@testing-library/react';
 
 import { CodeBlock } from './CodeBlock';
 
-vi.mock('@lobehub/ui/Highlighter', () => ({
-  default: ({ children, language }: { children: string; language: string }) => (
+vi.mock('@lobehub/ui', () => ({
+  Highlighter: ({ children, language }: { children: string; language: string }) => (
     <pre data-language={language} data-testid="docs-code-block">
       {children}
     </pre>

--- a/packages/docs-kit/site/components/Mdx/CodeBlock.tsx
+++ b/packages/docs-kit/site/components/Mdx/CodeBlock.tsx
@@ -1,4 +1,4 @@
-import Highlighter from '@lobehub/ui/Highlighter';
+import { Highlighter } from '@lobehub/ui';
 import { Children, isValidElement, type ReactElement, type ReactNode } from 'react';
 
 import { styles } from './codeBlockStyle';

--- a/packages/docs-kit/site/components/Search/SearchDialog.tsx
+++ b/packages/docs-kit/site/components/Search/SearchDialog.tsx
@@ -1,9 +1,8 @@
+import { Hotkey } from '@lobehub/ui';
 import { Search } from 'lucide-react';
 import type { ChangeEvent, KeyboardEvent, RefObject } from 'react';
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
-
-import Hotkey from '@/Hotkey';
 
 import { loadSearchEngine } from '../../search/loadSearchEngine';
 import type { SearchEngine, SearchSubResult } from '../../search/types';

--- a/packages/docs-kit/site/components/Sidebar/Sidebar.test.tsx
+++ b/packages/docs-kit/site/components/Sidebar/Sidebar.test.tsx
@@ -1,9 +1,34 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
-import { expect, it, vi } from 'vitest';
+import { afterEach, expect, it, vi } from 'vitest';
 
 import type { DocumentManifestEntry, NavigationSection } from '../../types/content';
 import { Sidebar } from './Sidebar';
+
+const createRect = ({
+  height,
+  left,
+  top,
+  width,
+}: {
+  height: number;
+  left: number;
+  top: number;
+  width: number;
+}): DOMRect =>
+  ({
+    bottom: top + height,
+    height,
+    left,
+    right: left + width,
+    toJSON: () => ({}),
+    top,
+    width,
+    x: left,
+    y: top,
+  }) as DOMRect;
+
+afterEach(() => vi.restoreAllMocks());
 
 const actionDocument: DocumentManifestEntry = {
   category: 'General',
@@ -68,4 +93,45 @@ it('preserves active-link semantics and invokes the mobile navigation callback',
   expect(onNavigate).toHaveBeenCalledOnce();
   await waitFor(() => expect(baseActionLink.getAttribute('aria-current')).toBe('page'));
   expect(actionLink.getAttribute('aria-current')).toBeNull();
+});
+
+it('keeps one indicator positioned from active-link geometry across navigation', async () => {
+  let rootTop = -1112;
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+    this: HTMLElement,
+  ) {
+    if (this.getAttribute('aria-label') === 'Component documentation') {
+      return createRect({ height: 400, left: 24, top: rootTop, width: 224 });
+    }
+
+    if (this.textContent === 'Action') {
+      return createRect({ height: 32, left: 24, top: rootTop + 30, width: 224 });
+    }
+
+    if (this.textContent === 'Base Action') {
+      return createRect({ height: 32, left: 24, top: rootTop + 112, width: 224 });
+    }
+
+    return createRect({ height: 0, left: 0, top: 0, width: 0 });
+  });
+
+  const { container } = render(
+    <MemoryRouter initialEntries={[actionDocument.pathname]}>
+      <Sidebar navigation={navigation} />
+    </MemoryRouter>,
+  );
+
+  const initialIndicator = container.querySelector<HTMLElement>('[data-sidebar-active-indicator]');
+  expect(initialIndicator?.style.transform).toBe('translate3d(0px, 30px, 0)');
+
+  rootTop = 132;
+  fireEvent.click(screen.getByRole('link', { name: 'Base Action' }));
+
+  await waitFor(() => {
+    const indicator = container.querySelector<HTMLElement>('[data-sidebar-active-indicator]');
+    expect(indicator).toBe(initialIndicator);
+    expect(indicator?.style.transform).toBe('translate3d(0px, 112px, 0)');
+  });
+
+  expect(container.querySelectorAll('[data-sidebar-active-indicator]')).toHaveLength(1);
 });

--- a/packages/docs-kit/site/components/Sidebar/Sidebar.tsx
+++ b/packages/docs-kit/site/components/Sidebar/Sidebar.tsx
@@ -1,6 +1,5 @@
-import { LayoutGroup, motion, MotionConfig } from 'motion/react';
-import { useId } from 'react';
-import { NavLink } from 'react-router';
+import { useCallback, useLayoutEffect, useRef } from 'react';
+import { NavLink, useLocation } from 'react-router';
 
 import type { NavigationCategory, NavigationSection } from '../../types/content';
 import { styles } from './style';
@@ -16,7 +15,18 @@ const overviewLinks = [
   { pathname: '/changelog', title: 'Changelog' },
 ] as const;
 
-const pillTransition = { damping: 32, stiffness: 380, type: 'spring' } as const;
+interface IndicatorGeometry {
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+}
+
+const isSameGeometry = (left: IndicatorGeometry, right: IndicatorGeometry) =>
+  left.height === right.height &&
+  left.width === right.width &&
+  left.x === right.x &&
+  left.y === right.y;
 
 const SidebarLink = ({
   end,
@@ -30,18 +40,7 @@ const SidebarLink = ({
   title: string;
 }) => (
   <NavLink end={end} to={pathname} onClick={onNavigate}>
-    {({ isActive }) => (
-      <>
-        {isActive ? (
-          <motion.span
-            className={styles.activePill}
-            layoutId="docs-sidebar-active"
-            transition={pillTransition}
-          />
-        ) : null}
-        <span className={styles.label}>{title}</span>
-      </>
-    )}
+    <span className={styles.label}>{title}</span>
   </NavLink>
 );
 
@@ -65,48 +64,101 @@ const CategoryGroup = ({
 );
 
 export function Sidebar({ navigation, onNavigate, section }: SidebarProps) {
-  const layoutGroupId = useId();
+  const { pathname } = useLocation();
+  const rootRef = useRef<HTMLElement>(null);
+  const indicatorRef = useRef<HTMLSpanElement>(null);
+  const geometryRef = useRef<IndicatorGeometry>(undefined);
+
+  const measureIndicator = useCallback(() => {
+    const root = rootRef.current;
+    const indicator = indicatorRef.current;
+    const activeLink = root?.querySelector<HTMLElement>('a[aria-current="page"]');
+
+    if (!root || !indicator || !activeLink) {
+      geometryRef.current = undefined;
+      indicator?.removeAttribute('data-positioned');
+      return;
+    }
+
+    const rootRect = root.getBoundingClientRect();
+    const activeRect = activeLink.getBoundingClientRect();
+    const nextGeometry = {
+      height: activeRect.height,
+      width: activeRect.width,
+      x: activeRect.left - rootRect.left,
+      y: activeRect.top - rootRect.top,
+    };
+
+    if (geometryRef.current && isSameGeometry(geometryRef.current, nextGeometry)) return;
+
+    geometryRef.current = nextGeometry;
+    indicator.style.height = `${nextGeometry.height}px`;
+    indicator.style.transform = `translate3d(${nextGeometry.x}px, ${nextGeometry.y}px, 0)`;
+    indicator.style.width = `${nextGeometry.width}px`;
+    indicator.setAttribute('data-positioned', '');
+
+    if (!indicator.hasAttribute('data-animated')) {
+      indicator.getBoundingClientRect();
+      indicator.setAttribute('data-animated', '');
+    }
+  }, []);
+
+  useLayoutEffect(() => {
+    measureIndicator();
+
+    const root = rootRef.current;
+    const activeLink = root?.querySelector<HTMLElement>('a[aria-current="page"]');
+    if (!root || !activeLink || typeof ResizeObserver === 'undefined') return;
+
+    const resizeObserver = new ResizeObserver(measureIndicator);
+    resizeObserver.observe(root);
+    resizeObserver.observe(activeLink);
+
+    return () => resizeObserver.disconnect();
+  }, [measureIndicator, pathname, section]);
 
   return (
-    <MotionConfig reducedMotion="user">
-      <LayoutGroup id={layoutGroupId}>
-        {section ? (
-          <nav aria-label="Component documentation" className={styles.root}>
-            <section aria-label={section.title} className={styles.section}>
-              {section.categories.map((category) => (
+    <nav aria-label="Component documentation" className={styles.root} ref={rootRef}>
+      <span
+        aria-hidden
+        className={styles.activePill}
+        data-sidebar-active-indicator=""
+        ref={indicatorRef}
+      />
+      {section ? (
+        <section aria-label={section.title} className={styles.section}>
+          {section.categories.map((category) => (
+            <CategoryGroup category={category} key={category.title} onNavigate={onNavigate} />
+          ))}
+        </section>
+      ) : (
+        <>
+          <section className={styles.section}>
+            <h2>Documentation</h2>
+            <ul>
+              {overviewLinks.map((item) => (
+                <li key={item.pathname}>
+                  <SidebarLink
+                    end={item.pathname === '/'}
+                    pathname={item.pathname}
+                    title={item.title}
+                    onNavigate={onNavigate}
+                  />
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          {navigation.map((navigationSection) => (
+            <section className={styles.section} key={navigationSection.title}>
+              <h2>{navigationSection.title}</h2>
+              {navigationSection.categories.map((category) => (
                 <CategoryGroup category={category} key={category.title} onNavigate={onNavigate} />
               ))}
             </section>
-          </nav>
-        ) : (
-          <nav aria-label="Component documentation" className={styles.root}>
-            <section className={styles.section}>
-              <h2>Documentation</h2>
-              <ul>
-                {overviewLinks.map((item) => (
-                  <li key={item.pathname}>
-                    <SidebarLink
-                      end={item.pathname === '/'}
-                      pathname={item.pathname}
-                      title={item.title}
-                      onNavigate={onNavigate}
-                    />
-                  </li>
-                ))}
-              </ul>
-            </section>
-
-            {navigation.map((navigationSection) => (
-              <section className={styles.section} key={navigationSection.title}>
-                <h2>{navigationSection.title}</h2>
-                {navigationSection.categories.map((category) => (
-                  <CategoryGroup category={category} key={category.title} onNavigate={onNavigate} />
-                ))}
-              </section>
-            ))}
-          </nav>
-        )}
-      </LayoutGroup>
-    </MotionConfig>
+          ))}
+        </>
+      )}
+    </nav>
   );
 }

--- a/packages/docs-kit/site/components/Sidebar/style.ts
+++ b/packages/docs-kit/site/components/Sidebar/style.ts
@@ -2,10 +2,34 @@ import { createStaticStyles } from 'antd-style';
 
 export const styles = createStaticStyles(({ css }) => ({
   activePill: css`
+    pointer-events: none;
+    will-change: transform;
+
     position: absolute;
-    inset: 0;
+    z-index: 0;
+    inset-block-start: 0;
+    inset-inline-start: 0;
+
+    width: 0;
+    height: 0;
     border-radius: var(--docs-radius-md);
+
+    opacity: 0;
     background: var(--docs-surface-active);
+
+    &[data-positioned] {
+      opacity: 1;
+    }
+
+    &[data-animated] {
+      transition:
+        opacity 120ms ease,
+        transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      transition-duration: 0.01ms;
+    }
   `,
 
   category: css`
@@ -28,12 +52,16 @@ export const styles = createStaticStyles(({ css }) => ({
 
   label: css`
     position: relative;
+    z-index: 1;
   `,
 
   root: css`
+    position: relative;
+
     display: flex;
     flex-direction: column;
     gap: 1.75rem;
+
     padding-block: 0.25rem 2rem;
   `,
 

--- a/packages/docs-kit/site/components/TableOfContents/TableOfContents.tsx
+++ b/packages/docs-kit/site/components/TableOfContents/TableOfContents.tsx
@@ -1,4 +1,4 @@
-import { ScrollArea, type ScrollAreaViewportProps } from '@lobehub/ui/ScrollArea';
+import { ScrollArea, type ScrollAreaViewportProps } from '@lobehub/ui';
 import { ChevronDown } from 'lucide-react';
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import type { MouseEvent as ReactMouseEvent } from 'react';

--- a/packages/docs-kit/site/content/navigation.ts
+++ b/packages/docs-kit/site/content/navigation.ts
@@ -102,6 +102,7 @@ export function createNavigation(
 
     if (frozenRecords.length === 0) {
       if ([...specialSections.values()].includes(document.pathname)) continue;
+      if (document.source.startsWith('docs/')) continue;
       diagnostics.push(`${document.source}: no frozen section record`);
       continue;
     }

--- a/packages/docs-kit/site/content/pageChrome.test.ts
+++ b/packages/docs-kit/site/content/pageChrome.test.ts
@@ -104,6 +104,7 @@ describe('createDocumentLinks', () => {
       description: 'Alpha.',
       pathname: '/components/alpha',
       source: 'src/Alpha/index.mdx',
+      subType: 'react',
       title: 'Alpha',
     };
 
@@ -111,11 +112,15 @@ describe('createDocumentLinks', () => {
       docUrl: '{github}/edit/main/{atomId}',
       github: 'https://github.com/lobehub/lobe-editor',
       match: ['/components/'],
+      packageName: '@lobehub/editor',
+      packageNames: { react: '@lobehub/editor/react' },
       sourceUrl: '{github}/blob/main/{atomId}',
     });
 
     expect(links).toMatchObject({
       editUrl: 'https://github.com/lobehub/lobe-editor/edit/main/src/Alpha/index.mdx',
+      importStatement: "import { Alpha } from '@lobehub/editor/react';",
+      npmUrl: 'https://www.npmjs.com/package/@lobehub/editor',
       sourceUrl: 'https://github.com/lobehub/lobe-editor/blob/main/src/Alpha',
     });
 

--- a/packages/docs-kit/site/content/pageChrome.ts
+++ b/packages/docs-kit/site/content/pageChrome.ts
@@ -1,5 +1,5 @@
-import { packageNamespaces } from '../../../../config/packageNamespaces';
 import type { DocsApiHeaderConfig } from '../../src/config';
+import { packageNamespaces } from '../../src/packageNamespaces';
 import type { DocumentManifestEntry, NavigationSection } from '../types/content';
 
 export interface DocumentLinks {
@@ -75,7 +75,14 @@ export function createDocumentLinks(
   }
 
   const [, namespace] = source.split('/');
-  const packageName = namespaceSet.has(namespace) ? `@lobehub/ui/${namespace}` : '@lobehub/ui';
+  const defaultPackageName = namespaceSet.has(namespace)
+    ? `@lobehub/ui/${namespace}`
+    : '@lobehub/ui';
+  const packageName =
+    (document.subType ? apiHeader?.packageNames?.[document.subType] : undefined) ??
+    apiHeader?.packageName ??
+    defaultPackageName;
+  const npmPackageName = apiHeader?.packageName ?? '@lobehub/ui';
   const directory = source.replace(/\/index\.mdx?$/, '');
   const github = apiHeader?.github ?? '';
 
@@ -87,7 +94,7 @@ export function createDocumentLinks(
     importStatement: identifierPattern.test(document.title)
       ? `import { ${document.title} } from '${packageName}';`
       : undefined,
-    npmUrl: 'https://www.npmjs.com/package/@lobehub/ui',
+    npmUrl: `https://www.npmjs.com/package/${npmPackageName}`,
     sourceUrl: resolveApiHeaderTemplate(apiHeader?.sourceUrl ?? defaultSourceUrlTemplate, {
       atomId: directory,
       github,

--- a/packages/docs-kit/site/content/siteMetadata.ts
+++ b/packages/docs-kit/site/content/siteMetadata.ts
@@ -1,8 +1,6 @@
-import path from 'node:path';
-
 import { getDocsConfig } from '../../src/config';
 
-const repositoryRoot = path.resolve(import.meta.dirname, '../../../..');
+const repositoryRoot = process.cwd();
 const config = getDocsConfig(repositoryRoot);
 
 export const siteMetadata = {

--- a/packages/docs-kit/site/react-router.config.ts
+++ b/packages/docs-kit/site/react-router.config.ts
@@ -2,10 +2,17 @@ import type { Config } from '@react-router/dev/config';
 
 import { getPrerenderPaths } from './compiler/manifests';
 
-export default {
-  appDirectory: 'packages/docs-kit/site',
+export const lobeDocsReactRouterConfig = {
+  appDirectory: import.meta.dirname,
   buildDirectory: '.react-router/build',
   prerender: async () => getPrerenderPaths(),
   routeDiscovery: { mode: 'initial' },
   ssr: false,
 } satisfies Config;
+
+export const defineLobeDocsReactRouterConfig = (overrides: Config = {}): Config => ({
+  ...lobeDocsReactRouterConfig,
+  ...overrides,
+});
+
+export default lobeDocsReactRouterConfig;

--- a/packages/docs-kit/site/styles/globalStyles.ts
+++ b/packages/docs-kit/site/styles/globalStyles.ts
@@ -184,6 +184,7 @@ export const styles = createStaticStyles(({ css }) => ({
   `,
 
   page: css`
+    overflow-x: clip;
     display: flex;
     flex-direction: column;
     min-height: calc(100dvh - var(--docs-header-height));

--- a/packages/docs-kit/site/types/demo-imports.d.ts
+++ b/packages/docs-kit/site/types/demo-imports.d.ts
@@ -4,6 +4,14 @@ declare module '*?demo' {
   export default demo;
 }
 
+declare module '@lobehub/ui/es/styles/theme/antdTheme' {
+  export const createLobeAntdTheme: (options: {
+    appearance: 'dark' | 'light';
+    neutralColor?: string;
+    primaryColor?: string;
+  }) => import('antd').ThemeConfig;
+}
+
 declare module 'virtual:lobedocs/compatibility' {
   const compatibility: import('../compiler/types').DocumentationInventory;
 

--- a/packages/docs-kit/src/cli/commands.ts
+++ b/packages/docs-kit/src/cli/commands.ts
@@ -3,22 +3,25 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import { buildReactRouterArgs } from './reactRouterArgs';
+import { withReactRouterConfig } from './reactRouterConfig';
 import { resolveBin } from './resolveBin';
 import { runProcess } from './runProcess';
 
 export interface CliContext {
   cwd: string;
   finalizeBuildPath: string;
+  reactRouterConfigPath: string;
   viteConfigPath: string;
 }
 
 export const createCliContext = (kitRoot: string, cwd: string): CliContext => ({
   cwd,
   finalizeBuildPath: path.join(kitRoot, 'site/compiler/finalizeBuild.ts'),
+  reactRouterConfigPath: path.join(kitRoot, 'site/react-router.config.ts'),
   viteConfigPath: path.join(kitRoot, 'vite.config.ts'),
 });
 
-const runReactRouter = (
+const runReactRouter = async (
   context: CliContext,
   subcommand: string,
   extraArgs: string[],
@@ -31,13 +34,17 @@ const runReactRouter = (
     consumerRequire.resolve,
   );
 
-  return runProcess(
-    process.execPath,
-    [
-      reactRouterBinPath,
-      ...buildReactRouterArgs(subcommand, context.cwd, context.viteConfigPath, extraArgs),
-    ],
-    { cwd: context.cwd, ...options },
+  return withReactRouterConfig(
+    { cwd: context.cwd, defaultConfigPath: context.reactRouterConfigPath },
+    async () =>
+      runProcess(
+        process.execPath,
+        [
+          reactRouterBinPath,
+          ...buildReactRouterArgs(subcommand, context.cwd, context.viteConfigPath, extraArgs),
+        ],
+        { cwd: context.cwd, ...options },
+      ),
   );
 };
 

--- a/packages/docs-kit/src/cli/reactRouterArgs.ts
+++ b/packages/docs-kit/src/cli/reactRouterArgs.ts
@@ -6,8 +6,8 @@
 // once `--config` is passed, the CLI's own root-resolution fallback becomes
 // `dirname(configFile)` (the kit), not `cwd`. Passing `cwd` as the explicit
 // positional project directory pins root resolution to the consumer repo
-// regardless of `--config`, so a 2-line `react-router.config.ts` shell stays
-// required at the consumer root for `react-router.config` discovery.
+// regardless of `--config`. The CLI supplies the kit-owned React Router config
+// separately when the consumer has not provided an explicit override.
 export const buildReactRouterArgs = (
   subcommand: string,
   cwd: string,

--- a/packages/docs-kit/src/cli/reactRouterConfig.test.ts
+++ b/packages/docs-kit/src/cli/reactRouterConfig.test.ts
@@ -1,0 +1,125 @@
+import { existsSync } from 'node:fs';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { withReactRouterConfig } from './reactRouterConfig';
+
+const createConsumer = () => mkdtemp(path.join(tmpdir(), 'lobedocs-consumer-'));
+
+describe('withReactRouterConfig', () => {
+  const consumers: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(consumers.splice(0).map((consumer) => rm(consumer, { recursive: true })));
+  });
+
+  it('provides and then removes the kit default when the consumer has no config', async () => {
+    const consumer = await createConsumer();
+    consumers.push(consumer);
+    const defaultConfigPath = path.join(consumer, 'kit-default.ts');
+
+    await withReactRouterConfig({ cwd: consumer, defaultConfigPath }, async (configPath) => {
+      expect(configPath).toBe(path.join(consumer, 'react-router.config.mjs'));
+      expect(existsSync(configPath)).toBe(true);
+      expect(await readFile(configPath, 'utf8')).toContain(
+        `export { default } from ${JSON.stringify(pathToFileURL(defaultConfigPath).href)}`,
+      );
+    });
+
+    expect(existsSync(path.join(consumer, 'react-router.config.mjs'))).toBe(false);
+  });
+
+  it('preserves an explicit consumer config', async () => {
+    const consumer = await createConsumer();
+    consumers.push(consumer);
+    const configPath = path.join(consumer, 'react-router.config.ts');
+    const contents = 'export default { basename: "/docs" };\n';
+    await writeFile(configPath, contents);
+
+    await withReactRouterConfig(
+      { cwd: consumer, defaultConfigPath: '/kit/react-router-config.ts' },
+      async (resolvedConfigPath) => {
+        expect(resolvedConfigPath).toBe(configPath);
+      },
+    );
+
+    expect(await readFile(configPath, 'utf8')).toBe(contents);
+  });
+
+  it('keeps the generated config until every concurrent command releases its lease', async () => {
+    const consumer = await createConsumer();
+    consumers.push(consumer);
+    const configPath = path.join(consumer, 'react-router.config.mjs');
+    let releaseFirst: (() => void) | undefined;
+    let firstStarted: (() => void) | undefined;
+    const firstReady = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const firstCommand = withReactRouterConfig(
+      { cwd: consumer, defaultConfigPath: '/kit/react-router-config.ts' },
+      async () => {
+        firstStarted?.();
+        await firstBlocked;
+      },
+    );
+    await firstReady;
+
+    await withReactRouterConfig(
+      { cwd: consumer, defaultConfigPath: '/kit/react-router-config.ts' },
+      async () => {
+        expect(existsSync(configPath)).toBe(true);
+      },
+    );
+    expect(existsSync(configPath)).toBe(true);
+
+    releaseFirst?.();
+    await firstCommand;
+    expect(existsSync(configPath)).toBe(false);
+  });
+
+  it('cleans the generated config after a failed command', async () => {
+    const consumer = await createConsumer();
+    consumers.push(consumer);
+    const configPath = path.join(consumer, 'react-router.config.mjs');
+
+    await expect(
+      withReactRouterConfig(
+        { cwd: consumer, defaultConfigPath: '/kit/react-router-config.ts' },
+        async () => {
+          throw new Error('build failed');
+        },
+      ),
+    ).rejects.toThrow('build failed');
+    expect(existsSync(configPath)).toBe(false);
+  });
+
+  it('cleans the generated config immediately on termination', async () => {
+    const consumer = await createConsumer();
+    consumers.push(consumer);
+    const configPath = path.join(consumer, 'react-router.config.mjs');
+    const existingHandlers = new Set(process.listeners('SIGINT'));
+
+    await withReactRouterConfig(
+      { cwd: consumer, defaultConfigPath: '/kit/react-router-config.ts' },
+      async () => {
+        const terminationHandler = process
+          .listeners('SIGINT')
+          .find((handler) => !existingHandlers.has(handler));
+        expect(terminationHandler).toBeDefined();
+
+        terminationHandler?.('SIGINT');
+        expect(existsSync(configPath)).toBe(false);
+      },
+    );
+
+    expect(process.listeners('SIGINT').every((handler) => existingHandlers.has(handler))).toBe(
+      true,
+    );
+  });
+});

--- a/packages/docs-kit/src/cli/reactRouterConfig.ts
+++ b/packages/docs-kit/src/cli/reactRouterConfig.ts
@@ -1,0 +1,193 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { existsSync, readdirSync, readFileSync, unlinkSync } from 'node:fs';
+import { mkdir, readdir, realpath, unlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const CONFIG_EXTENSIONS = ['.js', '.jsx', '.ts', '.tsx', '.mjs', '.mts'];
+const GENERATED_CONFIG_FILENAME = 'react-router.config.mjs';
+const GENERATED_CONFIG_MARKER = '// @lobehub/docs-kit generated react-router config';
+const LEASE_FILENAME_PATTERN = /^(\d+)-[\da-f-]+\.lease$/i;
+const TERMINATION_SIGNALS = ['SIGINT', 'SIGTERM'] as const;
+
+const isMissingFileError = (error: unknown): error is NodeJS.ErrnoException =>
+  error instanceof Error && 'code' in error && error.code === 'ENOENT';
+
+const isProcessAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error instanceof Error && 'code' in error && error.code !== 'ESRCH';
+  }
+};
+
+const findReactRouterConfig = (cwd: string): string | undefined => {
+  for (const extension of CONFIG_EXTENSIONS) {
+    const configPath = path.join(cwd, `react-router.config${extension}`);
+    if (existsSync(configPath)) return configPath;
+  }
+};
+
+const createGeneratedConfig = (defaultConfigPath: string): string =>
+  [
+    GENERATED_CONFIG_MARKER,
+    '// This file is managed by `lobedocs` and is removed when the command exits.',
+    `export { default } from ${JSON.stringify(pathToFileURL(defaultConfigPath).href)};`,
+    '',
+  ].join('\n');
+
+const isGeneratedConfig = (configPath: string): boolean => {
+  try {
+    return readFileSync(configPath, 'utf8').startsWith(GENERATED_CONFIG_MARKER);
+  } catch {
+    return false;
+  }
+};
+
+const getLeaseDirectory = async (cwd: string): Promise<string> => {
+  const canonicalCwd = await realpath(cwd).catch(() => path.resolve(cwd));
+  const repositoryId = createHash('sha256').update(canonicalCwd).digest('hex');
+  return path.join(tmpdir(), 'lobedocs-react-router-config', repositoryId);
+};
+
+const removeStaleLeases = async (leaseDirectory: string): Promise<string[]> => {
+  let entries: string[];
+  try {
+    entries = await readdir(leaseDirectory);
+  } catch (error) {
+    if (isMissingFileError(error)) return [];
+    throw error;
+  }
+
+  const activeLeases: string[] = [];
+  for (const entry of entries) {
+    const match = LEASE_FILENAME_PATTERN.exec(entry);
+    if (!match) continue;
+
+    if (isProcessAlive(Number(match[1]))) {
+      activeLeases.push(entry);
+      continue;
+    }
+
+    await unlink(path.join(leaseDirectory, entry)).catch((error: unknown) => {
+      if (!isMissingFileError(error)) throw error;
+    });
+  }
+  return activeLeases;
+};
+
+const removeStaleLeasesSync = (leaseDirectory: string): string[] => {
+  let entries: string[];
+  try {
+    entries = readdirSync(leaseDirectory);
+  } catch {
+    return [];
+  }
+
+  const activeLeases: string[] = [];
+  for (const entry of entries) {
+    const match = LEASE_FILENAME_PATTERN.exec(entry);
+    if (!match) continue;
+
+    if (isProcessAlive(Number(match[1]))) {
+      activeLeases.push(entry);
+      continue;
+    }
+
+    try {
+      unlinkSync(path.join(leaseDirectory, entry));
+    } catch {
+      // Another process may have removed the same stale lease.
+    }
+  }
+  return activeLeases;
+};
+
+const removeGeneratedConfig = async (configPath: string): Promise<void> => {
+  if (!isGeneratedConfig(configPath)) return;
+  await unlink(configPath).catch((error: unknown) => {
+    if (!isMissingFileError(error)) throw error;
+  });
+};
+
+const removeGeneratedConfigSync = (configPath: string): void => {
+  if (!isGeneratedConfig(configPath)) return;
+  try {
+    unlinkSync(configPath);
+  } catch {
+    // Best-effort cleanup during process exit.
+  }
+};
+
+export interface ReactRouterConfigOptions {
+  cwd: string;
+  defaultConfigPath: string;
+}
+
+export const withReactRouterConfig = async <Result>(
+  { cwd, defaultConfigPath }: ReactRouterConfigOptions,
+  run: (configPath: string) => Promise<Result>,
+): Promise<Result> => {
+  const generatedConfigPath = path.join(cwd, GENERATED_CONFIG_FILENAME);
+  const leaseDirectory = await getLeaseDirectory(cwd);
+  const leasePath = path.join(leaseDirectory, `${process.pid}-${randomUUID()}.lease`);
+
+  await mkdir(leaseDirectory, { recursive: true });
+  await removeStaleLeases(leaseDirectory);
+  await writeFile(leasePath, '');
+
+  const cleanupSync = (): void => {
+    try {
+      unlinkSync(leasePath);
+    } catch {
+      // The async cleanup path may already have removed this lease.
+    }
+    if (removeStaleLeasesSync(leaseDirectory).length === 0) {
+      removeGeneratedConfigSync(generatedConfigPath);
+    }
+  };
+  process.once('exit', cleanupSync);
+
+  let receivedSignal: (typeof TERMINATION_SIGNALS)[number] | undefined;
+  const signalHandlers = TERMINATION_SIGNALS.map((signal) => {
+    const handler = (): void => {
+      receivedSignal ??= signal;
+      cleanupSync();
+    };
+    process.once(signal, handler);
+    return [signal, handler] as const;
+  });
+
+  try {
+    let configPath = findReactRouterConfig(cwd);
+    if (!configPath) {
+      try {
+        await writeFile(generatedConfigPath, createGeneratedConfig(defaultConfigPath), {
+          flag: 'wx',
+        });
+      } catch (error) {
+        if (!(error instanceof Error && 'code' in error && error.code === 'EEXIST')) throw error;
+      }
+      configPath = findReactRouterConfig(cwd);
+    }
+
+    if (!configPath) {
+      throw new Error(`Unable to provide a React Router config in ${cwd}`);
+    }
+    if (receivedSignal) {
+      throw new Error(`lobedocs received ${receivedSignal} before React Router started`);
+    }
+    return await run(configPath);
+  } finally {
+    process.off('exit', cleanupSync);
+    for (const [signal, handler] of signalHandlers) process.off(signal, handler);
+    await unlink(leasePath).catch((error: unknown) => {
+      if (!isMissingFileError(error)) throw error;
+    });
+    if ((await removeStaleLeases(leaseDirectory)).length === 0) {
+      await removeGeneratedConfig(generatedConfigPath);
+    }
+  }
+};

--- a/packages/docs-kit/src/config.ts
+++ b/packages/docs-kit/src/config.ts
@@ -67,6 +67,8 @@ export interface DocsApiHeaderConfig {
   docUrl?: string;
   github?: string;
   match?: string[];
+  packageName?: string;
+  packageNames?: Record<string, string>;
   sourceUrl?: string;
 }
 
@@ -90,6 +92,7 @@ export interface DocsConfig {
   homePage?: string;
   legacyRedirects?: DocumentationInventory;
   navSections: Record<string, string>;
+  publicDocs?: string[];
   siteUrl: string;
   themeConfig?: DocsThemeConfig;
   title: string;

--- a/packages/docs-kit/src/packageNamespaces.ts
+++ b/packages/docs-kit/src/packageNamespaces.ts
@@ -1,0 +1,11 @@
+export const packageNamespaces = [
+  'awesome',
+  'brand',
+  'chat',
+  'color',
+  'icons',
+  'mdx',
+  'mobile',
+  'storybook',
+  'base-ui',
+] as const;

--- a/packages/docs-kit/vite.config.ts
+++ b/packages/docs-kit/vite.config.ts
@@ -49,23 +49,25 @@ const createAliasEntries = (alias: Record<string, string> = {}): Alias[] =>
     });
 
 export default defineConfig({
-  optimizeDeps: {
-    // Components and demos are lazy-loaded per docs page, so with default entry
-    // crawling Vite keeps discovering deps mid-session, re-optimizing and
-    // full-reloading on nearly every navigation. Crawl all client sources
-    // upfront so every dep is found in the initial optimize pass.
-    entries: [
-      'src/**/*.{ts,tsx}',
-      `${docsKitRoot}/site/app/**/*.{ts,tsx}`,
-      `${docsKitRoot}/site/components/**/*.{ts,tsx}`,
-      '!**/*.d.ts',
-      '!**/*.test.*',
-    ],
-    // Installed UI packages and generated demo modules expose these only at
-    // runtime. Pre-bundle the dependencies available in the consuming project
-    // to avoid an invalidating second optimization pass after first paint.
-    include: runtimeOptimizeDeps,
-  },
+  optimizeDeps: process.env.VITEST
+    ? { noDiscovery: true }
+    : {
+        // Components and demos are lazy-loaded per docs page, so with default entry
+        // crawling Vite keeps discovering deps mid-session, re-optimizing and
+        // full-reloading on nearly every navigation. Crawl all client sources
+        // upfront so every dep is found in the initial optimize pass.
+        entries: [
+          'src/**/*.{ts,tsx}',
+          `${docsKitRoot}/site/app/**/*.{ts,tsx}`,
+          `${docsKitRoot}/site/components/**/*.{ts,tsx}`,
+          '!**/*.d.ts',
+          '!**/*.test.*',
+        ],
+        // Installed UI packages and generated demo modules expose these only at
+        // runtime. Pre-bundle the dependencies available in the consuming project
+        // to avoid an invalidating second optimization pass after first paint.
+        include: runtimeOptimizeDeps,
+      },
   plugins: [
     codeInspectorPlugin({
       bundler: 'vite',

--- a/packages/docs-kit/vite.config.ts
+++ b/packages/docs-kit/vite.config.ts
@@ -1,9 +1,10 @@
+import { createRequire } from 'node:module';
 import path from 'node:path';
 
 import { reactRouter } from '@react-router/dev/vite';
 import { codeInspectorPlugin } from 'code-inspector-plugin';
 import { visualizer } from 'rollup-plugin-visualizer';
-import { type Alias, defineConfig } from 'vite';
+import { type Alias, defineConfig, normalizePath } from 'vite';
 
 import { createMdxPlugin } from './site/compiler/content/mdxPlugin';
 import { devPagefindPlugin } from './site/compiler/search/devPagefindPlugin';
@@ -11,19 +12,41 @@ import { lobeDocs } from './site/compiler/vitePlugin';
 import { getDocsConfig } from './src/config';
 
 const repositoryRoot = process.cwd();
+const docsKitRoot = normalizePath(import.meta.dirname);
 const docsConfig = getDocsConfig(repositoryRoot);
+const repositoryRequire = createRequire(path.join(repositoryRoot, 'package.json'));
+
+const runtimeOptimizeDeps = [
+  'ahooks',
+  'es-toolkit',
+  'polished',
+  'react-merge-refs',
+  'remark-breaks',
+  'remark-parse',
+  'remark-rehype',
+  ...(docsConfig.alias?.['@lobehub/ui/es'] ? ['emoji-regex'] : []),
+].filter((dependency) => {
+  try {
+    repositoryRequire.resolve(dependency);
+    return true;
+  } catch {
+    return false;
+  }
+});
 
 const escapeRegExp = (value: string): string => value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const createAliasEntries = (alias: Record<string, string> = {}): Alias[] =>
-  Object.entries(alias).flatMap(([find, target]) => {
-    const replacement = path.resolve(repositoryRoot, target);
-    const escapedFind = escapeRegExp(find);
-    return [
-      { find: new RegExp(`^${escapedFind}$`), replacement },
-      { find: new RegExp(`^${escapedFind}/(.+)$`), replacement: `${replacement}/$1` },
-    ];
-  });
+  Object.entries(alias)
+    .toSorted(([left], [right]) => right.length - left.length)
+    .flatMap(([find, target]) => {
+      const replacement = path.resolve(repositoryRoot, target);
+      const escapedFind = escapeRegExp(find);
+      return [
+        { find: new RegExp(`^${escapedFind}$`), replacement },
+        { find: new RegExp(`^${escapedFind}/(.+)$`), replacement: `${replacement}/$1` },
+      ];
+    });
 
 export default defineConfig({
   optimizeDeps: {
@@ -33,13 +56,15 @@ export default defineConfig({
     // upfront so every dep is found in the initial optimize pass.
     entries: [
       'src/**/*.{ts,tsx}',
-      'packages/docs-kit/site/app/**/*.{ts,tsx}',
-      'packages/docs-kit/site/components/**/*.{ts,tsx}',
+      `${docsKitRoot}/site/app/**/*.{ts,tsx}`,
+      `${docsKitRoot}/site/components/**/*.{ts,tsx}`,
+      '!**/*.d.ts',
       '!**/*.test.*',
     ],
-    // Reached only through a transitive runtime import inside node_modules,
-    // which entry crawling cannot see.
-    include: ['es-toolkit'],
+    // Installed UI packages and generated demo modules expose these only at
+    // runtime. Pre-bundle the dependencies available in the consuming project
+    // to avoid an invalidating second optimization pass after first paint.
+    include: runtimeOptimizeDeps,
   },
   plugins: [
     codeInspectorPlugin({
@@ -48,16 +73,20 @@ export default defineConfig({
     lobeDocs(),
     devPagefindPlugin(),
     createMdxPlugin(),
-    reactRouter(),
+    // Vite compiler tests run in parallel and share the repository-level
+    // React Router typegen directory. The route plugin is covered by the real
+    // lobedocs build/typegen commands instead of starting competing watchers.
+    process.env.VITEST ? undefined : reactRouter(),
     process.env.ANALYZE
       ? visualizer({ filename: '.react-router/build/client/stats.html' })
       : undefined,
   ],
   resolve: {
     alias: createAliasEntries(docsConfig.alias),
+    dedupe: ['@lobehub/ui', 'antd', 'antd-style', 'react', 'react-dom'],
     tsconfigPaths: true,
   },
   ssr: {
-    noExternal: ['@lobehub/icons', '@lobehub/fluent-emoji'],
+    noExternal: [/^@lobehub\/ui(?:\/.*)?$/, '@lobehub/icons', '@lobehub/fluent-emoji'],
   },
 });

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -1,1 +1,0 @@
-export { default } from './packages/docs-kit/site/react-router.config';

--- a/scripts/docs-inventory.ts
+++ b/scripts/docs-inventory.ts
@@ -12,5 +12,6 @@ const inventory = buildDocumentationInventory(root, {
   atomDirs: config.atomDirs,
   legacyRedirects: config.legacyRedirects,
   navSections: config.navSections,
+  publicDocs: config.publicDocs,
 });
 writeCompatibilityManifest(root, inventory);

--- a/tsconfig.site.json
+++ b/tsconfig.site.json
@@ -12,7 +12,6 @@
     "packages/docs-kit/site/**/*.tsx",
     "src/types/global.d.ts",
     "packages/docs-kit/vite.config.ts",
-    "react-router.config.ts",
     ".react-router/types/**/*"
   ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,8 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     hookTimeout: 30_000,
-    testTimeout: 20_000,
+    // Production Vite compiler integration can exceed one minute when the
+    // complete suite runs with coverage on constrained CI runners.
+    testTimeout: 120_000,
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,14 +6,16 @@ import { name } from './package.json';
 import { lobeDocsSiteConfigPlugin } from './packages/docs-kit/site/compiler/vitePlugin';
 
 const srcPath = fileURLToPath(new URL('./src', import.meta.url));
+const antdThemePath = fileURLToPath(new URL('./src/styles/theme/antdTheme.ts', import.meta.url));
 
 export default defineConfig({
   plugins: [lobeDocsSiteConfigPlugin()],
   resolve: {
-    alias: {
-      '@': srcPath,
-      [name]: srcPath,
-    },
+    alias: [
+      { find: '@lobehub/ui/es/styles/theme/antdTheme', replacement: antdThemePath },
+      { find: '@', replacement: srcPath },
+      { find: name, replacement: srcPath },
+    ],
   },
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary

- provide a process-scoped default React Router configuration so consumers do not need a root config file
- export an optional configuration helper for consumers that need React Router overrides
- harden consumer package resolution, demo compilation, navigation, and documentation shell behavior
- isolate Vite compiler tests from React Router typegen watchers while retaining the real CLI build and typegen paths

## Verification

- bunx vitest run packages/docs-kit/site packages/docs-kit/src/cli (76 files, 463 tests)
- bun run type-check
- bun run docs:build (15,190 client modules, 5,648 SSR modules, full prerender)
- lobe-editor no-config development and production builds verified