### PR TITLE
✨ feat(base-ui): add context menu interceptor for global behavior override

### DIFF
--- a/src/base-ui/ContextMenu/__tests__/interceptor.test.ts
+++ b/src/base-ui/ContextMenu/__tests__/interceptor.test.ts
@@ -1,0 +1,76 @@
+import {
+  closeContextMenu,
+  getSnapshot,
+  setContextMenuInterceptor,
+  showContextMenu,
+} from '../store';
+import type { ContextMenuItem } from '../type';
+
+const items: ContextMenuItem[] = [{ key: 'copy', label: 'Copy' }];
+
+afterEach(() => {
+  setContextMenuInterceptor(null);
+  closeContextMenu();
+});
+
+describe('setContextMenuInterceptor', () => {
+  it('routes showContextMenu through the interceptor without opening the web menu', () => {
+    const show = vi.fn();
+    setContextMenuInterceptor({ show });
+
+    showContextMenu(items, { iconAlign: 'start' });
+
+    expect(show).toHaveBeenCalledTimes(1);
+    expect(show.mock.calls[0][0]).toBe(items);
+    expect(show.mock.calls[0][1]).toEqual({ iconAlign: 'start' });
+    expect(getSnapshot().open).toBe(false);
+  });
+
+  it('opens the web menu when the interceptor invokes fallback', () => {
+    setContextMenuInterceptor({
+      show: (_items, _options, fallback) => fallback(),
+    });
+
+    showContextMenu(items);
+
+    expect(getSnapshot().open).toBe(true);
+    expect(getSnapshot().items).toBe(items);
+  });
+
+  it('routes closeContextMenu through the interceptor and closes only via fallback', () => {
+    showContextMenu(items);
+    expect(getSnapshot().open).toBe(true);
+
+    let deferredClose: (() => void) | undefined;
+    setContextMenuInterceptor({
+      close: (fallback) => {
+        deferredClose = fallback;
+      },
+    });
+
+    closeContextMenu();
+    expect(getSnapshot().open).toBe(true);
+
+    deferredClose?.();
+    expect(getSnapshot().open).toBe(false);
+  });
+
+  it('restores default behavior when unregistered with null', () => {
+    const show = vi.fn();
+    setContextMenuInterceptor({ show });
+    setContextMenuInterceptor(null);
+
+    showContextMenu(items);
+
+    expect(show).not.toHaveBeenCalled();
+    expect(getSnapshot().open).toBe(true);
+  });
+
+  it('leaves an interceptor without the invoked hook falling back to default', () => {
+    setContextMenuInterceptor({ close: vi.fn() });
+
+    showContextMenu(items);
+
+    expect(getSnapshot().open).toBe(true);
+  });
+});

--- a/src/base-ui/ContextMenu/imperative.tsx
+++ b/src/base-ui/ContextMenu/imperative.tsx
@@ -1,3 +1,8 @@
 export { ContextMenuHost } from './ContextMenuHost';
 export { ContextMenuTrigger } from './ContextMenuTrigger';
-export { closeContextMenu, showContextMenu, updateContextMenuItems } from './store';
+export {
+  closeContextMenu,
+  setContextMenuInterceptor,
+  showContextMenu,
+  updateContextMenuItems,
+} from './store';

--- a/src/base-ui/ContextMenu/index.ts
+++ b/src/base-ui/ContextMenu/index.ts
@@ -3,9 +3,10 @@ export {
   closeContextMenu,
   ContextMenuHost,
   ContextMenuTrigger,
+  setContextMenuInterceptor,
   showContextMenu,
   updateContextMenuItems,
 } from './imperative';
 export type { IconSpaceMode } from './renderItems';
-export type { ShowContextMenuOptions } from './store';
+export type { ContextMenuInterceptor, ShowContextMenuOptions } from './store';
 export type { ContextMenuCheckboxItem, ContextMenuItem, ContextMenuSwitchItem } from './type';

--- a/src/base-ui/ContextMenu/store.ts
+++ b/src/base-ui/ContextMenu/store.ts
@@ -81,9 +81,29 @@ export interface ShowContextMenuOptions {
   iconSpaceMode?: IconSpaceMode;
 }
 
