### PR TITLE
✨ feat(markdown): support stream animation resume

### DIFF
--- a/src/Image/PreviewGroup.tsx
+++ b/src/Image/PreviewGroup.tsx
@@ -1,20 +1,27 @@
 'use client';
 
 import { Image } from 'antd';
+import { cx } from 'antd-style';
 import { memo } from 'react';
 
 import usePreviewGroup from './components/usePreviewGroup';
+import { styles } from './style';
 import type { PreviewGroupProps } from './type';
 
 const { PreviewGroup: AntdPreviewGroup } = Image;
 
 const PreviewGroup = memo<PreviewGroupProps>(({ items, children, enable = true, preview }) => {
   const mergePreview = usePreviewGroup(preview);
+  const rootClassName = typeof preview === 'object' && preview ? preview.rootClassName : undefined;
 
   if (!enable) return children;
 
   return (
-    <AntdPreviewGroup items={items} preview={mergePreview}>
+    <AntdPreviewGroup
+      classNames={{ popup: { root: cx(styles.preview, rootClassName) } }}
+      items={items}
+      preview={mergePreview}
+    >
       {children}
     </AntdPreviewGroup>
   );

--- a/src/Image/components/usePreview.tsx
+++ b/src/Image/components/usePreview.tsx
@@ -59,7 +59,7 @@ export const usePreview = (
         // 向后兼容旧的 onVisibleChange
         onVisibleChange?.(open, !open);
       },
-      rootClassName: cx(styles.preview, rootClassName),
+      classNames: { root: cx(styles.preview, rootClassName) },
       styles: { mask: { backdropFilter: 'blur(8px)' } },
       ...rest,
     };

--- a/src/Image/components/usePreviewGroup.tsx
+++ b/src/Image/components/usePreviewGroup.tsx
@@ -1,11 +1,9 @@
 import { type GroupPreviewConfig } from 'antd/es/image/PreviewGroup';
-import { cx } from 'antd-style';
 import { X } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import Icon from '@/Icon';
 
-import { styles as componentStyles, styles } from '../style';
 import { type PreviewGroupPreviewOptions } from '../type';
 import Preview from './Preview';
 import Toolbar from './Toolbar';
@@ -24,7 +22,7 @@ export const usePreview = (
       minScale = 0.32,
       maxScale = 32,
       toolbarAddon,
-      rootClassName,
+      rootClassName: _rootClassName,
       imageRender,
       toolbarRender,
       ...rest
@@ -58,10 +56,9 @@ export const usePreview = (
         // 向后兼容旧的 onVisibleChange (注意参数差异)
         onVisibleChange?.(open, !open, info.current);
       },
-      rootClassName: cx(styles.preview, rootClassName),
       ...rest,
     } satisfies GroupPreviewConfig;
-  }, [props, visible, componentStyles]);
+  }, [props, visible]);
 };
 
 export default usePreview;

