### PR TITLE
🐛 fix(docs): register mermaid-18 and Switch asyncLoading demos in the frozen inventory

### DIFF
--- a/compatibility.json
+++ b/compatibility.json
@@ -2414,6 +2414,18 @@
     },
     {
       "document": "src/Mermaid/index.mdx",
+      "legacyId": "src-mermaid-demo-mermaid-18",
+      "legacyRouteId": "components/Mermaid/index",
+      "options": {
+        "inline": false,
+        "isolated": false,
+        "layout": "default"
+      },
+      "pathname": "/components/mermaid",
+      "source": "src/Mermaid/demos/mermaid-18.tsx"
+    },
+    {
+      "document": "src/Mermaid/index.mdx",
       "legacyId": "src-mermaid-demo-mermaid-2",
       "legacyRouteId": "components/Mermaid/index",
       "options": {
@@ -4175,6 +4187,18 @@
       },
       "pathname": "/components/base-ui/select",
       "source": "src/base-ui/Select/demos/virtual.tsx"
+    },
+    {
+      "document": "src/base-ui/Switch/index.mdx",
+      "legacyId": "src-base-ui-switch-demo-asyncloading",
+      "legacyRouteId": "components/base-ui/Switch/index",
+      "options": {
+        "inline": false,
+        "isolated": false,
+        "layout": "bare"
+      },
+      "pathname": "/components/base-ui/switch",
+      "source": "src/base-ui/Switch/demos/asyncLoading.tsx"
     },
     {
       "document": "src/base-ui/Switch/index.mdx",

--- a/packages/docs-kit/site/content/migration.test.ts
+++ b/packages/docs-kit/site/content/migration.test.ts
@@ -62,7 +62,7 @@ describe('reviewed production migration metadata', () => {
     expect(report.legacyDocuments + report.migratedDocuments).toBe(160);
     expect(
       report.legacyDemoTags + report.migratedDemoUses + report.acknowledgedStandaloneOnly,
-    ).toBe(514);
+    ).toBe(516);
     expect(report.apiSections + report.deliberateApiOmissions).toBe(158);
   });
 

--- a/packages/docs-kit/site/content/migration.ts
+++ b/packages/docs-kit/site/content/migration.ts
@@ -585,7 +585,7 @@ const migration = {
   frozenInventory: {
     apiSourceOverrides: 79,
     componentApiDecisions: 158,
-    demoReferences: 514,
+    demoReferences: 516,
     documents: 160,
     initiallyMissingDescriptions: 43,
     isolatedDemos: 35,

--- a/scripts/migrate-dumi-docs.ts
+++ b/scripts/migrate-dumi-docs.ts
@@ -264,7 +264,7 @@ const markdownProcessor = unified()
 const defaultFrozenInventory: FrozenInventoryConfig = {
   apiSourceOverrides: 79,
   componentApiDecisions: 158,
-  demoReferences: 514,
+  demoReferences: 516,
   documents: 160,
   initiallyMissingDescriptions: 43,
   isolatedDemos: 35,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🐛 fix

#### 🔀 变更说明 | Description of Change

Master CI (`test` / `Release CI`) has been red since two recently added demos were referenced from docs without being registered in the frozen migration inventory:

- `src/Mermaid/index.mdx:113` → `src/Mermaid/demos/mermaid-18.tsx`
- `src/base-ui/Switch/index.mdx:18` → `src/base-ui/Switch/demos/asyncLoading.tsx`

`migration.test.ts > closes every review blocker while preserving the frozen corpus equations` reports both as `unresolvedSources`. This PR registers exactly those two demo references in `compatibility.json` (option contracts derived from the actual `<Demo>` usages: `default` layout for mermaid-18, `bare` for asyncLoading) and bumps the frozen reference-count contract 514 → 516 in the three places that pin it.

Deliberately **not** a blanket `scripts/docs-inventory.ts` regeneration: a full regen also pulls unreviewed `.md` documents (AutoComplete/Checkbox/Form…) into the corpus, changing `apiSections` 124→130 and introducing new `unpersistedMetadata` blockers — that would silently widen the reviewed frozen snapshot instead of fixing the two-line drift.

#### 📝 补充信息 | Additional Information

- Scoped verification: `migration.test.ts` + `migrate-dumi-docs.test.ts` + `inventory.test.ts` → 42/42 passing; `tsc --noEmit` and eslint clean.
- Unblocks CI for every open PR (e.g. #586, which fails on this same pre-existing test).
- Side note: `bun scripts/docs-inventory.ts` currently crashes under Bun (`Cannot find module './cjs/index.cjs'` from the tsx subprocess loader in `loadConfigInSubprocess`); it works via `node_modules/.bin/tsx scripts/docs-inventory.ts`. Left as-is, worth a separate look.