### PR TITLE
:bug: fix(docs): exclude demo headings from TOC

### DIFF
--- a/packages/docs-kit/site/components/Demo/Demo.tsx
+++ b/packages/docs-kit/site/components/Demo/Demo.tsx
@@ -251,6 +251,7 @@ export function Demo({
       data-demo-editable={resolvedEditable}
       data-demo-isolated={isolated}
       data-demo-layout={layout}
+      data-toc-ignore=""
       ref={frameRef}
     >
       <header className={styles.caption}>

--- a/packages/docs-kit/site/components/TableOfContents/TableOfContents.test.tsx
+++ b/packages/docs-kit/site/components/TableOfContents/TableOfContents.test.tsx
@@ -69,6 +69,29 @@ it('skips a heading without a compile-time identifier and never mutates the DOM'
   );
 });
 
+it('excludes headings inside regions that are not part of the document outline', async () => {
+  render(
+    <>
+      <main id="toc-content">
+        <h2 id="usage">Usage</h2>
+        <section data-toc-ignore="">
+          <h3 id="demo-title">Demo title</h3>
+          <div>
+            <h3 id="preview-heading">Preview heading</h3>
+          </div>
+        </section>
+        <h3 id="configuration">Configuration</h3>
+      </main>
+      <TableOfContents contentId="toc-content" scopeKey="ignored-region" />
+    </>,
+  );
+
+  expect(await screen.findByRole('link', { name: 'Usage' })).toBeTruthy();
+  expect(screen.getByRole('link', { name: 'Configuration' })).toBeTruthy();
+  expect(screen.queryByRole('link', { name: 'Demo title' })).toBeNull();
+  expect(screen.queryByRole('link', { name: 'Preview heading' })).toBeNull();
+});
+
 it('spring-scrolls to the heading when a toc link is clicked', async () => {
   const springScrollToElement = vi
     .spyOn(scroller, 'springScrollToElement')

--- a/packages/docs-kit/site/components/TableOfContents/TableOfContents.tsx
+++ b/packages/docs-kit/site/components/TableOfContents/TableOfContents.tsx
@@ -70,7 +70,9 @@ export function TableOfContents({ contentId, scopeKey }: TableOfContentsProps) {
       return;
     }
 
-    const headings = Array.from(content.querySelectorAll<HTMLHeadingElement>('h2, h3'));
+    const headings = Array.from(content.querySelectorAll<HTMLHeadingElement>('h2, h3')).filter(
+      (heading) => !heading.closest('[data-toc-ignore]'),
+    );
     const nextItems = headings.flatMap((heading) => {
       const title = heading.textContent?.trim();
       if (!title || !heading.id) return [];


### PR DESCRIPTION
## Summary

Exclude demo headings from the docs site table of contents so the TOC only reflects real document headings.

## Changes

- Mark demo headings in `packages/docs-kit/site/components/Demo/Demo.tsx` so they are skipped by the TOC
- Filter marked headings out in `TableOfContents`
- Add regression test coverage in `TableOfContents.test.tsx`