### PR TITLE
🐛 fix(mermaid): render HTML-label diagrams by making Blob SVG XML-safe

### DIFF
--- a/src/Mermaid/SyntaxMermaid/StaticMermaid.tsx
+++ b/src/Mermaid/SyntaxMermaid/StaticMermaid.tsx
@@ -9,6 +9,7 @@ import Image from '@/Image';
 
 import { mermaidThemes } from '../const';
 import { type SyntaxMermaidProps } from '../type';
+import { prepareMermaidSvgString } from './prepareMermaidSvg';
 
 interface StaticMermaidProps {
   children: string;
@@ -48,31 +49,8 @@ const StaticMermaid = memo<StaticMermaidProps>(
 
     useEffect(() => {
       if (isLoading || !data) return;
-      let finalSvgString = data;
 
-      // 修复Firefox点击预览mermaid图时宽高为0导致不显示的异常
-      if (
-        typeof window !== 'undefined' &&
-        typeof navigator !== 'undefined' &&
-        navigator.userAgent.includes('Firefox')
-      ) {
-        const parser = new DOMParser();
-        const svgDoc = parser.parseFromString(data, 'image/svg+xml');
-        const svgElement = svgDoc.documentElement;
-        if (svgElement && svgElement.hasAttribute('viewBox')) {
-          const viewBox = svgElement.getAttribute('viewBox')!;
-          const viewBoxParts = viewBox.split(' ');
-          if (Array.isArray(viewBoxParts) && viewBoxParts.length === 4) {
-            svgElement.setAttribute('width', viewBoxParts[2]);
-            svgElement.setAttribute('height', viewBoxParts[3]);
-          }
-          finalSvgString = new XMLSerializer().serializeToString(svgDoc);
-        }
-      }
-
-      // 创建Blob对象
-      const svgBlob = new Blob([finalSvgString], { type: 'image/svg+xml' });
-      // 创建并保存Blob URL
+      const svgBlob = new Blob([prepareMermaidSvgString(data)], { type: 'image/svg+xml' });
       const url = URL.createObjectURL(svgBlob);
       setBlobUrl(url);
     }, [isLoading, data]);

--- a/src/Mermaid/SyntaxMermaid/StreamMermaid.tsx
+++ b/src/Mermaid/SyntaxMermaid/StreamMermaid.tsx
@@ -9,6 +9,7 @@ import Image from '@/Image';
 
 import { mermaidThemes } from '../const';
 import { type SyntaxMermaidProps } from '../type';
+import { prepareMermaidSvgString } from './prepareMermaidSvg';
 
 interface StreamMermaidProps {
   children: string;
@@ -54,31 +55,7 @@ const StreamMermaid = memo<StreamMermaidProps>(
         return;
       }
 
-      let finalSvgString = data;
-
-      // 修复Firefox点击预览mermaid图时宽高为0导致不显示的异常
-      if (
-        typeof window !== 'undefined' &&
-        typeof navigator !== 'undefined' &&
-        navigator.userAgent.includes('Firefox')
-      ) {
-        const parser = new DOMParser();
-        const svgDoc = parser.parseFromString(data, 'image/svg+xml');
-        const svgElement = svgDoc.documentElement;
-        if (svgElement && svgElement.hasAttribute('viewBox')) {
-          const viewBox = svgElement.getAttribute('viewBox')!;
-          const viewBoxParts = viewBox.split(' ');
-          if (Array.isArray(viewBoxParts) && viewBoxParts.length === 4) {
-            svgElement.setAttribute('width', viewBoxParts[2]);
-            svgElement.setAttribute('height', viewBoxParts[3]);
-          }
-          finalSvgString = new XMLSerializer().serializeToString(svgDoc);
-        }
-      }
-
-      // 创建Blob对象
-      const svgBlob = new Blob([finalSvgString], { type: 'image/svg+xml' });
-      // 创建并保存Blob URL
+      const svgBlob = new Blob([prepareMermaidSvgString(data)], { type: 'image/svg+xml' });
       const url = URL.createObjectURL(svgBlob);
       setBlobUrl(url);
     }, [isLoading, data]);

--- a/src/Mermaid/SyntaxMermaid/prepareMermaidSvg.test.ts
+++ b/src/Mermaid/SyntaxMermaid/prepareMermaidSvg.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { prepareMermaidSvgString } from './prepareMermaidSvg';
+
+const parsesAsStrictXml = (svg: string): boolean => {
+  const doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
+  return !doc.querySelector('parsererror');
+};
+
+const svgWithUnclosedBr = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100"><foreignObject width="200" height="100"><div xmlns="http://www.w3.org/1999/xhtml"><p>G-CSF 启动<br>化疗前24h</p></div></foreignObject></svg>`;
+
+describe('prepareMermaidSvgString', () => {
+  it('reproduces the bug: raw mermaid <br> output fails strict XML parsing', () => {
+    expect(parsesAsStrictXml(svgWithUnclosedBr)).toBe(false);
+  });
+
+  it('makes unclosed <br> loadable as a standalone image/svg+xml document', () => {
+    const result = prepareMermaidSvgString(svgWithUnclosedBr);
+
+    expect(result).not.toContain('<br>');
+    expect(result).toContain('<br/>');
+    expect(parsesAsStrictXml(result)).toBe(true);
+  });
+
+  it('normalizes other HTML void elements while leaving SVG elements untouched', () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg"><foreignObject><div xmlns="http://www.w3.org/1999/xhtml"><span>a<br>b</span><hr><img src="x.png"></div></foreignObject><image href="y.png"/><rect width="10" height="10"/></svg>`;
+
+    const result = prepareMermaidSvgString(svg);
+
+    expect(result).toContain('<hr/>');
+    expect(result).toContain('<img src="x.png"/>');
+    expect(result).toContain('<image href="y.png"/>');
+    expect(result).toContain('<rect width="10" height="10"/>');
+    expect(parsesAsStrictXml(result)).toBe(true);
+  });
+
+  it('preserves already self-closed void elements and case-sensitive attributes', () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50"><foreignObject><div xmlns="http://www.w3.org/1999/xhtml"><p>a<br/>b</p></div></foreignObject></svg>`;
+
+    const result = prepareMermaidSvgString(svg);
+
+    expect(result).toContain('viewBox="0 0 50 50"');
+    expect(result).toContain('<br/>');
+    expect(result).not.toContain('<br/><br/>');
+    expect(parsesAsStrictXml(result)).toBe(true);
+  });
+
+  it('leaves diagrams without HTML labels byte-for-byte unchanged', () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30"><g class="node"><rect width="10" height="10"/></g></svg>`;
+
+    expect(prepareMermaidSvgString(svg)).toBe(svg);
+  });
+});

