### PR TITLE
🐛 fix(docs): register ContextMenu overflow demo in the frozen inventory

### DIFF
--- a/compatibility.json
+++ b/compatibility.json
@@ -626,6 +626,18 @@
     },
     {
       "document": "src/ContextMenu/index.mdx",
+      "legacyId": "src-context-menu-demo-overflow",
+      "legacyRouteId": "components/ContextMenu/index",
+      "options": {
+        "inline": false,
+        "isolated": false,
+        "layout": "center"
+      },
+      "pathname": "/components/context-menu",
+      "source": "src/ContextMenu/demos/overflow.tsx"
+    },
+    {
+      "document": "src/ContextMenu/index.mdx",
       "legacyId": "src-context-menu-demo-switch",
       "legacyRouteId": "components/ContextMenu/index",
       "options": {
@@ -3419,6 +3431,18 @@
       },
       "pathname": "/components/base-ui/context-menu",
       "source": "src/ContextMenu/demos/imperative.tsx"
+    },
+    {
+      "document": "src/base-ui/ContextMenu/index.mdx",
+      "legacyId": "src-base-ui-context-menu-demo-overflow",
+      "legacyRouteId": "components/base-ui/ContextMenu/index",
+      "options": {
+        "inline": false,
+        "isolated": false,
+        "layout": "center"
+      },
+      "pathname": "/components/base-ui/context-menu",
+      "source": "src/ContextMenu/demos/overflow.tsx"
     },
     {
       "document": "src/base-ui/ContextMenu/index.mdx",

--- a/packages/docs-kit/site/content/migration.test.ts
+++ b/packages/docs-kit/site/content/migration.test.ts
@@ -62,7 +62,7 @@ describe('reviewed production migration metadata', () => {
     expect(report.legacyDocuments + report.migratedDocuments).toBe(160);
     expect(
       report.legacyDemoTags + report.migratedDemoUses + report.acknowledgedStandaloneOnly,
-    ).toBe(516);
+    ).toBe(518);
     expect(report.apiSections + report.deliberateApiOmissions).toBe(158);
   });
 

--- a/packages/docs-kit/site/content/migration.ts
+++ b/packages/docs-kit/site/content/migration.ts
@@ -585,7 +585,7 @@ const migration = {
   frozenInventory: {
     apiSourceOverrides: 79,
     componentApiDecisions: 158,
-    demoReferences: 516,
+    demoReferences: 518,
     documents: 160,
     initiallyMissingDescriptions: 43,
     isolatedDemos: 35,

--- a/scripts/migrate-dumi-docs.ts
+++ b/scripts/migrate-dumi-docs.ts
@@ -264,7 +264,7 @@ const markdownProcessor = unified()
 const defaultFrozenInventory: FrozenInventoryConfig = {
   apiSourceOverrides: 79,
   componentApiDecisions: 158,
-  demoReferences: 516,
+  demoReferences: 518,
   documents: 160,
   initiallyMissingDescriptions: 43,
   isolatedDemos: 35,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🐛 fix

#### 🔀 变更说明 | Description of Change

Master is still red after #587: commit 04eaac70 (`🐛 fix(context-menu): constrain long menus to viewport`) added `src/ContextMenu/demos/overflow.tsx`, referenced from BOTH `src/ContextMenu/index.mdx:31` and `src/base-ui/ContextMenu/index.mdx:31`, without registering it in the frozen inventory — #587 was branched before that commit landed, so it fixed only the mermaid-18 / asyncLoading drift.

This registers the overflow demo for both documents (per-document entries with `src-context-menu-demo-overflow` / `src-base-ui-context-menu-demo-overflow` legacy ids, `center` layout matching the actual `<Demo>` usages) and bumps the frozen reference-count contract 516 → 518 in the three pinning sites. `compatibility.json` diff is +24 lines, zero reformat churn.

#### 📝 补充信息 | Additional Information

Verified against current master (includes #586 + #587): `migration.test.ts` + `migrate-dumi-docs.test.ts` + `inventory.test.ts` → 42/42 passing; `tsc --noEmit` clean. This should finally let Release CI publish.