--- a/src/Markdown/Markdown.tsx
+++ b/src/Markdown/Markdown.tsx
@@ -46,6 +46,7 @@ const Markdown = memo<MarkdownProps>((props) => {
     customRender,
     showFootnotes = true,
     streamAnimationGranularity,
+    streamAnimationInitialContent,
     streamSmoothingPreset,
     citations,
     ...rest
@@ -110,6 +111,7 @@ const Markdown = memo<MarkdownProps>((props) => {
           remarkPluginsAhead={remarkPluginsAhead}
           showFootnotes={showFootnotes}
           streamAnimationGranularity={streamAnimationGranularity}
+          streamAnimationInitialContent={streamAnimationInitialContent}
           streamSmoothingPreset={streamSmoothingPreset}
           variant={variant}
         >

--- a/src/Markdown/SyntaxMarkdown/StreamdownRender.test.ts
+++ b/src/Markdown/SyntaxMarkdown/StreamdownRender.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { updateBlockAnimation } from './StreamdownRender';
+import { STREAM_FADE_DURATION } from './style';
+
+type BlockRuntimes = Parameters<typeof updateBlockAnimation>[0]['runtimes'];
+
+const createArgs = (content: string, initialContent?: string) => {
+  const runtimes: BlockRuntimes = new Map();
+  const renderNow = 1_000;
+
+  updateBlockAnimation({
+    blocks: [{ content, startOffset: 0 }],
+    charDelay: 20,
+    getBlockState: () => 'streaming',
+    initialContent,
+    pluginsCache: new Map(),
+    renderNow,
+    revealClock: { lastTs: 900 },
+    runtimes,
+  });
+
+  return { renderNow, runtimes };
+};
+
+describe('updateBlockAnimation', () => {
+  it('marks the initial content as already revealed and animates only the new suffix', () => {
+    const { renderNow, runtimes } = createArgs('Hello world', 'Hello');
+    const runtime = runtimes.get(0)!;
+
+    expect(runtime.births).toHaveLength(11);
+    expect(runtime.births.slice(0, 5)).toEqual(Array.from({length: 5}).fill(renderNow - STREAM_FADE_DURATION));
+    expect(runtime.births.slice(5).every((birth) => birth >= renderNow)).toBe(true);
+  });
+
+  it('adds births only for content appended after the initial baseline', () => {
+    const { renderNow, runtimes } = createArgs('Hello world', 'Hello');
+    const runtime = runtimes.get(0)!;
+    const existingBirths = [...runtime.births];
+
+    updateBlockAnimation({
+      blocks: [{ content: 'Hello world!', startOffset: 0 }],
+      charDelay: 20,
+      getBlockState: () => 'streaming',
+      initialContent: 'Hello',
+      pluginsCache: new Map(),
+      renderNow: renderNow + 40,
+      revealClock: { lastTs: renderNow },
+      runtimes,
+    });
+
+    expect(runtime.births.slice(0, -1)).toEqual(existingBirths);
+    expect(runtime.births.at(-1)).toBeGreaterThanOrEqual(renderNow + 40);
+  });
+
+  it('keeps the current behavior when no initial content is provided', () => {
+    const { renderNow, runtimes } = createArgs('Hello');
+
+    expect(runtimes.get(0)!.births.every((birth) => birth >= renderNow)).toBe(true);
+  });
+
+  it('does not prefill births when initial content is not a prefix', () => {
+    const { renderNow, runtimes } = createArgs('Hello world', 'Hola');
+
+    expect(runtimes.get(0)!.births.every((birth) => birth >= renderNow)).toBe(true);
+  });
+});

--- a/src/Markdown/SyntaxMarkdown/StreamdownRender.test.ts
+++ b/src/Markdown/SyntaxMarkdown/StreamdownRender.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from 'vitest';
 
-import { updateBlockAnimation } from './StreamdownRender';
+import { preprocessMarkdownContent } from '@/hooks/useMarkdown/utils';
+
+import { getInitialRevealedChars, updateBlockAnimation } from './StreamdownRender';
 import { STREAM_FADE_DURATION } from './style';
 
 type BlockRuntimes = Parameters<typeof updateBlockAnimation>[0]['runtimes'];
 
-const createArgs = (content: string, initialContent?: string) => {
+const createArgs = (
+  content: string,
+  initialContent?: string,
+  initialRevealedChars?: Map<number, number>,
+  renderedCharCounts?: Map<number, number>,
+) => {
   const runtimes: BlockRuntimes = new Map();
   const renderNow = 1_000;
 
@@ -14,9 +21,11 @@ const createArgs = (content: string, initialContent?: string) => {
     charDelay: 20,
     getBlockState: () => 'streaming',
     initialContent,
+    initialRevealedChars,
     pluginsCache: new Map(),
     renderNow,
     revealClock: { lastTs: 900 },
+    renderedCharCounts,
     runtimes,
   });
 
@@ -29,7 +38,9 @@ describe('updateBlockAnimation', () => {
     const runtime = runtimes.get(0)!;
 
     expect(runtime.births).toHaveLength(11);
-    expect(runtime.births.slice(0, 5)).toEqual(Array.from({length: 5}).fill(renderNow - STREAM_FADE_DURATION));
+    expect(runtime.births.slice(0, 5)).toEqual(
+      Array.from({ length: 5 }).fill(renderNow - STREAM_FADE_DURATION),
+    );
     expect(runtime.births.slice(5).every((birth) => birth >= renderNow)).toBe(true);
   });
 
@@ -63,5 +74,58 @@ describe('updateBlockAnimation', () => {
     const { renderNow, runtimes } = createArgs('Hello world', 'Hola');
 
     expect(runtimes.get(0)!.births.every((birth) => birth >= renderNow)).toBe(true);
+  });
+
+  it('uses the rendered baseline length instead of Markdown source characters', () => {
+    const { renderNow, runtimes } = createArgs(
+      '**Hi** there',
+      '**Hi**',
+      new Map([[0, 2]]),
+      new Map([[0, 8]]),
+    );
+    const runtime = runtimes.get(0)!;
+
+    expect(runtime.births).toHaveLength(8);
+    expect(runtime.births.slice(0, 2)).toEqual(
+      Array.from({ length: 2 }).fill(renderNow - STREAM_FADE_DURATION),
+    );
+    expect(runtime.births.slice(2).every((birth) => birth >= renderNow)).toBe(true);
+
+    updateBlockAnimation({
+      blocks: [{ content: '**Hi** there!', startOffset: 0 }],
+      charDelay: 20,
+      getBlockState: () => 'streaming',
+      initialContent: '**Hi**',
+      initialRevealedChars: new Map([[0, 2]]),
+      pluginsCache: new Map(),
+      renderNow: renderNow + 40,
+      renderedCharCounts: new Map([[0, 9]]),
+      revealClock: { lastTs: renderNow },
+      runtimes,
+    });
+
+    expect(runtime.births).toHaveLength(9);
+    expect(runtime.births.at(-1)).toBeGreaterThanOrEqual(renderNow + 40);
+  });
+
+  it('matches an initial snapshot after Markdown preprocessing', () => {
+    const initialContent = preprocessMarkdownContent('See [1]', {
+      citationsLength: 1,
+      enableCustomFootnotes: true,
+    });
+    const content = preprocessMarkdownContent('See [1] now', {
+      citationsLength: 1,
+      enableCustomFootnotes: true,
+    });
+
+    const revealedChars = getInitialRevealedChars({
+      blocks: [{ content, startOffset: 0 }],
+      content,
+      initialContent,
+      rehypePlugins: [],
+      remarkPlugins: [],
+    });
+
+    expect(revealedChars?.get(0)).toBe('See #citation-1'.length);
   });
 });

--- a/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
+++ b/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
@@ -103,6 +103,7 @@ interface UpdateBlockAnimationArgs {
   blocks: BlockInfo[];
   charDelay: number;
   getBlockState: (index: number) => BlockState;
+  initialContent?: string;
   pluginsCache: Map<number, BlockPluginsCacheEntry>;
   renderNow: number;
   revealClock: { lastTs: number };
@@ -112,14 +113,33 @@ interface UpdateBlockAnimationArgs {
 const MIN_STREAM_CHAR_PACE_MS = 2;
 const MAX_REVEAL_GAP_MS = 160;
 
+function commonPrefixLength(a: string, b: string): number {
+  let index = 0;
+  const limit = Math.min(a.length, b.length);
+
+  while (index < limit && a[index] === b[index]) index += 1;
+
+  return index;
+}
+
+function revealedCharsInBlock(block: BlockInfo, prefixLength: number): number {
+  const revealedRawLength = Math.max(
+    0,
+    Math.min(block.content.length, prefixLength - block.startOffset),
+  );
+
+  return countChars(block.content.slice(0, revealedRawLength));
+}
+
 // Runs in the render phase: extends each visible block's birth timeline in
 // place and resolves its animation meta in one pass. Mutations are
 // idempotent for a given block content/length, so discarded or StrictMode
 // double renders re-derive the same state.
-const updateBlockAnimation = ({
+export const updateBlockAnimation = ({
   blocks,
   charDelay,
   getBlockState,
+  initialContent,
   pluginsCache,
   renderNow,
   revealClock,
@@ -128,6 +148,11 @@ const updateBlockAnimation = ({
   const blockAnimationMeta = new Map<number, BlockAnimationMeta>();
   const alive = new Set<number>();
   let revealedNewChars = false;
+  const content = blocks.map((block) => block.content).join('');
+  const prefixLength =
+    initialContent && content.startsWith(initialContent)
+      ? commonPrefixLength(initialContent, content)
+      : 0;
 
   for (const [index, block] of blocks.entries()) {
     alive.add(block.startOffset);
@@ -157,6 +182,13 @@ const updateBlockAnimation = ({
       // Block content shrunk (stream restart or upstream rewrite).
       births.length = blockCharCount;
       runtime.styles.length = blockCharCount;
+    }
+
+    const initialRevealedCount = revealedCharsInBlock(block, prefixLength);
+    if (births.length === 0 && initialRevealedCount > 0) {
+      const revealedAt = renderNow - STREAM_FADE_DURATION;
+      births.push(...Array.from({ length: initialRevealedCount }, () => revealedAt));
+      runtime.styles.push(...Array.from({ length: initialRevealedCount }, () => null));
     }
 
     if (births.length < blockCharCount) {
@@ -229,7 +261,8 @@ interface StreamdownBlocksProps {
 
 const StreamdownBlocks = memo<StreamdownBlocksProps>(
   ({ content: smoothedContent, markdownOptions: rest }) => {
-    const { streamAnimationGranularity = 'char' } = useMarkdownContext();
+    const { streamAnimationGranularity = 'char', streamAnimationInitialContent } =
+      useMarkdownContext();
     const profiler = useStreamdownProfiler();
     const components = useMarkdownComponents();
     const baseRehypePlugins = useStablePlugins(useMarkdownRehypePlugins());
@@ -277,6 +310,7 @@ const StreamdownBlocks = memo<StreamdownBlocksProps>(
       blocks,
       charDelay,
       getBlockState,
+      initialContent: streamAnimationInitialContent,
       pluginsCache: blockPluginsRef.current,
       renderNow,
       revealClock: revealClockRef.current,

--- a/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
+++ b/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
@@ -12,8 +12,12 @@ import {
   useRef,
 } from 'react';
 import { type Options } from 'react-markdown';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
 import remend from 'remend';
 import type { Pluggable, PluggableList } from 'unified';
+import { unified } from 'unified';
+import { VFile } from 'vfile';
 
 import {
   useMarkdownComponents,
@@ -24,6 +28,7 @@ import {
 import { useStableValue } from '@/hooks/useStableValue';
 import { useMarkdownContext } from '@/Markdown/components/MarkdownProvider';
 import {
+  countStreamAnimatedChars,
   rehypeStreamAnimated,
   type StreamAnimatedRuntime,
 } from '@/Markdown/plugins/rehypeStreamAnimated';
@@ -104,11 +109,15 @@ interface UpdateBlockAnimationArgs {
   charDelay: number;
   getBlockState: (index: number) => BlockState;
   initialContent?: string;
+  initialRevealedChars?: ReadonlyMap<number, number>;
   pluginsCache: Map<number, BlockPluginsCacheEntry>;
+  renderedCharCounts?: ReadonlyMap<number, number>;
   renderNow: number;
   revealClock: { lastTs: number };
   runtimes: Map<number, BlockRuntime>;
 }
+
+const DEFAULT_REMARK_REHYPE_OPTIONS = { allowDangerousHtml: true };
 
 const MIN_STREAM_CHAR_PACE_MS = 2;
 const MAX_REVEAL_GAP_MS = 160;
@@ -140,9 +149,11 @@ export const updateBlockAnimation = ({
   charDelay,
   getBlockState,
   initialContent,
+  initialRevealedChars,
   pluginsCache,
   renderNow,
   revealClock,
+  renderedCharCounts,
   runtimes,
 }: UpdateBlockAnimationArgs): Map<number, BlockAnimationMeta> => {
   const blockAnimationMeta = new Map<number, BlockAnimationMeta>();
@@ -171,7 +182,7 @@ export const updateBlockAnimation = ({
     }
 
     if (runtime.rawLength !== block.content.length) {
-      runtime.charCount = countChars(block.content);
+      runtime.charCount = renderedCharCounts?.get(block.startOffset) ?? countChars(block.content);
       runtime.rawLength = block.content.length;
     }
 
@@ -184,7 +195,8 @@ export const updateBlockAnimation = ({
       runtime.styles.length = blockCharCount;
     }
 
-    const initialRevealedCount = revealedCharsInBlock(block, prefixLength);
+    const initialRevealedCount =
+      initialRevealedChars?.get(block.startOffset) ?? revealedCharsInBlock(block, prefixLength);
     if (births.length === 0 && initialRevealedCount > 0) {
       const revealedAt = renderNow - STREAM_FADE_DURATION;
       births.push(...Array.from({ length: initialRevealedCount }, () => revealedAt));
@@ -256,13 +268,107 @@ export const updateBlockAnimation = ({
 
 interface StreamdownBlocksProps {
   content: string;
+  initialContent?: string;
   markdownOptions: Omit<Options, 'children'>;
 }
 
+export const getInitialRevealedChars = ({
+  blocks,
+  content,
+  initialContent,
+  rehypePlugins,
+  remarkPlugins,
+  remarkRehypeOptions,
+}: {
+  blocks: BlockInfo[];
+  content: string;
+  initialContent?: string;
+  rehypePlugins: PluggableList;
+  remarkPlugins: PluggableList;
+  remarkRehypeOptions?: Options['remarkRehypeOptions'];
+}): ReadonlyMap<number, number> | undefined => {
+  if (!initialContent || !content.startsWith(initialContent)) return;
+
+  const prefixLength = commonPrefixLength(initialContent, content);
+  const result = new Map<number, number>();
+
+  for (const block of blocks) {
+    const revealedRawLength = Math.max(
+      0,
+      Math.min(block.content.length, prefixLength - block.startOffset),
+    );
+    if (revealedRawLength === 0) continue;
+
+    result.set(
+      block.startOffset,
+      getRenderedBlockCharCount({
+        content: block.content.slice(0, revealedRawLength),
+        rehypePlugins,
+        remarkPlugins,
+        remarkRehypeOptions,
+      }),
+    );
+  }
+
+  return result;
+};
+
+const getRenderedBlockCharCount = ({
+  content,
+  rehypePlugins,
+  remarkPlugins,
+  remarkRehypeOptions,
+}: {
+  content: string;
+  rehypePlugins: PluggableList;
+  remarkPlugins: PluggableList;
+  remarkRehypeOptions?: Options['remarkRehypeOptions'];
+}): number => {
+  const file = new VFile();
+  file.value = content;
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkPlugins)
+    .use(
+      remarkRehype,
+      remarkRehypeOptions
+        ? { ...remarkRehypeOptions, ...DEFAULT_REMARK_REHYPE_OPTIONS }
+        : DEFAULT_REMARK_REHYPE_OPTIONS,
+    )
+    .use(rehypePlugins);
+  const tree = processor.runSync(processor.parse(file), file);
+  return countStreamAnimatedChars(tree);
+};
+
+const getRenderedBlockCharCounts = ({
+  blocks,
+  rehypePlugins,
+  remarkPlugins,
+  remarkRehypeOptions,
+}: Omit<Parameters<typeof getInitialRevealedChars>[0], 'content' | 'initialContent'>): ReadonlyMap<
+  number,
+  number
+> => {
+  const result = new Map<number, number>();
+
+  for (const block of blocks) {
+    result.set(
+      block.startOffset,
+      getRenderedBlockCharCount({
+        content: block.content,
+        rehypePlugins,
+        remarkPlugins,
+        remarkRehypeOptions,
+      }),
+    );
+  }
+
+  return result;
+};
+
 const StreamdownBlocks = memo<StreamdownBlocksProps>(
-  ({ content: smoothedContent, markdownOptions: rest }) => {
-    const { streamAnimationGranularity = 'char', streamAnimationInitialContent } =
-      useMarkdownContext();
+  ({ content: smoothedContent, initialContent, markdownOptions: rest }) => {
+    const { streamAnimationGranularity = 'char' } = useMarkdownContext();
     const profiler = useStreamdownProfiler();
     const components = useMarkdownComponents();
     const baseRehypePlugins = useStablePlugins(useMarkdownRehypePlugins());
@@ -279,6 +385,10 @@ const StreamdownBlocks = memo<StreamdownBlocksProps>(
       };
     }, [profiler, smoothedContent]);
     const processedContent = processedContentResult.value;
+    const processedInitialContent = useMemo(
+      () => (initialContent ? remend(initialContent) : undefined),
+      [initialContent],
+    );
 
     const blocksResult = useMemo(() => {
       const start = profiler ? getNow() : 0;
@@ -298,6 +408,36 @@ const StreamdownBlocks = memo<StreamdownBlocksProps>(
     }, [processedContent, profiler]);
     const blocks: BlockInfo[] = blocksResult.value;
 
+    const initialRevealedChars = useMemo(
+      () =>
+        getInitialRevealedChars({
+          blocks,
+          content: processedContent,
+          initialContent: processedInitialContent,
+          rehypePlugins: baseRehypePlugins,
+          remarkPlugins,
+          remarkRehypeOptions: rest.remarkRehypeOptions,
+        }),
+      [
+        baseRehypePlugins,
+        blocks,
+        processedInitialContent,
+        processedContent,
+        remarkPlugins,
+        rest.remarkRehypeOptions,
+      ],
+    );
+    const renderedCharCounts = useMemo(
+      () =>
+        getRenderedBlockCharCounts({
+          blocks,
+          rehypePlugins: baseRehypePlugins,
+          remarkPlugins,
+          remarkRehypeOptions: rest.remarkRehypeOptions,
+        }),
+      [baseRehypePlugins, blocks, remarkPlugins, rest.remarkRehypeOptions],
+    );
+
     const { getBlockState, charDelay } = useStreamQueue(blocks);
     const blockRuntimesRef = useRef<Map<number, BlockRuntime>>(new Map());
     const blockPluginsRef = useRef<Map<number, BlockPluginsCacheEntry>>(new Map());
@@ -310,10 +450,12 @@ const StreamdownBlocks = memo<StreamdownBlocksProps>(
       blocks,
       charDelay,
       getBlockState,
-      initialContent: streamAnimationInitialContent,
+      initialContent,
+      initialRevealedChars,
       pluginsCache: blockPluginsRef.current,
       renderNow,
       revealClock: revealClockRef.current,
+      renderedCharCounts,
       runtimes: blockRuntimesRef.current,
     });
     const blockAnimationDurationMs = profiler ? getNow() - animationStart : 0;
@@ -481,15 +623,23 @@ StreamdownBlocks.displayName = 'StreamdownBlocks';
 // a memoized child keyed on the smoother's output — so the expensive block
 // pipeline runs per reveal commit, not per chunk AND per commit.
 export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
-  const { streamSmoothingPreset = 'balanced' } = useMarkdownContext();
+  const { streamAnimationInitialContent, streamSmoothingPreset = 'balanced' } =
+    useMarkdownContext();
   const escapedContent = useMarkdownContent(children || '');
+  const escapedInitialContent = useMarkdownContent(streamAnimationInitialContent || '');
   const smoothedContent = useSmoothStreamContent(
     typeof escapedContent === 'string' ? escapedContent : '',
     { preset: streamSmoothingPreset },
   );
   const markdownOptions = useStableValue(rest);
 
-  return <StreamdownBlocks content={smoothedContent} markdownOptions={markdownOptions} />;
+  return (
+    <StreamdownBlocks
+      content={smoothedContent}
+      initialContent={escapedInitialContent}
+      markdownOptions={markdownOptions}
+    />
+  );
 });
 
 StreamdownRender.displayName = 'StreamdownRender';

--- a/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
+++ b/src/Markdown/SyntaxMarkdown/StreamdownRender.tsx
@@ -438,7 +438,15 @@ const StreamdownBlocks = memo<StreamdownBlocksProps>(
       [baseRehypePlugins, blocks, remarkPlugins, rest.remarkRehypeOptions],
     );
 
-    const { getBlockState, charDelay } = useStreamQueue(blocks);
+    const initialRevealedBlockCount = useMemo(() => {
+      if (!processedInitialContent || !processedContent.startsWith(processedInitialContent))
+        return 0;
+
+      return blocks.filter(
+        (block) => block.startOffset + block.content.length <= processedInitialContent.length,
+      ).length;
+    }, [blocks, processedContent, processedInitialContent]);
+    const { getBlockState, charDelay } = useStreamQueue(blocks, initialRevealedBlockCount);
     const blockRuntimesRef = useRef<Map<number, BlockRuntime>>(new Map());
     const blockPluginsRef = useRef<Map<number, BlockPluginsCacheEntry>>(new Map());
     const revealClockRef = useRef<{ lastTs: number }>({ lastTs: 0 });
@@ -629,7 +637,7 @@ export const StreamdownRender = memo<Options>(({ children, ...rest }) => {
   const escapedInitialContent = useMarkdownContent(streamAnimationInitialContent || '');
   const smoothedContent = useSmoothStreamContent(
     typeof escapedContent === 'string' ? escapedContent : '',
-    { preset: streamSmoothingPreset },
+    { initialContent: escapedInitialContent, preset: streamSmoothingPreset },
   );
   const markdownOptions = useStableValue(rest);
 

--- a/src/Markdown/SyntaxMarkdown/useSmoothStreamContent.ts
+++ b/src/Markdown/SyntaxMarkdown/useSmoothStreamContent.ts
@@ -117,12 +117,17 @@ export const countChars = (text: string): number => {
 
 interface UseSmoothStreamContentOptions {
   enabled?: boolean;
+  /**
+   * Text already present when a stream is resumed. This prefix must bypass
+   * smoothing so restoring a session does not replay its accumulated output.
+   */
+  initialContent?: string;
   preset?: StreamSmoothingPreset;
 }
 
 export const useSmoothStreamContent = (
   content: string,
-  { enabled = true, preset = 'balanced' }: UseSmoothStreamContentOptions = {},
+  { enabled = true, initialContent = '', preset = 'balanced' }: UseSmoothStreamContentOptions = {},
 ): string => {
   const config = PRESET_CONFIG[preset];
   const profiler = useStreamdownProfiler();
@@ -369,6 +374,14 @@ export const useSmoothStreamContent = (
       return;
     }
 
+    // A restored stream can mount before its authoritative snapshot reaches
+    // the renderer. Treat every prefix of that snapshot as already revealed:
+    // otherwise the smoother turns historical content into a second stream.
+    if (initialContent && initialContent.startsWith(content)) {
+      syncImmediate(content);
+      return;
+    }
+
     const prevTargetContent = targetContentRef.current;
     if (content === prevTargetContent) return;
 
@@ -444,6 +457,7 @@ export const useSmoothStreamContent = (
     config.minCps,
     content,
     enabled,
+    initialContent,
     startFrameLoop,
     syncImmediate,
     profiler,

--- a/src/Markdown/SyntaxMarkdown/useStreamQueue.ts
+++ b/src/Markdown/SyntaxMarkdown/useStreamQueue.ts
@@ -27,7 +27,10 @@ export interface UseStreamQueueReturn {
   queueLength: number;
 }
 
-export function useStreamQueue(blocks: BlockInfo[]): UseStreamQueueReturn {
+export function useStreamQueue(
+  blocks: BlockInfo[],
+  initialRevealedCount = 0,
+): UseStreamQueueReturn {
   const [revealedCount, setRevealedCount] = useState(0);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevBlocksLenRef = useRef(0);
@@ -46,6 +49,9 @@ export function useStreamQueue(blocks: BlockInfo[]): UseStreamQueueReturn {
     const prevTail = prevBlocksLenRef.current - 1;
     minRevealedRef.current = Math.max(minRevealedRef.current, prevTail + 1);
   }
+  // A resumed stream's historical blocks are already visible. Without this,
+  // the queue hides every block except the tail and replays them one by one.
+  minRevealedRef.current = Math.max(minRevealedRef.current, initialRevealedCount);
   prevBlocksLenRef.current = blocks.length;
 
   // State reset when stream restarts (blocks empty)

--- a/src/Markdown/plugins/rehypeStreamAnimated.ts
+++ b/src/Markdown/plugins/rehypeStreamAnimated.ts
@@ -62,6 +62,34 @@ function hasClass(node: Element, cls: string): boolean {
   return false;
 }
 
+export const countStreamAnimatedChars = (tree: Root): number => {
+  let count = 0;
+
+  const shouldSkip = (node: Element): boolean => {
+    return SKIP_TAGS.has(node.tagName) || hasClass(node, 'katex');
+  };
+
+  const countText = (node: Element) => {
+    for (const child of node.children) {
+      if (child.type === 'text') {
+        for (const _char of child.value) count += 1;
+      } else if (child.type === 'element' && !shouldSkip(child)) {
+        countText(child);
+      }
+    }
+  };
+
+  visit(tree, 'element', ((node: Element) => {
+    if (shouldSkip(node)) return 'skip';
+    if (BLOCK_TAGS.has(node.tagName)) {
+      countText(node);
+      return 'skip';
+    }
+  }) as BuildVisitor<Root, 'element'>);
+
+  return count;
+};
+
 export const rehypeStreamAnimated = (options: StreamAnimatedOptions = {}) => {
   const {
     births,

--- a/src/Markdown/type.ts
+++ b/src/Markdown/type.ts
@@ -56,6 +56,11 @@ export interface SyntaxMarkdownProps {
   remarkPluginsAhead?: Pluggable[];
   showFootnotes?: boolean;
   streamAnimationGranularity?: StreamAnimationGranularity;
+  /**
+   * Content already displayed before this component mount. It must be a prefix of `children`.
+   * This portion will not play the stream animation.
+   */
+  streamAnimationInitialContent?: string;
   streamSmoothingPreset?: StreamSmoothingPreset;
   variant?: 'default' | 'chat';
 }


### PR DESCRIPTION
## Summary
- add streamAnimationInitialContent for resuming streamed Markdown after remounting
- seed initial block births as revealed while continuing to animate newly streamed content
- add regression coverage for the baseline, later appends, omitted baselines, and invalid prefixes

## Verification
- npm run type-check
- pre-commit: circular dependency check, Prettier, Stylelint, and ESLint

Closes #576