--- a/src/Mermaid/SyntaxMermaid/prepareMermaidSvg.ts
+++ b/src/Mermaid/SyntaxMermaid/prepareMermaidSvg.ts
@@ -1,0 +1,37 @@
+const VOID_ELEMENTS = 'area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr';
+const voidElementPattern = new RegExp(`<(${VOID_ELEMENTS})((?:\\s[^>]*?)?)\\s*/?>`, 'gi');
+
+// Mermaid serializes HTML labels (foreignObject) with HTML rules, leaving void elements
+// like <br> unclosed. When that SVG string is loaded as a standalone image/svg+xml Blob,
+// the browser parses it as strict XML, rejects the unclosed tag, and fails the whole image.
+const ensureXmlSafeVoidElements = (svg: string): string =>
+  svg.replaceAll(voidElementPattern, '<$1$2/>');
+
+const applyFirefoxSizeFix = (svg: string): string => {
+  if (
+    typeof window === 'undefined' ||
+    typeof navigator === 'undefined' ||
+    !navigator.userAgent.includes('Firefox') ||
+    typeof DOMParser === 'undefined'
+  ) {
+    return svg;
+  }
+
+  const svgDoc = new DOMParser().parseFromString(svg, 'image/svg+xml');
+  if (svgDoc.querySelector('parsererror')) return svg;
+
+  const svgElement = svgDoc.documentElement;
+  if (!svgElement || svgElement.localName !== 'svg' || !svgElement.hasAttribute('viewBox')) {
+    return svg;
+  }
+
+  const viewBoxParts = svgElement.getAttribute('viewBox')!.split(' ');
+  if (viewBoxParts.length !== 4) return svg;
+
+  svgElement.setAttribute('width', viewBoxParts[2]!);
+  svgElement.setAttribute('height', viewBoxParts[3]!);
+  return new XMLSerializer().serializeToString(svgDoc);
+};
+
+export const prepareMermaidSvgString = (svg: string): string =>
+  applyFirefoxSizeFix(ensureXmlSafeVoidElements(svg));

