### PR TITLE
🐛 fix(docs-kit): keep standalone demos full width

### DIFF
--- a/packages/docs-kit/site/components/Demo/DemoAppearance.test.tsx
+++ b/packages/docs-kit/site/components/Demo/DemoAppearance.test.tsx
@@ -58,6 +58,22 @@ it('applies the pre-hydration standalone appearance marker before page attribute
   );
 });
 
+it('gives the provider-wrapped standalone demo a full-width grid track', () => {
+  container.innerHTML = `
+    <main class="${styles.standalonePage}" data-standalone-demo="">
+      <div data-lobe-demo-appearance="dark" style="display: contents">
+        <div data-demo-provider="">
+          <div id="lobe-demo-example"></div>
+        </div>
+      </div>
+    </main>`;
+
+  const appearance = container.querySelector<HTMLElement>('[data-lobe-demo-appearance]')!;
+  const standalonePage = container.querySelector<HTMLElement>('[data-standalone-demo]')!;
+  expect(getComputedStyle(standalonePage).gridTemplateColumns).toBe('minmax(0, 1fr)');
+  expect(getComputedStyle(appearance).width).toBe('100%');
+});
+
 it('keeps pending live candidates measurable while making their entire subtree non-interactive', () => {
   container.innerHTML = `
     <div class="${styles.liveStage}">

--- a/packages/docs-kit/site/components/Demo/style.ts
+++ b/packages/docs-kit/site/components/Demo/style.ts
@@ -389,6 +389,7 @@ export const styles = createStaticStyles(({ css }) => ({
 
   standalonePage: css`
     display: grid;
+    grid-template-columns: minmax(0, 1fr);
     place-items: center;
 
     min-width: 20rem;
@@ -411,6 +412,10 @@ export const styles = createStaticStyles(({ css }) => ({
 
     > [data-demo-placeholder],
     > [id^='lobe-demo-'] {
+      width: 100%;
+    }
+
+    > [data-lobe-demo-appearance] {
       width: 100%;
     }
   `,


### PR DESCRIPTION
## Summary

- give standalone demo pages an explicit full-width grid track
- propagate that width through the appearance wrapper used by AntApp providers
- add a regression test for the provider-wrapped standalone layout

## Root cause

AntApp sets width: inherit on its provider wrapper. Because the appearance boundary uses display: contents without an explicit width, responsive demos could shrink to their intrinsic width even though the standalone page itself occupied the viewport.

## Verification

- targeted Vitest suite: 5 tests passed
- targeted ESLint: passed
- type-check: passed
- docs production build: passed (15,189 modules)
- package build: passed (2,235 files)
- browser: provider and rendered demo both measured 1,232 px in a 1,280 px viewport with 24 px page padding and zero horizontal overflow