-export const showContextMenu = (items: ContextMenuItem[], options?: ShowContextMenuOptions) => {
-  if (typeof window === 'undefined') return;
+export interface ContextMenuInterceptor {
+  close?: (fallback: () => void) => void;
+  show?: (
+    items: ContextMenuItem[],
+    options: ShowContextMenuOptions | undefined,
+    fallback: () => void,
+  ) => void;
+}
 
+let interceptor: ContextMenuInterceptor | null = null;
+
+/**
+ * Register a global interceptor for every context menu — imperative
+ * `showContextMenu`/`closeContextMenu` calls and `ContextMenuTrigger` alike.
+ * The interceptor may render the menu through another system (e.g. a native
+ * OS menu) or invoke `fallback()` to show the default web menu. Pass `null`
+ * to restore the default behavior.
+ */
+export const setContextMenuInterceptor = (next: ContextMenuInterceptor | null) => {
+  interceptor = next;
+};
+
+const showWebContextMenu = (items: ContextMenuItem[], options?: ShowContextMenuOptions) => {
   const fallbackPoint = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
   const point = lastPointer.ready ? { x: lastPointer.x, y: lastPointer.y } : fallbackPoint;
 
@@ -99,6 +119,17 @@ export const showContextMenu = (items: ContextMenuItem[], options?: ShowContextM
   });
 };
 
+export const showContextMenu = (items: ContextMenuItem[], options?: ShowContextMenuOptions) => {
+  if (typeof window === 'undefined') return;
+
+  if (interceptor?.show) {
+    interceptor.show(items, options, () => showWebContextMenu(items, options));
+    return;
+  }
+
+  showWebContextMenu(items, options);
+};
+
 /**
  * Update menu items while keeping current anchor/position.
  * Useful for interactive menu items (e.g. checkbox) to avoid re-positioning.
@@ -108,7 +139,7 @@ export const updateContextMenuItems = (items: ContextMenuItem[]) => {
   setContextMenuState({ items });
 };
 
-export const closeContextMenu = () => {
+const closeWebContextMenu = () => {
   setContextMenuState({
     anchor: null,
     footer: undefined,
@@ -118,4 +149,13 @@ export const closeContextMenu = () => {
     open: false,
     triggerId: null,
   });
+};
+
+export const closeContextMenu = () => {
+  if (interceptor?.close) {
+    interceptor.close(closeWebContextMenu);
+    return;
+  }
+
+  closeWebContextMenu();
 };

--- a/src/base-ui/index.ts
+++ b/src/base-ui/index.ts
@@ -2,11 +2,16 @@ export * from './AutoComplete';
 export { default as Button } from './Button';
 export * from './Button';
 export * from './Checkbox';
-export type { ContextMenuCheckboxItem, ContextMenuItem } from './ContextMenu';
+export type {
+  ContextMenuCheckboxItem,
+  ContextMenuInterceptor,
+  ContextMenuItem,
+} from './ContextMenu';
 export {
   closeContextMenu,
   ContextMenuHost,
   ContextMenuTrigger,
+  setContextMenuInterceptor,
   showContextMenu,
   updateContextMenuItems,
 } from './ContextMenu';

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,11 +37,16 @@ export { default as CodeEditor, type CodeEditorProps } from './CodeEditor';
 export { default as Collapse, type CollapseItemType, type CollapseProps } from './Collapse';
 export { default as ColorSwatches, type ColorSwatchesProps } from './ColorSwatches';
 export { type Config, default as ConfigProvider, useCdnFn } from './ConfigProvider';
-export type { ContextMenuCheckboxItem, ContextMenuItem } from './ContextMenu';
+export type {
+  ContextMenuCheckboxItem,
+  ContextMenuInterceptor,
+  ContextMenuItem,
+} from './ContextMenu';
 export {
   closeContextMenu,
   ContextMenuHost,
   ContextMenuTrigger,
+  setContextMenuInterceptor,
   showContextMenu,
   updateContextMenuItems,
 } from './ContextMenu';


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] ✨ feat

#### 🔀 变更说明 | Description of Change

Adds `setContextMenuInterceptor(interceptor | null)` to the base-ui ContextMenu store: a single global hook that every context-menu entry point — the imperative `showContextMenu` / `closeContextMenu` exports AND `ContextMenuTrigger` — routes through.

```ts
setContextMenuInterceptor({
  show: (items, options, fallback) => { /* render elsewhere, or fallback() for the default web menu */ },
  close: (fallback) => { /* route close, or fallback() */ },
});
```

- The interceptor receives a `fallback` closure bound to the original web implementation, so partial takeover and recursion-free delegation are both trivial.
- Unregistered (or `null`) behavior is byte-identical to today — zero impact on existing consumers.
- `updateContextMenuItems` stays web-only (in-place update has no meaning for externally rendered menus).

#### 📝 补充信息 | Additional Information

Motivation: lobe-chat's desktop app renders eligible context menus as native macOS `NSMenu` (lobehub/lobehub#17648). The imperative call sites were migrated to an app-side wrapper, but declarative `ContextMenuTrigger` surfaces (tab bar, nav items, file tree, …) bypass any app-layer wrapper by construction. A library-level interceptor makes the override global and impossible to miss for future call sites, instead of relying on every author remembering to import a wrapper component.

5 new store-level tests cover interceptor routing, fallback delegation, deferred close, unregistration, and partial interceptors.