--- a/src/Mermaid/demos/mermaid-18.tsx
+++ b/src/Mermaid/demos/mermaid-18.tsx
@@ -1,0 +1,20 @@
+import { Mermaid } from '@lobehub/ui';
+
+const flowchartWithHtmlLabels = `flowchart LR
+    subgraph "Step 1: 细胞动员"
+        A["G-CSF 启动<br>化疗前24h（d-1/d0）"]
+        B["使G0期白血病细胞<br>同步进入S期（DNA合成期）"]
+    end
+    subgraph "Step 2: 药物靶向杀伤"
+        C["低剂量Ara-C<br>（S期特异性）<br>10mg/m² q12h"]
+        D["阿克拉霉素<br>（嵌入DNA碱基对）<br>10-14mg/m²/d"]
+    end
+
+    A -->|"细胞周期同步"| B
+    B --> C
+    B --> D
+`;
+
+export default () => {
+  return <Mermaid>{flowchartWithHtmlLabels}</Mermaid>;
+};

--- a/src/Mermaid/index.mdx
+++ b/src/Mermaid/index.mdx
@@ -21,6 +21,7 @@ import DemoMermaid14 from './demos/mermaid-14.tsx?demo';
 import DemoMermaid15 from './demos/mermaid-15.tsx?demo';
 import DemoMermaid16 from './demos/mermaid-16.tsx?demo';
 import DemoMermaid17 from './demos/mermaid-17.tsx?demo';
+import DemoMermaid18 from './demos/mermaid-18.tsx?demo';
 import DemoIndex from './demos/index.tsx?demo';
 import DemoFullFeatured from './demos/FullFeatured.tsx?demo';
 import DemoActionsRender from './demos/ActionsRender.tsx?demo';
@@ -106,6 +107,10 @@ import DemoActionsRender from './demos/ActionsRender.tsx?demo';
 ### Architecture Diagrams
 
 <Demo of={DemoMermaid17} />
+
+### Flowchart with HTML Labels
+
+<Demo of={DemoMermaid18} />
 
 ## APIs
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Fixes [LOBE-10194](https://linear.app/lobehub/issue/LOBE-10194) — some Mermaid diagrams render as the `ant-image-error` placeholder instead of the chart (e.g. flowcharts whose node labels use `<br>`).

**Root cause.** `StaticMermaid` / `StreamMermaid` wrap the `mermaid.render()` output in a `Blob({ type: 'image/svg+xml' })` and load it via `<img>`. For diagrams with HTML labels (the flowchart default), Mermaid serializes the `<foreignObject>` content with HTML rules, leaving void elements like `<br>` **unclosed**. The browser loads the Blob as a standalone `image/svg+xml` document under **strict XML parsing**, which rejects the unclosed tag (`Opening and ending tag mismatch: br and p`), fires `onerror`, and shows the placeholder. Diagrams without `<br>` parse fine — matching the working/failing contrast in the issue.

**Fix.** New shared helper `prepareMermaidSvgString()` normalizes HTML void elements (`<br>` → `<br/>`, plus `hr`, `img`, …) to self-closing form so the SVG is well-formed XML before the Blob is created, then applies the existing Firefox width/height fix. Both components now call it in place of their duplicated inline logic. Chosen over a DOMParser round-trip because that produced engine-dependent duplicate-`xmlns` output; the string normalization is engine-independent and leaves everything else byte-for-byte unchanged, so existing diagrams cannot regress. It only touches HTML `<img>`, never SVG's `<image>`.

#### 📝 补充信息 | Additional Information

Verification:

- **Unit tests** (`prepareMermaidSvg.test.ts`): reproduces the bug (raw `<br>` fails strict XML parse), proves the fix loads, covers other void elements, preserves already self-closed tags and case-sensitive `viewBox`, and confirms label-free diagrams are unchanged.
- **Real browser** (Chromium against the docs dev server): added demo `mermaid-18.tsx` (the exact failing chart from the issue). Its image now loads (`complete: true`, blob URL, no `ant-image-error`); the blob content confirms Mermaid emitted `<br>` that is now `<br/>`. Zero captured browser errors; all mermaid diagrams on the doc page render without broken images.

The regression test covers the full `render → Blob → image load` path, not just `mermaid.parse()`.
