### PR TITLE
🐛 fix(docs-kit): route all manifest documents

### DIFF
--- a/packages/docs-kit/site/routes.test.ts
+++ b/packages/docs-kit/site/routes.test.ts
@@ -1,0 +1,16 @@
+import { matchRoutes } from 'react-router';
+
+import routes from './routes';
+
+const matchLeafId = (pathname: string) => matchRoutes(routes as never, pathname)?.at(-1)?.route.id;
+
+it.each(['/changelog', '/components/button', '/editor', '/features/model-icon'])(
+  'renders the documentation route for %s',
+  (pathname) => {
+    expect(matchLeafId(pathname)).toBe('document');
+  },
+);
+
+it('keeps standalone demos outside the documentation layout', () => {
+  expect(matchLeafId('/~demos/button-basic')).toBe('standalone-demo');
+});

--- a/packages/docs-kit/site/routes.ts
+++ b/packages/docs-kit/site/routes.ts
@@ -6,8 +6,6 @@ export default [
   route('~demos/:demoId', './app/routes/standalone-demo.tsx', { id: 'standalone-demo' }),
   layout('./app/routes/docs-layout.tsx', [
     index('./app/routes/home.tsx'),
-    route('changelog', './app/routes/document.tsx', { id: 'document-changelog' }),
-    route('components/*', './app/routes/document.tsx', { id: 'document-component' }),
-    route('*', './app/routes/not-found.tsx'),
+    route('*', './app/routes/document.tsx', { id: 'document' }),
   ]),
 ] satisfies RouteConfig;


### PR DESCRIPTION
## Summary

- route every manifest-backed document through the default document route
- support downstream `publicDocs` paths such as `/editor` and `/features/*` without a local React Router configuration
- preserve the standalone demo route outside the documentation layout

## Verification

- `pnpm exec vitest run packages/docs-kit/site/routes.test.ts packages/docs-kit/site/app/routes/document.test.ts`
- `pnpm run type-check`
- `pnpm run docs:build`
- `npm pack --dry-run ./packages/docs-kit`
