### PR TITLE
🐛 fix(draggable-panel): support reversible drag collapse

### DIFF
--- a/src/DraggablePanel/DraggablePanel.tsx
+++ b/src/DraggablePanel/DraggablePanel.tsx
@@ -25,7 +25,7 @@ import Icon from '@/Icon';
 
 import { handleVariants, panelVariants, styles, toggleVariants } from './style';
 import type { DraggablePanelProps } from './type';
-import { reversePlacement } from './utils';
+import { isBelowCollapseThreshold, reversePlacement } from './utils';
 
 const ARROW_MAP = {
   bottom: ChevronUp,
@@ -73,6 +73,7 @@ const DraggablePanel = memo<DraggablePanelProps>(
     showHandleHighlight = false,
     showHandleWideArea = true,
     backgroundColor,
+    collapseThreshold,
     size,
     stableLayout = false,
     defaultSize: customizeDefaultSize,
@@ -99,6 +100,7 @@ const DraggablePanel = memo<DraggablePanelProps>(
     const resetTransitionTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
     const resizableRef = useRef<Resizable>(null);
     const initialExpandedSizeRef = useRef<Size | undefined>(undefined);
+    const resizeStartSizeRef = useRef<Size | undefined>(undefined);
     const outerRef = useRef<HTMLDivElement>(null);
 
     const { direction: antdDirection } = use(ConfigProvider.ConfigContext);
@@ -123,6 +125,7 @@ const DraggablePanel = memo<DraggablePanelProps>(
 
     const [shouldTransition, setShouldTransition] = useState(true);
     const [showExpand, setShowExpand] = useState(true);
+    const usesStableLayout = stableLayout || collapseThreshold !== undefined;
 
     useEffect(() => {
       if (pin) return;
@@ -184,7 +187,7 @@ const DraggablePanel = memo<DraggablePanelProps>(
     const normalizedMinWidth = typeof minWidth === 'number' ? Math.max(minWidth, 0) : undefined;
 
     const sizeProps = useMemo(() => {
-      if (!stableLayout && !isExpand) {
+      if (!usesStableLayout && !isExpand) {
         return isVertical
           ? { minHeight: 0, size: { height: 0 } }
           : { minWidth: 0, size: { width: 0 } };
@@ -199,7 +202,7 @@ const DraggablePanel = memo<DraggablePanelProps>(
         size: size as Size,
       };
     }, [
-      stableLayout,
+      usesStableLayout,
       isExpand,
       isVertical,
       defaultSize,
@@ -231,7 +234,7 @@ const DraggablePanel = memo<DraggablePanelProps>(
 
     const setExpandedMainSize = useCallback(
       (nextSize: Size) => {
-        if (!stableLayout) return;
+        if (!usesStableLayout) return;
 
         const currentSize = isVertical ? nextSize.height : nextSize.width;
         if (!currentSize) return;
@@ -243,22 +246,27 @@ const DraggablePanel = memo<DraggablePanelProps>(
             : { ...state, horizontal: normalizedSize },
         );
       },
-      [fallbackExpandedSize, isVertical, stableLayout],
+      [fallbackExpandedSize, isVertical, usesStableLayout],
     );
+
+    const readCurrentSize = useCallback((): Size | undefined => {
+      const rect = resizableRef.current?.resizable?.getBoundingClientRect();
+      if (!rect) return undefined;
+
+      return isVertical
+        ? { height: rect.height, width: '100%' }
+        : { height: '100%', width: rect.width };
+    }, [isVertical]);
 
     const captureInitialExpandedSize = useCallback(() => {
       if (initialExpandedSizeRef.current) return initialExpandedSizeRef.current;
 
-      const rect = resizableRef.current?.resizable?.getBoundingClientRect();
-      if (!rect) return undefined;
-
-      const nextInitialSize = isVertical
-        ? ({ height: rect.height, width: '100%' } as Size)
-        : ({ height: '100%', width: rect.width } as Size);
+      const nextInitialSize = readCurrentSize();
+      if (!nextInitialSize) return undefined;
 
       initialExpandedSizeRef.current = nextInitialSize;
       return nextInitialSize;
-    }, [isVertical]);
+    }, [readCurrentSize]);
 
     useEffect(() => {
       if (!isExpand) return;
@@ -307,20 +315,37 @@ const DraggablePanel = memo<DraggablePanelProps>(
     const handleResize = useCallback(
       (_event: unknown, _direction: unknown, el: HTMLElement, delta: NumberSize) => {
         const nextSize = clampResizeSize(el);
-        if (stableLayout && outerRef.current) {
+        const nextCollapsePreview = isBelowCollapseThreshold({
+          axis: isVertical ? 'height' : 'width',
+          collapseThreshold,
+          size: nextSize,
+        });
+
+        if (usesStableLayout && outerRef.current) {
           // Sync outer DOM width immediately so it doesn't lag behind the
           // re-resizable inline style (which would otherwise trigger a 0.2s
           // width transition on the outer/aside each frame during drag).
           const dimension = isVertical ? nextSize.height : nextSize.width;
           if (dimension) {
-            if (isVertical) outerRef.current.style.height = dimension;
-            else outerRef.current.style.width = dimension;
+            const previewDimension = nextCollapsePreview ? '0px' : dimension;
+            if (isVertical) outerRef.current.style.height = previewDimension;
+            else outerRef.current.style.width = previewDimension;
           }
         }
-        setExpandedMainSize(nextSize);
+        // With drag-to-collapse enabled, defer the persisted expanded size until
+        // pointer release. This keeps the pre-drag width as the single source of
+        // truth while the outer stable-layout layer previews collapse/restore.
+        if (collapseThreshold === undefined) setExpandedMainSize(nextSize);
         onSizeDragging?.(delta, nextSize);
       },
-      [clampResizeSize, isVertical, onSizeDragging, setExpandedMainSize, stableLayout],
+      [
+        clampResizeSize,
+        collapseThreshold,
+        isVertical,
+        onSizeDragging,
+        setExpandedMainSize,
+        usesStableLayout,
+      ],
     );
 
     const triggerResetWithoutTransition = useCallback(() => {
@@ -377,34 +402,61 @@ const DraggablePanel = memo<DraggablePanelProps>(
           resetTransitionTimeoutRef.current = undefined;
         }
 
+        resizeStartSizeRef.current = readCurrentSize();
+
         // Synchronously disable the outer transition so the first drag frame
         // does not animate. `setShouldTransition(false)` below is asynchronous
         // and would only take effect after the next React commit.
-        if (stableLayout && outerRef.current) {
+        if (usesStableLayout && outerRef.current) {
           outerRef.current.style.transition = 'none';
         }
         setShouldTransition(false);
         setShowExpand(false);
       },
-      [handleResetSize, stableLayout],
+      [handleResetSize, readCurrentSize, usesStableLayout],
     );
 
     const handleResizeStop = useCallback(
       (_event: unknown, _direction: unknown, el: HTMLElement, delta: NumberSize) => {
         const nextSize = clampResizeSize(el);
-        setExpandedMainSize(nextSize);
+        const shouldCollapse = isBelowCollapseThreshold({
+          axis: isVertical ? 'height' : 'width',
+          collapseThreshold,
+          size: nextSize,
+        });
+        const committedSize = shouldCollapse ? (resizeStartSizeRef.current ?? nextSize) : nextSize;
+
+        resizableRef.current?.updateSize(committedSize);
+        if (!shouldCollapse) setExpandedMainSize(committedSize);
         setShouldTransition(true);
         setShowExpand(true);
-        // Clear imperative inline overrides so React resumes owning the outer
-        // width/transition on the next render.
-        if (stableLayout && outerRef.current) {
-          outerRef.current.style.removeProperty('width');
-          outerRef.current.style.removeProperty('height');
+        // Keep the collapsed main-axis size at zero until the controlled
+        // `expand=false` value arrives. Clearing it here would reveal the panel
+        // for one render between preview teardown and controlled-state commit.
+        if (usesStableLayout && outerRef.current) {
           outerRef.current.style.removeProperty('transition');
+          if (shouldCollapse) {
+            if (isVertical) outerRef.current.style.height = '0px';
+            else outerRef.current.style.width = '0px';
+          } else {
+            outerRef.current.style.removeProperty('width');
+            outerRef.current.style.removeProperty('height');
+          }
         }
-        onSizeChange?.(delta, nextSize);
+        if (shouldCollapse) setIsExpand(false);
+
+        resizeStartSizeRef.current = undefined;
+        onSizeChange?.(delta, committedSize);
       },
-      [clampResizeSize, onSizeChange, setExpandedMainSize, stableLayout],
+      [
+        clampResizeSize,
+        collapseThreshold,
+        isVertical,
+        onSizeChange,
+        setExpandedMainSize,
+        setIsExpand,
+        usesStableLayout,
+      ],
     );
 
     const resizeHandleClassName = useMemo(
@@ -422,7 +474,7 @@ const DraggablePanel = memo<DraggablePanelProps>(
     }
 
     const Arrow = ARROW_MAP[internalPlacement] ?? ChevronLeft;
-    const stableOuterFlex = stableLayout
+    const stableOuterFlex = usesStableLayout
       ? ({
           display: 'flex',
           flexDirection: 'column',
@@ -442,7 +494,7 @@ const DraggablePanel = memo<DraggablePanelProps>(
           overflow: 'hidden',
           transition: shouldTransition ? 'width 0.2s var(--ant-motion-ease-out, ease)' : 'none',
           width: isExpand ? expandedOuterSize : 0,
-          ...(stableLayout
+          ...(usesStableLayout
             ? {
                 ...stableOuterFlex,
                 flex: 1,
@@ -461,13 +513,13 @@ const DraggablePanel = memo<DraggablePanelProps>(
       minWidth: 0,
       width: '100%',
     };
-    const sidebarInnerStyle: CSSProperties = stableLayout
+    const sidebarInnerStyle: CSSProperties = usesStableLayout
       ? stableInnerStyle
       : isVertical
         ? { height: '100%', width: '100%' }
         : { width: '100%' };
 
-    const stableAsideStyle: CSSProperties = stableLayout
+    const stableAsideStyle: CSSProperties = usesStableLayout
       ? {
           display: 'flex',
           flexDirection: 'column',
@@ -502,14 +554,14 @@ const DraggablePanel = memo<DraggablePanelProps>(
         style={{
           ...cssVariables,
           transition: shouldTransition ? undefined : 'none',
-          ...(stableLayout ? stableResizableStyle : {}),
+          ...(usesStableLayout ? stableResizableStyle : {}),
           ...style,
         }}
         onResize={handleResize}
         onResizeStart={handleResizeStart}
         onResizeStop={handleResizeStop}
       >
-        {stableLayout ? <div style={sidebarInnerStyle}>{children}</div> : children}
+        {usesStableLayout ? <div style={sidebarInnerStyle}>{children}</div> : children}
       </Resizable>
     );
 
@@ -548,7 +600,7 @@ const DraggablePanel = memo<DraggablePanelProps>(
             </Center>
           </Center>
         )}
-        {stableLayout ? (
+        {usesStableLayout ? (
           <div ref={outerRef} style={sidebarOuterStyle}>
             {panelNode}
           </div>

--- a/src/DraggablePanel/demos/DragToCollapse.tsx
+++ b/src/DraggablePanel/demos/DragToCollapse.tsx
@@ -10,6 +10,8 @@ export default () => {
     <Flexbox horizontal height={'100%'} style={{ minHeight: 500 }} width={'100%'}>
       <DraggablePanel
         showHandleWhenCollapsed
+        stableLayout
+        collapseThreshold={240}
         defaultSize={{ width: 300 }}
         expand={expand}
         minWidth={180}
@@ -19,7 +21,8 @@ export default () => {
         <Flexbox gap={8} padding={24}>
           <div>Drag to Collapse Demo</div>
           <div style={{ color: 'gray', fontSize: 12 }}>
-            <p>Drag the handle all the way to the left to collapse.</p>
+            <p>Drag below 240px to preview collapse; drag back before release to cancel.</p>
+            <p>Release while collapsed to commit. Use the arrow to reopen.</p>
             <p>Double-click the handle to restore default size (300px).</p>
           </div>
         </Flexbox>

--- a/src/DraggablePanel/type.ts
+++ b/src/DraggablePanel/type.ts
@@ -12,6 +12,14 @@ export interface DraggablePanelProps extends DivProps {
     content?: string;
     handle?: string;
   };
+  /**
+   * Preview a collapsed panel while resizing at or below this size, then commit
+   * the collapsed state on pointer release. Dragging back above the threshold
+   * before release restores the panel.
+   * Applies to width for left/right placement and height for top/bottom placement.
+   * Omit to disable drag-to-collapse behavior.
+   */
+  collapseThreshold?: number;
   defaultExpand?: boolean;
   defaultSize?: Partial<Size>;
   destroyOnClose?: boolean;

--- a/src/DraggablePanel/utils.test.ts
+++ b/src/DraggablePanel/utils.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { isBelowCollapseThreshold } from './utils';
+
+describe('isBelowCollapseThreshold', () => {
+  it('enters collapse preview when a horizontal panel reaches the threshold', () => {
+    expect(
+      isBelowCollapseThreshold({
+        axis: 'width',
+        collapseThreshold: 300,
+        size: { height: '100%', width: '300px' },
+      }),
+    ).toBe(true);
+  });
+
+  it('enters collapse preview when a vertical panel reaches the threshold', () => {
+    expect(
+      isBelowCollapseThreshold({
+        axis: 'height',
+        collapseThreshold: 180,
+        size: { height: 180, width: '100%' },
+      }),
+    ).toBe(true);
+  });
+
+  it('leaves collapse preview after dragging back above the threshold', () => {
+    expect(
+      isBelowCollapseThreshold({
+        axis: 'width',
+        collapseThreshold: 300,
+        size: { height: '100%', width: 320 },
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps existing resize behavior when no threshold is configured', () => {
+    expect(
+      isBelowCollapseThreshold({
+        axis: 'width',
+        size: { height: '100%', width: 0 },
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/DraggablePanel/utils.ts
+++ b/src/DraggablePanel/utils.ts
@@ -1,4 +1,28 @@
+import type { Size } from 're-resizable';
+
 import type { DraggablePanelProps } from './type';
+
+interface IsBelowCollapseThresholdOptions {
+  axis: 'height' | 'width';
+  collapseThreshold?: number;
+  size: Size;
+}
+
+export const isBelowCollapseThreshold = ({
+  axis,
+  collapseThreshold,
+  size,
+}: IsBelowCollapseThresholdOptions): boolean => {
+  if (collapseThreshold === undefined) return false;
+
+  const currentSize = size[axis];
+  if (currentSize === undefined) return false;
+
+  const numericSize =
+    typeof currentSize === 'number' ? currentSize : Number.parseFloat(currentSize);
+
+  return Number.isFinite(numericSize) && numericSize <= Math.max(collapseThreshold, 0);
+};
 
 export const reversePlacement = (placement: DraggablePanelProps['placement']) => {
   switch (placement) {


### PR DESCRIPTION
## Summary

- add an opt-in `collapseThreshold` to `DraggablePanel`
- preview collapse through the stable outer layout while dragging below the threshold
- allow dragging back above the threshold before release to cancel collapse
- commit the controlled `expand=false` state on release without a transient reappearance
- update the interactive demo and add threshold regression tests

## Verification

- focused Vitest: 4/4 passed
- focused ESLint passed (existing default-export warnings only)
- `pnpm run type-check` passed
- browser interaction verified for collapse preview, drag-back cancellation, and no post-release flash