### PR TITLE
🐛 fix(docs-kit): require flex-compatible ui runtime

### DIFF
--- a/packages/docs-kit/package.json
+++ b/packages/docs-kit/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@ant-design/cssinjs": "^2.1.2",
     "@giscus/react": "^3.1.0",
-    "@lobehub/ui": "^5.20.3",
+    "@lobehub/ui": "^5.21.0",
     "@mdx-js/rollup": "3.1.1",
     "antd": "^6.5.0",
     "antd-style": "^4.1.0",


### PR DESCRIPTION
## Summary

- require `@lobehub/ui` 5.21 or newer from `@lobehub/docs-kit`
- ensure downstream documentation demos receive the essential `lobe-flex` runtime styles
- prevent chart and Flex-based demos from collapsing when an existing lockfile resolves UI 5.20.x

## Validation

- `pnpm run type-check`
- `npm pack --dry-run ./packages/docs-kit`
- reproduced against the migrated `lobe-charts` standalone BarChart demo
