### PR TITLE
✨ feat(base-ui): add Drawer built on Base UI dialog primitives

### DIFF
--- a/navigationSections.json
+++ b/navigationSections.json
@@ -88,6 +88,7 @@
   "src/awesome/TypewriterEffect/index.mdx": "Awesome",
   "src/base-ui/Button/index.mdx": "Base UI",
   "src/base-ui/ContextMenu/index.mdx": "Base UI",
+  "src/base-ui/Drawer/index.mdx": "Base UI",
   "src/base-ui/DropdownMenu/index.mdx": "Base UI",
   "src/base-ui/FloatingPanel/index.mdx": "Base UI",
   "src/base-ui/FloatingSheet/index.mdx": "Base UI",

--- a/packages/docs-kit/site/components/Demo/DemoEnvironment.tsx
+++ b/packages/docs-kit/site/components/Demo/DemoEnvironment.tsx
@@ -17,6 +17,7 @@ export function DemoEnvironment({ appearance, children, demoId }: DemoEnvironmen
           appId={`lobe-demo-${demoId}`}
           appearance={appearance}
           enableGlobalStyle={false}
+          style={demoAppStyle}
         >
           {children}
         </ThemeProvider>
@@ -26,3 +27,8 @@ export function DemoEnvironment({ appearance, children, demoId }: DemoEnvironmen
 }
 
 const demoScopeStyle: CSSProperties = { display: 'contents' };
+
+// ThemeProvider isolates its <App> into its own stacking context. Nesting one per demo
+// traps every floating layer the demo opens below the site header and TOC, so a drawer
+// or popover renders underneath the chrome instead of above it.
+const demoAppStyle: CSSProperties = { isolation: 'auto' };

--- a/src/base-ui/Drawer/Drawer.tsx
+++ b/src/base-ui/Drawer/Drawer.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import { cx } from 'antd-style';
+import { X } from 'lucide-react';
+import type { CSSProperties } from 'react';
+import { memo, useCallback, useMemo } from 'react';
+
+import {
+  DrawerBackdrop,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerPopup,
+  DrawerPortal,
+  DrawerRoot,
+  type DrawerRootProps,
+  DrawerTitle,
+} from './atoms';
+import {
+  DEFAULT_CONTAINER_MAX_WIDTH,
+  DEFAULT_DRAWER_HEIGHT,
+  DEFAULT_DRAWER_WIDTH,
+  DEFAULT_PUSH_DISTANCE,
+  DEFAULT_SIDEBAR_WIDTH,
+} from './constants';
+import { DrawerPushProvider, useDrawerPush } from './DrawerPushContext';
+import { styles } from './style';
+import type { DrawerProps, DrawerPush } from './type';
+
+const resolvePushDistance = (push: DrawerPush) => {
+  if (push === false) return 0;
+  if (push === true) return DEFAULT_PUSH_DISTANCE;
+  return push.distance ?? DEFAULT_PUSH_DISTANCE;
+};
+
+const FULL_SIZES = new Set(['100%', '100dvh', '100dvw', '100vh', '100vw']);
+
+const Drawer = memo<DrawerProps>(
+  ({
+    open,
+    placement = 'right',
+    width,
+    height,
+    mask = true,
+    maskClosable = true,
+    keyboard = true,
+    closable = true,
+    closeIcon,
+    extra,
+    title,
+    footer,
+    noHeader,
+    sidebar,
+    sidebarWidth = DEFAULT_SIDEBAR_WIDTH,
+    containerMaxWidth = DEFAULT_CONTAINER_MAX_WIDTH,
+    push = true,
+    zIndex,
+    getContainer,
+    className,
+    classNames,
+    style,
+    styles: semanticStyles,
+    afterOpenChange,
+    onClose,
+    children,
+  }) => {
+    const isOpen = open ?? false;
+    const { childValue, pushed } = useDrawerPush(isOpen);
+    const pushOffset = pushed ? resolvePushDistance(push) : 0;
+
+    const handleOpenChange = useCallback<NonNullable<DrawerRootProps['onOpenChange']>>(
+      (nextOpen, eventDetails) => {
+        if (nextOpen || !isOpen) return;
+        if (!keyboard && eventDetails.reason === 'escape-key') return;
+        if (!maskClosable && eventDetails.reason === 'outside-press') return;
+        onClose?.();
+      },
+      [isOpen, keyboard, maskClosable, onClose],
+    );
+
+    const handleExitComplete = useCallback(() => afterOpenChange?.(false), [afterOpenChange]);
+    const handleAnimationComplete = useCallback(() => {
+      if (isOpen) afterOpenChange?.(true);
+    }, [isOpen, afterOpenChange]);
+
+    const isHorizontal = placement === 'left' || placement === 'right';
+    const resolvedWidth = isHorizontal ? (width ?? DEFAULT_DRAWER_WIDTH) : width;
+    const resolvedHeight = isHorizontal ? height : (height ?? DEFAULT_DRAWER_HEIGHT);
+
+    const isFlush = FULL_SIZES.has(String(isHorizontal ? resolvedWidth : resolvedHeight));
+    const surfaceWeightClass = (() => {
+      if (isFlush) return undefined;
+      if (pushed) return styles.panelRecessed;
+      return mask ? undefined : styles.panelBoosted;
+    })();
+
+    const showTitle = title !== undefined && title !== null;
+    const showHeader = !noHeader && (showTitle || closable || !!extra);
+    const hasSidebar = !!sidebar;
+
+    const containerStyle = useMemo<CSSProperties>(
+      () => ({ maxWidth: containerMaxWidth }),
+      [containerMaxWidth],
+    );
+
+    const closeNode = closable && (
+      <button
+        aria-label="Close"
+        className={cx(styles.close, classNames?.close)}
+        style={semanticStyles?.close}
+        type="button"
+        onClick={onClose}
+      >
+        {closeIcon ?? <X size={16} />}
+      </button>
+    );
+
+    const extraNode = (extra || closeNode) && (
+      <div
+        className={cx(styles.extra, !showHeader && styles.extraFloating, classNames?.extra)}
+        style={semanticStyles?.extra}
+      >
+        {extra}
+        {closeNode}
+      </div>
+    );
+
+    const bodyNode = hasSidebar ? (
+      <>
+        <div
+          className={cx(styles.sidebar, classNames?.sidebar)}
+          style={{ width: sidebarWidth, ...semanticStyles?.sidebar }}
+        >
+          {sidebar}
+        </div>
+        <div
+          className={cx(styles.sidebarContent, classNames?.sidebarContent)}
+          style={semanticStyles?.sidebarContent}
+        >
+          {children}
+        </div>
+      </>
+    ) : (
+      children
+    );
+
+    const container = getContainer === false ? undefined : (getContainer ?? undefined);
+
+    return (
+      <DrawerRoot
+        modal={mask}
+        open={isOpen}
+        zIndex={zIndex}
+        onExitComplete={handleExitComplete}
+        onOpenChange={handleOpenChange}
+      >
+        <DrawerPortal container={container}>
+          {mask && (
+            <DrawerBackdrop className={classNames?.backdrop} style={semanticStyles?.backdrop} />
+          )}
+          <DrawerPopup
+            className={classNames?.popup}
+            flush={isFlush}
+            height={resolvedHeight}
+            motionProps={{ onAnimationComplete: handleAnimationComplete }}
+            panelClassName={cx(surfaceWeightClass, className, classNames?.panel)}
+            panelStyle={{ ...style, ...semanticStyles?.panel }}
+            placement={placement}
+            popupStyle={semanticStyles?.popup}
+            pushOffset={pushOffset}
+            width={resolvedWidth}
+          >
+            <DrawerPushProvider value={childValue}>
+              {showHeader ? (
+                <DrawerHeader className={classNames?.header} style={semanticStyles?.header}>
+                  <div className={styles.containerInner} style={containerStyle}>
+                    {showTitle ? (
+                      <DrawerTitle className={classNames?.title} style={semanticStyles?.title}>
+                        {title}
+                      </DrawerTitle>
+                    ) : (
+                      <span />
+                    )}
+                    {extraNode}
+                  </div>
+                </DrawerHeader>
+              ) : (
+                extraNode
+              )}
+              <DrawerContent
+                className={cx(hasSidebar && styles.contentSidebar, classNames?.content)}
+                style={semanticStyles?.content}
+              >
+                <div
+                  style={{ ...containerStyle, ...semanticStyles?.bodyContent }}
+                  className={cx(
+                    styles.bodyContent,
+                    hasSidebar && styles.bodyContentSidebar,
+                    classNames?.bodyContent,
+                  )}
+                >
+                  {bodyNode}
+                </div>
+              </DrawerContent>
+              {footer && (
+                <DrawerFooter className={classNames?.footer} style={semanticStyles?.footer}>
+                  <div
+                    className={cx(styles.containerInner, styles.containerInnerFooter)}
+                    style={containerStyle}
+                  >
+                    {footer}
+                  </div>
+                </DrawerFooter>
+              )}
+            </DrawerPushProvider>
+          </DrawerPopup>
+        </DrawerPortal>
+      </DrawerRoot>
+    );
+  },
+);
+
+Drawer.displayName = 'Drawer';
+
+export default Drawer;

--- a/src/base-ui/Drawer/DrawerLayerContext.tsx
+++ b/src/base-ui/Drawer/DrawerLayerContext.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { createContext, use } from 'react';
+
+export interface DrawerLayer {
+  popupRef: (node: HTMLElement | null) => void;
+  zIndex: number | undefined;
+}
+
+const DrawerLayerContext = createContext<DrawerLayer | null>(null);
+
+export const useDrawerLayer = () => use(DrawerLayerContext);
+export const DrawerLayerProvider = DrawerLayerContext.Provider;

--- a/src/base-ui/Drawer/DrawerPushContext.tsx
+++ b/src/base-ui/Drawer/DrawerPushContext.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { createContext, use, useCallback, useEffect, useMemo, useState } from 'react';
+
+export interface DrawerPushParent {
+  pull: () => void;
+  push: () => void;
+}
+
+const DrawerPushContext = createContext<DrawerPushParent | null>(null);
+
+export const DrawerPushProvider = DrawerPushContext.Provider;
+
+export const useDrawerPush = (open: boolean) => {
+  const parent = use(DrawerPushContext);
+  const [pushedCount, setPushedCount] = useState(0);
+
+  const push = useCallback(() => setPushedCount((count) => count + 1), []);
+  const pull = useCallback(() => setPushedCount((count) => Math.max(0, count - 1)), []);
+
+  useEffect(() => {
+    if (!open || !parent) return;
+    parent.push();
+    return () => parent.pull();
+  }, [open, parent]);
+
+  const childValue = useMemo<DrawerPushParent>(() => ({ pull, push }), [pull, push]);
+
+  return { childValue, pushed: pushedCount > 0 };
+};

--- a/src/base-ui/Drawer/__tests__/Drawer.test.tsx
+++ b/src/base-ui/Drawer/__tests__/Drawer.test.tsx
@@ -1,0 +1,244 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { motion } from 'motion/react';
+import type { ReactNode } from 'react';
+
+import ConfigProvider from '@/ConfigProvider';
+
+import Drawer from '../Drawer';
+import type { DrawerPlacement } from '../type';
+
+// Echoes each style key back as its own class name so surface variants stay assertable.
+vi.mock('antd-style', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('antd-style')>();
+  return {
+    ...actual,
+    createStaticStyles: vi.fn((fn: any) => {
+      const result = fn({ css: () => '', cssVar: new Proxy({}, { get: () => '' }) });
+      return new Proxy(result, { get: (_target, key) => String(key) });
+    }),
+  };
+});
+
+const renderWithProvider = (node: ReactNode) =>
+  render(<ConfigProvider motion={motion}>{node}</ConfigProvider>);
+
+const getPanel = () => document.querySelector('[data-drawer-placement]');
+
+describe('Drawer', () => {
+  test('renders title, extra, footer, and children when open', () => {
+    renderWithProvider(
+      <Drawer open extra={<button>Share</button>} footer={<button>Save</button>} title="Settings">
+        <div>Drawer body</div>
+      </Drawer>,
+    );
+
+    expect(screen.getByText('Settings')).toBeDefined();
+    expect(screen.getByText('Share')).toBeDefined();
+    expect(screen.getByText('Save')).toBeDefined();
+    expect(screen.getByText('Drawer body')).toBeDefined();
+  });
+
+  test('renders nothing while closed', () => {
+    renderWithProvider(<Drawer open={false} title="Settings" />);
+
+    expect(screen.queryByText('Settings')).toBeNull();
+  });
+
+  test.each(['bottom', 'left', 'right', 'top'] as DrawerPlacement[])(
+    'anchors the panel to the %s edge',
+    (placement) => {
+      renderWithProvider(
+        <Drawer open placement={placement} title="Settings">
+          Body
+        </Drawer>,
+      );
+
+      expect(getPanel()?.getAttribute('data-drawer-placement')).toBe(placement);
+    },
+  );
+
+  test('defaults to the right edge', () => {
+    renderWithProvider(
+      <Drawer open title="Settings">
+        Body
+      </Drawer>,
+    );
+
+    expect(getPanel()?.getAttribute('data-drawer-placement')).toBe('right');
+  });
+
+  test('closes through the close button', () => {
+    const onClose = vi.fn();
+    renderWithProvider(
+      <Drawer open title="Settings" onClose={onClose}>
+        Body
+      </Drawer>,
+    );
+
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('omits the close button when closable is false', () => {
+    renderWithProvider(
+      <Drawer open closable={false} title="Settings">
+        Body
+      </Drawer>,
+    );
+
+    expect(screen.queryByLabelText('Close')).toBeNull();
+  });
+
+  test('hides the header but keeps the close affordance when noHeader is set', () => {
+    renderWithProvider(
+      <Drawer noHeader open title="Settings">
+        Body
+      </Drawer>,
+    );
+
+    expect(screen.queryByText('Settings')).toBeNull();
+    expect(screen.getByLabelText('Close')).toBeDefined();
+  });
+
+  test('renders both columns in sidebar mode', () => {
+    renderWithProvider(
+      <Drawer open sidebar={<nav>Sections</nav>} title="Settings">
+        <div>Section body</div>
+      </Drawer>,
+    );
+
+    expect(screen.getByText('Sections')).toBeDefined();
+    expect(screen.getByText('Section body')).toBeDefined();
+  });
+
+  test('closes on Escape', () => {
+    const onClose = vi.fn();
+    renderWithProvider(
+      <Drawer open title="Settings" onClose={onClose}>
+        Body
+      </Drawer>,
+    );
+
+    fireEvent.keyDown(document.activeElement ?? document.body, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test('ignores Escape when keyboard is false', () => {
+    const onClose = vi.fn();
+    renderWithProvider(
+      <Drawer open keyboard={false} title="Settings" onClose={onClose}>
+        Body
+      </Drawer>,
+    );
+
+    fireEvent.keyDown(document.activeElement ?? document.body, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test('renders a nested drawer inside its parent', () => {
+    renderWithProvider(
+      <Drawer open title="Incident">
+        <span>Summary</span>
+        <Drawer open title="Timeline">
+          <span>Events</span>
+        </Drawer>
+      </Drawer>,
+    );
+
+    expect(screen.getByText('Summary')).toBeDefined();
+    expect(screen.getByText('Events')).toBeDefined();
+    expect(document.querySelectorAll('[data-drawer-placement]')).toHaveLength(2);
+  });
+
+  test('keeps the anchored edge while exiting, even if placement changes on close', () => {
+    const { rerender } = renderWithProvider(
+      <Drawer open placement="left" title="Settings">
+        Body
+      </Drawer>,
+    );
+
+    expect(document.querySelector('[data-drawer-anchor]')?.getAttribute('data-drawer-anchor')).toBe(
+      'left',
+    );
+
+    rerender(
+      <ConfigProvider motion={motion}>
+        <Drawer open={false} placement="right" title="Settings">
+          Body
+        </Drawer>
+      </ConfigProvider>,
+    );
+
+    const anchor = document.querySelector('[data-drawer-anchor]');
+    expect(anchor?.getAttribute('data-drawer-anchor')).toBe('left');
+    expect(
+      anchor?.querySelector('[data-drawer-placement]')?.getAttribute('data-drawer-placement'),
+    ).toBe('left');
+  });
+
+  test('rounds only the edges facing content', () => {
+    renderWithProvider(
+      <Drawer open placement="bottom" title="Settings">
+        Body
+      </Drawer>,
+    );
+
+    expect(getPanel()?.className).toContain('panelRoundedBottom');
+    expect(getPanel()?.className).not.toContain('panelFlush');
+  });
+
+  test('drops the cast and the radius once it fills the viewport', () => {
+    renderWithProvider(
+      <Drawer open title="Settings" width="100%">
+        Body
+      </Drawer>,
+    );
+
+    expect(getPanel()?.className).toContain('panelFlush');
+    expect(getPanel()?.className).not.toContain('panelRounded');
+  });
+
+  test('deepens the cast when there is no backdrop to separate it', () => {
+    renderWithProvider(
+      <Drawer open mask={false} title="Settings">
+        Body
+      </Drawer>,
+    );
+
+    expect(getPanel()?.className).toContain('panelBoosted');
+  });
+
+  test('lightens the cast on an ancestor that a nested drawer pushed aside', () => {
+    renderWithProvider(
+      <Drawer open title="Incident">
+        <Drawer open title="Timeline">
+          Events
+        </Drawer>
+      </Drawer>,
+    );
+
+    const [outer, inner] = document.querySelectorAll('[data-drawer-placement]');
+    expect(outer.className).toContain('panelRecessed');
+    expect(inner.className).not.toContain('panelRecessed');
+  });
+
+  test('follows a placement change while it stays open', () => {
+    const { rerender } = renderWithProvider(
+      <Drawer open placement="left" title="Settings">
+        Body
+      </Drawer>,
+    );
+
+    rerender(
+      <ConfigProvider motion={motion}>
+        <Drawer open placement="bottom" title="Settings">
+          Body
+        </Drawer>
+      </ConfigProvider>,
+    );
+
+    expect(document.querySelector('[data-drawer-anchor]')?.getAttribute('data-drawer-anchor')).toBe(
+      'bottom',
+    );
+  });
+});

--- a/src/base-ui/Drawer/__tests__/constants.test.ts
+++ b/src/base-ui/Drawer/__tests__/constants.test.ts
@@ -1,0 +1,28 @@
+import { getDrawerMotionConfig } from '../constants';
+
+describe('getDrawerMotionConfig', () => {
+  test('parks the panel offscreen along the placement axis', () => {
+    expect(getDrawerMotionConfig('right').initial).toEqual({ x: '100%' });
+    expect(getDrawerMotionConfig('left').initial).toEqual({ x: '-100%' });
+    expect(getDrawerMotionConfig('top').initial).toEqual({ y: '-100%' });
+    expect(getDrawerMotionConfig('bottom').initial).toEqual({ y: '100%' });
+  });
+
+  test('rests at origin when nothing pushes it', () => {
+    for (const placement of ['bottom', 'left', 'right', 'top'] as const) {
+      expect(getDrawerMotionConfig(placement).animate).toEqual({ x: 0, y: 0 });
+    }
+  });
+
+  test('pushes away from the anchored edge', () => {
+    expect(getDrawerMotionConfig('right', 180).animate).toEqual({ x: -180, y: 0 });
+    expect(getDrawerMotionConfig('left', 180).animate).toEqual({ x: 180, y: 0 });
+    expect(getDrawerMotionConfig('top', 180).animate).toEqual({ x: 0, y: 180 });
+    expect(getDrawerMotionConfig('bottom', 180).animate).toEqual({ x: 0, y: -180 });
+  });
+
+  test('carries the exit offset on the same axis as the entrance', () => {
+    expect(getDrawerMotionConfig('right', 180).exit).toMatchObject({ x: '100%' });
+    expect(getDrawerMotionConfig('bottom', 180).exit).toMatchObject({ y: '100%' });
+  });
+});

--- a/src/base-ui/Drawer/atoms.tsx
+++ b/src/base-ui/Drawer/atoms.tsx
@@ -1,0 +1,387 @@
+'use client';
+
+import { Dialog } from '@base-ui/react/dialog';
+import { mergeProps } from '@base-ui/react/merge-props';
+import { cx } from 'antd-style';
+import { X } from 'lucide-react';
+import { AnimatePresence } from 'motion/react';
+import type React from 'react';
+import {
+  cloneElement,
+  createContext,
+  isValidElement,
+  use,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { mergeRefs, useMergeRefs } from 'react-merge-refs';
+
+import { useNativeButton } from '@/hooks/useNativeButton';
+import { useMotionComponent } from '@/MotionProvider';
+import { useAppElement } from '@/ThemeProvider';
+
+import { useLayerZIndex } from '../zIndex';
+import { drawerBackdropTransition, getDrawerMotionConfig, pushAxis } from './constants';
+import { DrawerLayerProvider, useDrawerLayer } from './DrawerLayerContext';
+import { styles } from './style';
+import type { DrawerPlacement } from './type';
+
+const mergeStateClassName = <TState,>(
+  base: string,
+  className: string | ((state: TState) => string | undefined) | undefined,
+) => {
+  if (typeof className === 'function') return (state: TState) => cx(base, className(state));
+  return cx(base, className);
+};
+
+const popupPlacementClass: Record<DrawerPlacement, string> = {
+  bottom: styles.popupBottom,
+  left: styles.popupLeft,
+  right: styles.popupRight,
+  top: styles.popupTop,
+};
+
+const panelPlacementClass: Record<DrawerPlacement, string> = {
+  bottom: styles.panelBottom,
+  left: styles.panelLeft,
+  right: styles.panelRight,
+  top: styles.panelTop,
+};
+
+const panelRoundedClass: Record<DrawerPlacement, string> = {
+  bottom: styles.panelRoundedBottom,
+  left: styles.panelRoundedLeft,
+  right: styles.panelRoundedRight,
+  top: styles.panelRoundedTop,
+};
+
+const DrawerOpenContext = createContext<boolean | null>(null);
+
+interface DrawerAnimationActions {
+  onExitComplete: () => void;
+}
+const DrawerActionsContext = createContext<DrawerAnimationActions | null>(null);
+
+export const useDrawerOpen = () => use(DrawerOpenContext);
+export const useDrawerActions = () => use(DrawerActionsContext);
+
+export type DrawerRootProps = Dialog.Root.Props & {
+  onExitComplete?: () => void;
+  zIndex?: number;
+};
+
+const AnimatedDrawerRoot = ({
+  open,
+  children,
+  onExitComplete: onExitCompleteProp,
+  zIndex: explicitZIndex,
+  ...rest
+}: Omit<DrawerRootProps, 'open'> & { open: boolean }) => {
+  const [isPresent, setIsPresent] = useState(!!open);
+
+  useEffect(() => {
+    if (open) setIsPresent(true);
+  }, [open]);
+
+  const handleExitComplete = useCallback(() => {
+    setIsPresent(false);
+    onExitCompleteProp?.();
+  }, [onExitCompleteProp]);
+
+  const actions = useMemo(() => ({ onExitComplete: handleExitComplete }), [handleExitComplete]);
+
+  const { zIndex, ref: popupRef } = useLayerZIndex<HTMLDivElement>('modal', explicitZIndex);
+  const layer = useMemo(
+    () => ({ popupRef: popupRef as (node: HTMLElement | null) => void, zIndex }),
+    [zIndex, popupRef],
+  );
+
+  if (!isPresent) return null;
+
+  return (
+    <DrawerOpenContext value={open}>
+      <DrawerActionsContext value={actions}>
+        <DrawerLayerProvider value={layer}>
+          <Dialog.Root modal open {...rest}>
+            {children}
+          </Dialog.Root>
+        </DrawerLayerProvider>
+      </DrawerActionsContext>
+    </DrawerOpenContext>
+  );
+};
+
+const NonAnimatedDrawerRoot = ({ zIndex: explicitZIndex, children, ...rest }: DrawerRootProps) => {
+  const { zIndex, ref: popupRef } = useLayerZIndex<HTMLDivElement>('modal', explicitZIndex);
+  const layer = useMemo(
+    () => ({ popupRef: popupRef as (node: HTMLElement | null) => void, zIndex }),
+    [zIndex, popupRef],
+  );
+
+  return (
+    <DrawerLayerProvider value={layer}>
+      <Dialog.Root modal {...rest}>
+        {children}
+      </Dialog.Root>
+    </DrawerLayerProvider>
+  );
+};
+
+export const DrawerRoot = ({ open, onExitComplete, ...rest }: DrawerRootProps) => {
+  if (open !== undefined) {
+    return <AnimatedDrawerRoot open={open} onExitComplete={onExitComplete} {...rest} />;
+  }
+  return <NonAnimatedDrawerRoot {...rest} />;
+};
+
+export type DrawerPortalProps = React.ComponentProps<typeof Dialog.Portal> & {
+  container?: HTMLElement | null;
+};
+export const DrawerPortal = ({ container, ...rest }: DrawerPortalProps) => {
+  const appElement = useAppElement();
+  return <Dialog.Portal container={container ?? appElement ?? undefined} {...rest} />;
+};
+
+export type DrawerBackdropProps = React.ComponentProps<typeof Dialog.Backdrop>;
+export const DrawerBackdrop = ({ className, style, ...rest }: DrawerBackdropProps) => {
+  const open = useDrawerOpen();
+  const layer = useDrawerLayer();
+  const Motion = useMotionComponent();
+  const layerStyle = layer?.zIndex !== undefined ? { zIndex: layer.zIndex } : undefined;
+
+  if (open !== null) {
+    return (
+      <Dialog.Backdrop
+        {...rest}
+        className={cx(styles.backdrop, className as string)}
+        style={{ ...layerStyle, ...style, transition: 'none' }}
+        render={
+          <Motion.div
+            animate={{ opacity: open ? 1 : 0 }}
+            initial={{ opacity: 0 }}
+            transition={drawerBackdropTransition}
+          />
+        }
+      />
+    );
+  }
+
+  return (
+    <Dialog.Backdrop
+      {...rest}
+      className={mergeStateClassName(styles.backdrop, className as any) as any}
+      style={{ ...layerStyle, ...style }}
+    />
+  );
+};
+
+export type DrawerPopupProps = React.ComponentProps<typeof Dialog.Popup> & {
+  flush?: boolean;
+  height?: number | string;
+  motionProps?: Record<string, any>;
+  panelClassName?: string;
+  panelStyle?: React.CSSProperties;
+  placement?: DrawerPlacement;
+  popupStyle?: React.CSSProperties;
+  pushOffset?: number;
+  width?: number | string;
+};
+
+export const DrawerPopup = ({
+  className,
+  children,
+  placement: placementProp = 'right',
+  width: widthProp,
+  height: heightProp,
+  flush,
+  pushOffset = 0,
+  motionProps,
+  panelClassName,
+  panelStyle,
+  popupStyle,
+  ref: forwardedRef,
+  ...rest
+}: DrawerPopupProps) => {
+  const open = useDrawerOpen();
+  const actions = useDrawerActions();
+  const layer = useDrawerLayer();
+  const Motion = useMotionComponent();
+  const composedRef = useMergeRefs([forwardedRef, layer?.popupRef]);
+
+  // The exiting panel lives inside AnimatePresence and keeps the props it had while open,
+  // but this popup re-renders with whatever the consumer passes now. Freezing the geometry
+  // during exit keeps the two in sync — otherwise a placement change on close teleports the
+  // popup to the new edge while the panel animates out along the old axis.
+  const openGeometryRef = useRef({
+    height: heightProp,
+    placement: placementProp,
+    width: widthProp,
+  });
+  if (open !== false) {
+    openGeometryRef.current = { height: heightProp, placement: placementProp, width: widthProp };
+  }
+  const { height, placement, width } = openGeometryRef.current;
+
+  const isHorizontal = placement === 'left' || placement === 'right';
+  const sizeStyle: React.CSSProperties = isHorizontal ? { width } : { height };
+  const resolvedPopupStyle: React.CSSProperties = {
+    ...(layer?.zIndex === undefined ? undefined : { zIndex: layer.zIndex + 1 }),
+    ...sizeStyle,
+    ...popupStyle,
+  };
+  const popupBaseClassName = cx(styles.popup, popupPlacementClass[placement]);
+  const resolvedPanelClassName = cx(
+    styles.panel,
+    panelPlacementClass[placement],
+    flush ? styles.panelFlush : panelRoundedClass[placement],
+    panelClassName,
+  );
+
+  if (open !== null && actions) {
+    const motionConfig = getDrawerMotionConfig(placement, pushOffset);
+    return (
+      <Dialog.Popup
+        {...rest}
+        className={cx(popupBaseClassName, className as string)}
+        data-drawer-anchor={placement}
+        ref={composedRef as any}
+        style={resolvedPopupStyle}
+      >
+        <AnimatePresence onExitComplete={actions.onExitComplete}>
+          {open ? (
+            <Motion.div
+              {...motionConfig}
+              {...motionProps}
+              className={resolvedPanelClassName}
+              data-drawer-placement={placement}
+              key="drawer-popup-panel"
+              style={{ transition: 'none', ...panelStyle }}
+            >
+              {children}
+            </Motion.div>
+          ) : null}
+        </AnimatePresence>
+      </Dialog.Popup>
+    );
+  }
+
+  const { axis, sign } = pushAxis[placement];
+  const pushVars = {
+    [axis === 'x' ? '--drawer-push-x' : '--drawer-push-y']: `${pushOffset * sign}px`,
+  } as React.CSSProperties;
+
+  return (
+    <Dialog.Popup
+      {...rest}
+      className={mergeStateClassName(popupBaseClassName, className as any) as any}
+      data-drawer-anchor={placement}
+      ref={composedRef as any}
+      style={resolvedPopupStyle}
+    >
+      <div
+        className={resolvedPanelClassName}
+        data-drawer-placement={placement}
+        style={{ ...pushVars, ...panelStyle }}
+      >
+        {children}
+      </div>
+    </Dialog.Popup>
+  );
+};
+
+export type DrawerHeaderProps = React.HTMLAttributes<HTMLDivElement> & {
+  ref?: React.Ref<HTMLDivElement>;
+};
+export const DrawerHeader = ({ className, ...rest }: DrawerHeaderProps) => (
+  <div {...rest} className={cx(styles.header, className)} />
+);
+
+export type DrawerTitleProps = React.ComponentProps<typeof Dialog.Title>;
+export const DrawerTitle = ({ className, ...rest }: DrawerTitleProps) => (
+  <Dialog.Title {...rest} className={mergeStateClassName(styles.title, className as any) as any} />
+);
+
+export type DrawerDescriptionProps = React.ComponentProps<typeof Dialog.Description>;
+export const DrawerDescription: React.FC<DrawerDescriptionProps> = Dialog.Description;
+
+export type DrawerContentProps = React.HTMLAttributes<HTMLDivElement> & {
+  ref?: React.Ref<HTMLDivElement>;
+};
+export const DrawerContent = ({ className, ...rest }: DrawerContentProps) => (
+  <div {...rest} className={cx(styles.content, className)} />
+);
+
+export type DrawerFooterProps = React.HTMLAttributes<HTMLDivElement> & {
+  ref?: React.Ref<HTMLDivElement>;
+};
+export const DrawerFooter = ({ className, ...rest }: DrawerFooterProps) => (
+  <div {...rest} className={cx(styles.footer, className)} />
+);
+
+export type DrawerCloseProps = React.ComponentProps<typeof Dialog.Close>;
+export const DrawerClose = ({ className, children, ...rest }: DrawerCloseProps) => (
+  <Dialog.Close {...rest} className={mergeStateClassName(styles.close, className as any) as any}>
+    {children ?? <X size={16} />}
+  </Dialog.Close>
+);
+
+export type DrawerTriggerProps = Omit<
+  React.ComponentPropsWithRef<typeof Dialog.Trigger>,
+  'children' | 'render'
+> & {
+  children?: React.ReactNode;
+  nativeButton?: boolean;
+};
+
+export const DrawerTrigger = ({
+  children,
+  className,
+  nativeButton,
+  ref: refProp,
+  ...rest
+}: DrawerTriggerProps) => {
+  const { isNativeButtonTriggerElement, resolvedNativeButton } = useNativeButton({
+    children,
+    nativeButton,
+  });
+
+  const renderer = (props: any) => {
+    const resolvedProps = (() => {
+      if (isNativeButtonTriggerElement) return props as any;
+      // eslint-disable-next-line unused-imports/no-unused-vars
+      const { type, ...restProps } = props as any;
+      return restProps;
+    })();
+
+    const mergedProps = mergeProps((children as any).props, resolvedProps);
+    return cloneElement(children as any, {
+      ...mergedProps,
+      ref: mergeRefs([(children as any).ref, (props as any).ref, refProp]),
+    });
+  };
+
+  if (isValidElement(children)) {
+    return (
+      <Dialog.Trigger
+        {...rest}
+        className={className}
+        nativeButton={resolvedNativeButton}
+        render={renderer as any}
+      />
+    );
+  }
+
+  return (
+    <Dialog.Trigger
+      {...rest}
+      className={className}
+      nativeButton={resolvedNativeButton}
+      ref={refProp as any}
+    >
+      {children}
+    </Dialog.Trigger>
+  );
+};

--- a/src/base-ui/Drawer/constants.ts
+++ b/src/base-ui/Drawer/constants.ts
@@ -1,0 +1,52 @@
+import type { MotionProps } from 'motion/react';
+
+import type { DrawerPlacement } from './type';
+
+type CubicBezier = [number, number, number, number];
+
+const softEase: CubicBezier = [0.32, 0.72, 0, 1];
+const exitEase: CubicBezier = [0.4, 0, 1, 1];
+
+export const DEFAULT_PUSH_DISTANCE = 180;
+export const DEFAULT_SIDEBAR_WIDTH = 280;
+export const DEFAULT_CONTAINER_MAX_WIDTH = 1024;
+export const DEFAULT_DRAWER_WIDTH = 378;
+export const DEFAULT_DRAWER_HEIGHT = 378;
+
+const offscreen: Record<DrawerPlacement, MotionProps['initial']> = {
+  bottom: { y: '100%' },
+  left: { x: '-100%' },
+  right: { x: '100%' },
+  top: { y: '-100%' },
+};
+
+export const pushAxis: Record<DrawerPlacement, { axis: 'x' | 'y'; sign: 1 | -1 }> = {
+  bottom: { axis: 'y', sign: -1 },
+  left: { axis: 'x', sign: 1 },
+  right: { axis: 'x', sign: -1 },
+  top: { axis: 'y', sign: 1 },
+};
+
+export const getDrawerMotionConfig = (
+  placement: DrawerPlacement,
+  pushOffset = 0,
+): MotionProps & { animate: { x: number; y: number } } => {
+  const hidden = offscreen[placement];
+  const { axis, sign } = pushAxis[placement];
+  const shift = pushOffset === 0 ? 0 : pushOffset * sign;
+
+  return {
+    animate: axis === 'x' ? { x: shift, y: 0 } : { x: 0, y: shift },
+    exit: {
+      ...(hidden as object),
+      transition: { duration: 0.22, ease: exitEase },
+    },
+    initial: hidden,
+    transition: { duration: 0.3, ease: softEase },
+  };
+};
+
+export const drawerBackdropTransition = {
+  duration: 0.18,
+  ease: softEase,
+};

--- a/src/base-ui/Drawer/demos/Nested.tsx
+++ b/src/base-ui/Drawer/demos/Nested.tsx
@@ -1,0 +1,42 @@
+import { Flexbox, Text } from '@lobehub/ui';
+import { Button, Drawer } from '@lobehub/ui/base-ui';
+import { useState } from 'react';
+
+const TIMELINE = [
+  '09:14 · Alert fired on p99 latency',
+  '09:18 · On-call acknowledged',
+  '09:26 · Routing change identified',
+  '09:31 · Rollback deployed',
+  '09:38 · Metrics back to baseline',
+];
+
+export default () => {
+  const [outer, setOuter] = useState(false);
+  const [inner, setInner] = useState(false);
+
+  return (
+    <>
+      <Button onClick={() => setOuter(true)}>Review incident</Button>
+
+      <Drawer open={outer} title="INC-2481 · Elevated p99 latency" onClose={() => setOuter(false)}>
+        <Flexbox gap={12}>
+          <Text as="p" style={{ margin: 0, opacity: 0.65 }}>
+            Latency on the inference gateway crossed the 1.2s threshold for 14 minutes. Rollback of
+            the routing change restored baseline.
+          </Text>
+          <Button onClick={() => setInner(true)}>Open timeline</Button>
+        </Flexbox>
+
+        <Drawer open={inner} title="Timeline" width={320} onClose={() => setInner(false)}>
+          <Flexbox gap={12}>
+            {TIMELINE.map((entry) => (
+              <Text key={entry} style={{ fontSize: 13, opacity: 0.7 }}>
+                {entry}
+              </Text>
+            ))}
+          </Flexbox>
+        </Drawer>
+      </Drawer>
+    </>
+  );
+};

--- a/src/base-ui/Drawer/demos/Sidebar.tsx
+++ b/src/base-ui/Drawer/demos/Sidebar.tsx
@@ -1,0 +1,61 @@
+import { Flexbox, Text } from '@lobehub/ui';
+import { Button, Drawer } from '@lobehub/ui/base-ui';
+import { cssVar } from 'antd-style';
+import { useState } from 'react';
+
+const SECTIONS = {
+  'Appearance':
+    'Theme, density, and font preferences applied across every workspace you belong to.',
+  'Data controls': 'Retention windows, export requests, and training opt-out for this workspace.',
+  'General': 'Workspace name, default locale, and the landing surface members see on sign-in.',
+  'Members': 'Seat allocation, invite links, and per-role permission overrides.',
+  'Models': 'Provider keys, routing rules, and fallbacks used when a primary model is unavailable.',
+};
+
+type SectionKey = keyof typeof SECTIONS;
+
+export default () => {
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState<SectionKey>('General');
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Workspace settings</Button>
+
+      <Drawer
+        open={open}
+        title="Settings"
+        width="min(920px, 90vw)"
+        sidebar={
+          <Flexbox gap={2}>
+            {(Object.keys(SECTIONS) as SectionKey[]).map((key) => (
+              <Flexbox
+                key={key}
+                paddingBlock={8}
+                paddingInline={12}
+                style={{
+                  background: active === key ? cssVar.colorFillSecondary : 'transparent',
+                  borderRadius: 8,
+                  cursor: 'pointer',
+                }}
+                onClick={() => setActive(key)}
+              >
+                <Text weight={active === key ? 600 : 400}>{key}</Text>
+              </Flexbox>
+            ))}
+          </Flexbox>
+        }
+        onClose={() => setOpen(false)}
+      >
+        <Flexbox gap={12}>
+          <Text as="h3" style={{ margin: 0 }}>
+            {active}
+          </Text>
+          <Text as="p" style={{ margin: 0, opacity: 0.65 }}>
+            {SECTIONS[active]}
+          </Text>
+        </Flexbox>
+      </Drawer>
+    </>
+  );
+};

--- a/src/base-ui/Drawer/demos/index.tsx
+++ b/src/base-ui/Drawer/demos/index.tsx
@@ -1,0 +1,70 @@
+import { Flexbox, Text } from '@lobehub/ui';
+import { Button, Drawer, type DrawerPlacement } from '@lobehub/ui/base-ui';
+import { cssVar } from 'antd-style';
+import { useState } from 'react';
+
+const PLACEMENTS: DrawerPlacement[] = ['left', 'right', 'top', 'bottom'];
+
+const RELEASES = [
+  { date: 'Mar 12', status: 'Shipped', title: 'Streaming tool calls' },
+  { date: 'Mar 08', status: 'Shipped', title: 'Workspace-level model routing' },
+  { date: 'Mar 01', status: 'Rolled back', title: 'Inline citation previews' },
+  { date: 'Feb 24', status: 'Shipped', title: 'Prompt library sharing' },
+];
+
+export default () => {
+  const [placement, setPlacement] = useState<DrawerPlacement>('right');
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Flexbox horizontal gap={8} wrap="wrap">
+        {PLACEMENTS.map((item) => (
+          <Button
+            key={item}
+            onClick={() => {
+              setPlacement(item);
+              setOpen(true);
+            }}
+          >
+            Open from {item}
+          </Button>
+        ))}
+      </Flexbox>
+
+      <Drawer
+        open={open}
+        placement={placement}
+        title="Release history"
+        footer={
+          <>
+            <Button onClick={() => setOpen(false)}>Close</Button>
+            <Button type="primary">Export changelog</Button>
+          </>
+        }
+        onClose={() => setOpen(false)}
+      >
+        <Flexbox gap={16}>
+          <Text as="p" style={{ margin: 0, opacity: 0.65 }}>
+            Deployments to production over the last three weeks.
+          </Text>
+          {RELEASES.map((release) => (
+            <Flexbox
+              gap={4}
+              key={release.title}
+              style={{
+                borderInlineStart: `2px solid ${cssVar.colorBorderSecondary}`,
+                paddingInlineStart: 12,
+              }}
+            >
+              <Text weight={600}>{release.title}</Text>
+              <Text style={{ fontSize: 12, opacity: 0.55 }}>
+                {release.date} · {release.status}
+              </Text>
+            </Flexbox>
+          ))}
+        </Flexbox>
+      </Drawer>
+    </>
+  );
+};

--- a/src/base-ui/Drawer/index.mdx
+++ b/src/base-ui/Drawer/index.mdx
@@ -1,0 +1,36 @@
+---
+title: Drawer
+description: Edge-anchored panel built directly on Base UI dialog primitives, with four placements, an optional sidebar layout, and nested push behaviour.
+category: Feedback
+---
+
+import DemoIndex from './demos/index.tsx?demo';
+import DemoSidebar from './demos/Sidebar.tsx?demo';
+import DemoNested from './demos/Nested.tsx?demo';
+
+## Placement
+
+<Demo of={DemoIndex} layout="bare" />
+
+## Sidebar
+
+<Demo of={DemoSidebar} layout="bare" />
+
+## Nested Push
+
+<Demo of={DemoNested} layout="bare" />
+
+## Notes
+
+- `Drawer` owns its dialog primitives rather than reusing `Modal`, so its popup is edge-anchored instead of centred. It still shares the layered z-index stack, so drawers and modals interleave by open order.
+- The surface adapts to how the drawer is being used rather than applying one fixed elevation. The shadow casts along the placement axis toward the content it covers, only the edges facing that content are rounded, and the weight shifts per scenario: a drawer filling the viewport drops both shadow and radius, `mask={false}` deepens the cast because there is no backdrop doing the separating, and an ancestor pushed aside by a nested drawer lightens so stacked panels don't silt up.
+- Nested drawers push their ancestors aside by `180px` along the placement axis. Pass `push={false}` to opt out, or `push={{ distance }}` to change the offset. The push only reaches drawers that are React ancestors of the nested one.
+- `sidebar` switches the body to a two-column layout with independently scrolling columns; `sidebarWidth` sets the fixed column.
+- `containerMaxWidth` centres and constrains the header, body, and footer content, which keeps line length readable on full-width drawers.
+- Composing your own layout is possible with the exported primitives: `DrawerRoot`, `DrawerPortal`, `DrawerBackdrop`, `DrawerPopup`, `DrawerHeader`, `DrawerTitle`, `DrawerContent`, `DrawerFooter`, `DrawerClose`, and `DrawerTrigger`.
+
+## APIs
+
+### Drawer
+
+<Api name="Drawer" />

--- a/src/base-ui/Drawer/index.ts
+++ b/src/base-ui/Drawer/index.ts
@@ -1,0 +1,31 @@
+import Drawer from './Drawer';
+
+export {
+  DrawerBackdrop,
+  type DrawerBackdropProps,
+  DrawerClose,
+  type DrawerCloseProps,
+  DrawerContent,
+  type DrawerContentProps,
+  DrawerDescription,
+  type DrawerDescriptionProps,
+  DrawerFooter,
+  type DrawerFooterProps,
+  DrawerHeader,
+  type DrawerHeaderProps,
+  DrawerPopup,
+  type DrawerPopupProps,
+  DrawerPortal,
+  type DrawerPortalProps,
+  DrawerRoot,
+  type DrawerRootProps,
+  DrawerTitle,
+  type DrawerTitleProps,
+  DrawerTrigger,
+  type DrawerTriggerProps,
+  useDrawerActions,
+  useDrawerOpen,
+} from './atoms';
+export { drawerBackdropTransition, getDrawerMotionConfig } from './constants';
+export { Drawer };
+export type * from './type';

--- a/src/base-ui/Drawer/style.ts
+++ b/src/base-ui/Drawer/style.ts
@@ -1,0 +1,328 @@
+import { createStaticStyles } from 'antd-style';
+
+export const styles = createStaticStyles(({ css, cssVar }) => ({
+  backdrop: css`
+    position: fixed;
+    z-index: 1200;
+    inset: 0;
+
+    background: ${cssVar.colorBgMask};
+
+    transition: opacity 180ms cubic-bezier(0.32, 0.72, 0, 1);
+
+    &[data-starting-style],
+    &[data-ending-style] {
+      opacity: 0;
+    }
+  `,
+
+  popup: css`
+    pointer-events: none;
+
+    position: fixed;
+    z-index: 1201;
+
+    display: flex;
+
+    /* clamp here rather than on the panel, so an oversized size prop shrinks the
+       box instead of detaching the panel from its anchored edge */
+    max-width: 100dvw;
+    max-height: 100dvh;
+  `,
+
+  popupLeft: css`
+    inset-block: 0;
+    inset-inline-start: 0;
+  `,
+
+  popupRight: css`
+    inset-block: 0;
+    inset-inline-end: 0;
+  `,
+
+  popupTop: css`
+    inset-block-start: 0;
+    inset-inline: 0;
+  `,
+
+  popupBottom: css`
+    inset-block-end: 0;
+    inset-inline: 0;
+  `,
+
+  panel: css`
+    pointer-events: auto;
+
+    position: relative;
+
+    /* push offset rides on CSS vars so [data-starting-style] can override the whole transform */
+    transform: translate(var(--drawer-push-x, 0), var(--drawer-push-y, 0));
+
+    overflow: hidden;
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+
+    box-sizing: border-box;
+    min-width: 0;
+    min-height: 0;
+
+    /* Elevated, not container: in dark themes container sits within 2 points of the page
+       background, so a panel with no border and a black-on-black cast loses its edge entirely. */
+    background: ${cssVar.colorBgElevated};
+
+    /* An edge-anchored panel casts along its placement axis, not downward like a centred
+       dialog would. Direction classes set the sign, weight classes set the opacity, so the
+       two compose without a class per combination. */
+    box-shadow:
+      calc(var(--drawer-cast-x, 0) * 6px) calc(var(--drawer-cast-y, 0) * 6px) 24px 0
+        rgb(0 0 0 / var(--drawer-cast-far, 8%)),
+      calc(var(--drawer-cast-x, 0) * 2px) calc(var(--drawer-cast-y, 0) * 2px) 6px 0
+        rgb(0 0 0 / var(--drawer-cast-near, 4%));
+
+    transition: transform 300ms cubic-bezier(0.32, 0.72, 0, 1);
+  `,
+
+  panelLeft: css`
+    --drawer-cast-x: 1;
+
+    &[data-starting-style],
+    &[data-ending-style] {
+      transform: translateX(-100%);
+    }
+  `,
+
+  panelRight: css`
+    --drawer-cast-x: -1;
+
+    &[data-starting-style],
+    &[data-ending-style] {
+      transform: translateX(100%);
+    }
+  `,
+
+  panelTop: css`
+    --drawer-cast-y: 1;
+
+    &[data-starting-style],
+    &[data-ending-style] {
+      transform: translateY(-100%);
+    }
+  `,
+
+  panelBottom: css`
+    --drawer-cast-y: -1;
+
+    &[data-starting-style],
+    &[data-ending-style] {
+      transform: translateY(100%);
+    }
+  `,
+
+  /* Only the edges facing content get rounded; the anchored edge stays flush with the viewport.
+     Kept apart from the direction classes so a flush panel can drop the radius by omitting the
+     class rather than by out-specifying it. */
+  panelRoundedLeft: css`
+    border-start-end-radius: 12px;
+    border-end-end-radius: 12px;
+  `,
+
+  panelRoundedRight: css`
+    border-start-start-radius: 12px;
+    border-end-start-radius: 12px;
+  `,
+
+  panelRoundedTop: css`
+    border-end-start-radius: 12px;
+    border-end-end-radius: 12px;
+  `,
+
+  panelRoundedBottom: css`
+    border-start-start-radius: 12px;
+    border-start-end-radius: 12px;
+  `,
+
+  /* Filling the viewport leaves nothing to cast onto — the shadow would only dirty the edge. */
+  panelFlush: css`
+    --drawer-cast-far: 0%;
+    --drawer-cast-near: 0%;
+  `,
+
+  /* Without a backdrop the panel has to earn its separation from live content behind it. */
+  panelBoosted: css`
+    --drawer-cast-far: 14%;
+    --drawer-cast-near: 7%;
+  `,
+
+  /* A pushed ancestor has receded behind its child; stacking full-weight casts would silt up. */
+  panelRecessed: css`
+    --drawer-cast-far: 4%;
+    --drawer-cast-near: 2%;
+  `,
+
+  header: css`
+    display: flex;
+    flex: none;
+    gap: 8px;
+    align-items: center;
+    justify-content: space-between;
+
+    min-height: 56px;
+    padding-block: 12px;
+    padding-inline: 16px;
+    border-block-end: 1px solid ${cssVar.colorSplit};
+  `,
+
+  containerInner: css`
+    display: flex;
+    flex: 1;
+    gap: 8px;
+    align-items: center;
+    justify-content: space-between;
+
+    width: 100%;
+    margin-inline: auto;
+  `,
+
+  containerInnerFooter: css`
+    justify-content: flex-end;
+  `,
+
+  title: css`
+    margin: 0;
+
+    font-size: 17px;
+    font-weight: 600;
+    line-height: 1.4;
+    color: ${cssVar.colorText};
+    letter-spacing: -0.005em;
+  `,
+
+  extra: css`
+    display: flex;
+    flex: none;
+    gap: 4px;
+    align-items: center;
+
+    margin-inline-end: -4px;
+  `,
+
+  extraFloating: css`
+    position: absolute;
+    z-index: 1;
+    inset-block-start: 12px;
+    inset-inline-end: 12px;
+
+    margin-inline-end: 0;
+  `,
+
+  close: css`
+    cursor: pointer;
+
+    position: relative;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    border: none;
+    border-radius: 8px;
+
+    color: ${cssVar.colorTextTertiary};
+
+    background: transparent;
+
+    transition:
+      color 160ms cubic-bezier(0.32, 0.72, 0, 1),
+      background 160ms cubic-bezier(0.32, 0.72, 0, 1),
+      transform 160ms cubic-bezier(0.32, 0.72, 0, 1);
+
+    /* Restores the 40px target the 32px visual box gives up, without nudging the header layout. */
+    &::after {
+      content: '';
+      position: absolute;
+      inset: -4px;
+    }
+
+    &:hover {
+      transform: scale(1.04);
+      color: ${cssVar.colorText};
+      background: ${cssVar.colorFillSecondary};
+    }
+
+    &:active {
+      transform: scale(0.96);
+    }
+
+    &:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 2px ${cssVar.colorPrimaryBorder};
+    }
+  `,
+
+  content: css`
+    overflow: hidden auto;
+    display: flex;
+    flex: 1;
+    min-height: 0;
+  `,
+
+  bodyContent: css`
+    display: flex;
+    flex-direction: column;
+
+    width: 100%;
+    min-height: 100%;
+    margin-inline: auto;
+    padding-block: 12px;
+    padding-inline: 16px;
+  `,
+
+  contentSidebar: css`
+    overflow: hidden;
+  `,
+
+  bodyContentSidebar: css`
+    flex-direction: row;
+    height: 100%;
+    min-height: 0;
+    padding: 0;
+  `,
+
+  sidebar: css`
+    overflow: hidden auto;
+    flex: none;
+
+    padding-block: 12px;
+    padding-inline: 16px;
+    border-inline-end: 1px solid ${cssVar.colorSplit};
+
+    /* A translucent fill reads as a secondary surface against whatever the panel is, where the
+       page-level layout colour would punch a hole through an elevated panel in dark themes. */
+    background: ${cssVar.colorFillTertiary};
+  `,
+
+  sidebarContent: css`
+    overflow: hidden auto;
+    flex: 1;
+
+    min-width: 0;
+    padding-block: 12px;
+    padding-inline: 16px;
+  `,
+
+  footer: css`
+    display: flex;
+    flex: none;
+    gap: 8px;
+    align-items: center;
+    justify-content: flex-end;
+
+    padding-block: 12px;
+    padding-inline: 16px;
+    border-block-start: 1px solid ${cssVar.colorSplit};
+  `,
+}));

--- a/src/base-ui/Drawer/type.ts
+++ b/src/base-ui/Drawer/type.ts
@@ -1,0 +1,64 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+export type DrawerPlacement = 'bottom' | 'left' | 'right' | 'top';
+
+export type DrawerPush = boolean | { distance?: number };
+
+export interface DrawerSemanticNames {
+  backdrop?: string;
+  bodyContent?: string;
+  close?: string;
+  content?: string;
+  extra?: string;
+  footer?: string;
+  header?: string;
+  panel?: string;
+  popup?: string;
+  sidebar?: string;
+  sidebarContent?: string;
+  title?: string;
+}
+
+export interface DrawerSemanticStyles {
+  backdrop?: CSSProperties;
+  bodyContent?: CSSProperties;
+  close?: CSSProperties;
+  content?: CSSProperties;
+  extra?: CSSProperties;
+  footer?: CSSProperties;
+  header?: CSSProperties;
+  panel?: CSSProperties;
+  popup?: CSSProperties;
+  sidebar?: CSSProperties;
+  sidebarContent?: CSSProperties;
+  title?: CSSProperties;
+}
+
+export interface DrawerProps {
+  afterOpenChange?: (open: boolean) => void;
+  children?: ReactNode;
+  className?: string;
+  classNames?: DrawerSemanticNames;
+  closable?: boolean;
+  closeIcon?: ReactNode;
+  containerMaxWidth?: number | string;
+  extra?: ReactNode;
+  footer?: ReactNode;
+  getContainer?: HTMLElement | false | null;
+  height?: number | string;
+  keyboard?: boolean;
+  mask?: boolean;
+  maskClosable?: boolean;
+  noHeader?: boolean;
+  onClose?: () => void;
+  open?: boolean;
+  placement?: DrawerPlacement;
+  push?: DrawerPush;
+  sidebar?: ReactNode;
+  sidebarWidth?: number | string;
+  style?: CSSProperties;
+  styles?: DrawerSemanticStyles;
+  title?: ReactNode;
+  width?: number | string;
+  zIndex?: number;
+}

--- a/src/base-ui/FloatingSheet/demos/index.tsx
+++ b/src/base-ui/FloatingSheet/demos/index.tsx
@@ -1,5 +1,5 @@
-import { Button, Flexbox, Text } from '@lobehub/ui';
-import { FloatingSheet, type FloatingSheetProps } from '@lobehub/ui/base-ui';
+import { Flexbox, Text } from '@lobehub/ui';
+import { Button, FloatingSheet, type FloatingSheetProps } from '@lobehub/ui/base-ui';
 import { Tag } from 'antd';
 import { cssVar } from 'antd-style';
 import { ChevronUp, Database, FileText, GripHorizontal, Search, Sparkles, X } from 'lucide-react';

--- a/src/base-ui/FloatingSheet/demos/inline.tsx
+++ b/src/base-ui/FloatingSheet/demos/inline.tsx
@@ -1,5 +1,5 @@
-import { Avatar, Button, Flexbox, Text } from '@lobehub/ui';
-import { FloatingSheet, type FloatingSheetProps } from '@lobehub/ui/base-ui';
+import { Avatar, Flexbox, Text } from '@lobehub/ui';
+import { Button, FloatingSheet, type FloatingSheetProps } from '@lobehub/ui/base-ui';
 import { Tag } from 'antd';
 import { cssVar } from 'antd-style';
 import { Bookmark, Heart, MessageCircle, Send, Share2 } from 'lucide-react';

--- a/src/base-ui/FloatingSheet/demos/playground.tsx
+++ b/src/base-ui/FloatingSheet/demos/playground.tsx
@@ -1,5 +1,5 @@
-import { Button, Flexbox, Text } from '@lobehub/ui';
-import { FloatingSheet, type FloatingSheetProps } from '@lobehub/ui/base-ui';
+import { Flexbox, Text } from '@lobehub/ui';
+import { Button, FloatingSheet, type FloatingSheetProps } from '@lobehub/ui/base-ui';
 import { StoryBook, useControls, useCreateStore } from '@lobehub/ui/storybook';
 import { Tag } from 'antd';
 import { cssVar } from 'antd-style';

--- a/src/base-ui/Modal/demos/atoms.tsx
+++ b/src/base-ui/Modal/demos/atoms.tsx
@@ -1,5 +1,6 @@
-import { Button, Flexbox, Text } from '@lobehub/ui';
+import { Flexbox, Text } from '@lobehub/ui';
 import {
+  Button,
   ModalBackdrop,
   ModalClose,
   ModalContent,

--- a/src/base-ui/Modal/demos/business.tsx
+++ b/src/base-ui/Modal/demos/business.tsx
@@ -1,5 +1,5 @@
-import { Button, Flexbox, Popover as LobePopover, Text, Tooltip as LobeTooltip } from '@lobehub/ui';
-import { createModalSystem, Modal, Select as LobeSelect } from '@lobehub/ui/base-ui';
+import { Flexbox, Popover as LobePopover, Text, Tooltip as LobeTooltip } from '@lobehub/ui';
+import { Button, createModalSystem, Modal, Select as LobeSelect } from '@lobehub/ui/base-ui';
 import { Avatar, Popover, Select, Space, Tag, Tooltip } from 'antd';
 import { cssVar } from 'antd-style';
 import { AlertTriangle, FileText, Share2 } from 'lucide-react';

--- a/src/base-ui/Modal/demos/imperative.tsx
+++ b/src/base-ui/Modal/demos/imperative.tsx
@@ -1,5 +1,5 @@
-import { Button, Flexbox, Text } from '@lobehub/ui';
-import { createModalSystem, useModalContext } from '@lobehub/ui/base-ui';
+import { Flexbox, Text } from '@lobehub/ui';
+import { Button, createModalSystem, useModalContext } from '@lobehub/ui/base-ui';
 import { Tag } from 'antd';
 import { cssVar } from 'antd-style';
 import { CheckCircle, Loader2, XCircle } from 'lucide-react';

--- a/src/base-ui/Modal/demos/index.tsx
+++ b/src/base-ui/Modal/demos/index.tsx
@@ -1,5 +1,5 @@
-import { Button, Flexbox, Text } from '@lobehub/ui';
-import { Modal } from '@lobehub/ui/base-ui';
+import { Flexbox, Text } from '@lobehub/ui';
+import { Button, Modal } from '@lobehub/ui/base-ui';
 import { Tag } from 'antd';
 import { cssVar } from 'antd-style';
 import { useState } from 'react';

--- a/src/base-ui/Modal/demos/nested.tsx
+++ b/src/base-ui/Modal/demos/nested.tsx
@@ -1,5 +1,5 @@
-import { Button, Flexbox, Text } from '@lobehub/ui';
-import { confirmModal, createModal, ModalHost, useModalContext } from '@lobehub/ui/base-ui';
+import { Flexbox, Text } from '@lobehub/ui';
+import { Button, confirmModal, createModal, ModalHost, useModalContext } from '@lobehub/ui/base-ui';
 
 const NestedBody = () => {
   const { close } = useModalContext();

--- a/src/base-ui/Modal/demos/zindex-dropdown-in-modal.tsx
+++ b/src/base-ui/Modal/demos/zindex-dropdown-in-modal.tsx
@@ -1,5 +1,6 @@
-import { Button, Flexbox, Text } from '@lobehub/ui';
+import { Flexbox, Text } from '@lobehub/ui';
 import {
+  Button,
   DropdownMenuItem,
   DropdownMenuPopup,
   DropdownMenuPortal,

--- a/src/base-ui/Modal/demos/zindex-with-dropdown.tsx
+++ b/src/base-ui/Modal/demos/zindex-with-dropdown.tsx
@@ -1,5 +1,6 @@
-import { Button, Flexbox, Text } from '@lobehub/ui';
+import { Flexbox, Text } from '@lobehub/ui';
 import {
+  Button,
   DropdownMenuItem,
   DropdownMenuPopup,
   DropdownMenuPortal,

--- a/src/base-ui/Popover/demos/atoms.tsx
+++ b/src/base-ui/Popover/demos/atoms.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   Flexbox,
   PopoverArrow,
   PopoverPopup,
@@ -10,6 +9,7 @@ import {
   PopoverViewport,
   Tag,
 } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { Blocks } from 'lucide-react';
 import { useState } from 'react';
 

--- a/src/base-ui/Popover/demos/context.tsx
+++ b/src/base-ui/Popover/demos/context.tsx
@@ -1,4 +1,5 @@
-import { Button, Flexbox, Popover, Tag, usePopoverContext } from '@lobehub/ui';
+import { Flexbox, Popover, Tag, usePopoverContext } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { Check, Code2 } from 'lucide-react';
 
 const Content = () => {

--- a/src/base-ui/Popover/demos/controlled.tsx
+++ b/src/base-ui/Popover/demos/controlled.tsx
@@ -1,4 +1,5 @@
-import { ActionIcon, Button, Flexbox, Input, Popover, Tag } from '@lobehub/ui';
+import { ActionIcon, Flexbox, Popover, Tag } from '@lobehub/ui';
+import { Button, Input } from '@lobehub/ui/base-ui';
 import { AlertTriangle, Check, Edit3, Trash2, X } from 'lucide-react';
 import { useState } from 'react';
 
@@ -86,7 +87,9 @@ export default () => {
                   size="large"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
-                  onPressEnter={() => setEditOpen(false)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') setEditOpen(false);
+                  }}
                 />
               </Flexbox>
               <Flexbox horizontal gap={8} justify="flex-end">

--- a/src/base-ui/Popover/demos/dropdown-menu.tsx
+++ b/src/base-ui/Popover/demos/dropdown-menu.tsx
@@ -1,4 +1,5 @@
-import { ActionIcon, Button, DropdownMenu, Flexbox, Popover, Tag } from '@lobehub/ui';
+import { ActionIcon, DropdownMenu, Flexbox, Popover, Tag } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { Folder, MoreHorizontal } from 'lucide-react';
 
 import { items } from '@/DropdownMenu/demos/data';

--- a/src/base-ui/Popover/demos/group.tsx
+++ b/src/base-ui/Popover/demos/group.tsx
@@ -1,4 +1,5 @@
-import { Button, Flexbox, Popover, PopoverGroup, Tag } from '@lobehub/ui';
+import { Flexbox, Popover, PopoverGroup, Tag } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { BarChart3, LayoutDashboard, Sparkles } from 'lucide-react';
 
 const content = {

--- a/src/base-ui/Popover/demos/hover-only.tsx
+++ b/src/base-ui/Popover/demos/hover-only.tsx
@@ -1,4 +1,5 @@
-import { Button, Flexbox, Popover, Tag, Text } from '@lobehub/ui';
+import { Flexbox, Popover, Tag, Text } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { MousePointerClick, Move, Pointer } from 'lucide-react';
 import { type ElementType, useState } from 'react';
 

--- a/src/base-ui/Popover/demos/index.tsx
+++ b/src/base-ui/Popover/demos/index.tsx
@@ -1,4 +1,5 @@
-import { Button, Flexbox, Popover, type PopoverProps, Tag } from '@lobehub/ui';
+import { Flexbox, Popover, type PopoverProps, Tag } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { StoryBook, useControls, useCreateStore } from '@lobehub/ui/storybook';
 import { Sliders } from 'lucide-react';
 

--- a/src/base-ui/Popover/demos/native-button.tsx
+++ b/src/base-ui/Popover/demos/native-button.tsx
@@ -1,7 +1,6 @@
 import {
   ActionIcon,
   Avatar,
-  Button,
   Center,
   CopyButton,
   Flexbox,
@@ -12,6 +11,7 @@ import {
   Text,
 } from '@lobehub/ui';
 import { GradientButton } from '@lobehub/ui/awesome';
+import { Button } from '@lobehub/ui/base-ui';
 import { Heart, Settings, Star } from 'lucide-react';
 
 const PopoverContent = ({ title }: { title: string }) => (

--- a/src/base-ui/Popover/demos/placement.tsx
+++ b/src/base-ui/Popover/demos/placement.tsx
@@ -1,4 +1,5 @@
-import { Button, Flexbox, Popover, PopoverGroup, Tag } from '@lobehub/ui';
+import { Flexbox, Popover, PopoverGroup, Tag } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp } from 'lucide-react';
 
 const content = (placement: string, icon: React.ReactNode) => (

--- a/src/base-ui/Popover/demos/popover-wrapping-tooltip-group.tsx
+++ b/src/base-ui/Popover/demos/popover-wrapping-tooltip-group.tsx
@@ -1,4 +1,5 @@
-import { Button, Flexbox, Popover, Tooltip, TooltipGroup } from '@lobehub/ui';
+import { Flexbox, Popover, Tooltip, TooltipGroup } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { HelpCircle, Info } from 'lucide-react';
 
 /**

--- a/src/base-ui/Popover/demos/popover-wrapping-tooltip.tsx
+++ b/src/base-ui/Popover/demos/popover-wrapping-tooltip.tsx
@@ -1,4 +1,5 @@
-import { Button, Flexbox, Popover, Tooltip } from '@lobehub/ui';
+import { Flexbox, Popover, Tooltip } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { HelpCircle } from 'lucide-react';
 
 /**

--- a/src/base-ui/Popover/demos/tooltip-hover-stay.tsx
+++ b/src/base-ui/Popover/demos/tooltip-hover-stay.tsx
@@ -1,4 +1,5 @@
-import { Button, Flexbox, Popover, Tooltip, TooltipGroup } from '@lobehub/ui';
+import { Flexbox, Popover, Tooltip, TooltipGroup } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { Info } from 'lucide-react';
 import { useState } from 'react';
 

--- a/src/base-ui/Popover/demos/tooltip-inside.tsx
+++ b/src/base-ui/Popover/demos/tooltip-inside.tsx
@@ -1,4 +1,5 @@
-import { Button, Flexbox, Popover, Tooltip } from '@lobehub/ui';
+import { Flexbox, Popover, Tooltip } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { Info, Sparkles } from 'lucide-react';
 
 export default () => {

--- a/src/base-ui/Popover/demos/trigger.tsx
+++ b/src/base-ui/Popover/demos/trigger.tsx
@@ -1,13 +1,5 @@
-import {
-  ActionIcon,
-  Avatar,
-  Button,
-  Flexbox,
-  Header,
-  Popover,
-  PopoverGroup,
-  Tag,
-} from '@lobehub/ui';
+import { ActionIcon, Avatar, Flexbox, Header, Popover, PopoverGroup, Tag } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { LobeHub } from '@lobehub/ui/brand';
 import {
   Bell,

--- a/src/base-ui/Switch/demos/nativeButton.tsx
+++ b/src/base-ui/Switch/demos/nativeButton.tsx
@@ -1,5 +1,5 @@
-import { Button, Flexbox, Text } from '@lobehub/ui';
-import { Switch } from '@lobehub/ui/base-ui';
+import { Flexbox, Text } from '@lobehub/ui';
+import { Button, Switch } from '@lobehub/ui/base-ui';
 import { useState } from 'react';
 
 export default () => {

--- a/src/base-ui/Toast/demos/actions.tsx
+++ b/src/base-ui/Toast/demos/actions.tsx
@@ -1,4 +1,5 @@
-import { Button, Flexbox, toast } from '@lobehub/ui';
+import { Flexbox, toast } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { StoryBook, useControls, useCreateStore } from '@lobehub/ui/storybook';
 import { Bell, Rocket, Sparkles, Trash2 } from 'lucide-react';
 

--- a/src/base-ui/Toast/demos/index.tsx
+++ b/src/base-ui/Toast/demos/index.tsx
@@ -1,4 +1,5 @@
-import { Button, Flexbox, toast, ToastHost, type ToastOptions } from '@lobehub/ui';
+import { Flexbox, toast, ToastHost, type ToastOptions } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { StoryBook, useControls, useCreateStore } from '@lobehub/ui/storybook';
 import { Bell, CheckCircle, Info, Loader2, type LucideIcon, XCircle } from 'lucide-react';
 

--- a/src/base-ui/Toast/demos/position.tsx
+++ b/src/base-ui/Toast/demos/position.tsx
@@ -1,4 +1,5 @@
-import { Button, Flexbox, toast, type ToastOptions } from '@lobehub/ui';
+import { Flexbox, toast, type ToastOptions } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { StoryBook, useControls, useCreateStore } from '@lobehub/ui/storybook';
 import { MapPin } from 'lucide-react';
 

--- a/src/base-ui/Toast/demos/promise.tsx
+++ b/src/base-ui/Toast/demos/promise.tsx
@@ -1,4 +1,5 @@
-import { Button, Flexbox, toast } from '@lobehub/ui';
+import { Flexbox, toast } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { StoryBook, useControls, useCreateStore } from '@lobehub/ui/storybook';
 import { CheckCircle, CloudDownload, Database, RefreshCw, XCircle } from 'lucide-react';
 

--- a/src/base-ui/Tooltip/demos/group-children-preserve.tsx
+++ b/src/base-ui/Tooltip/demos/group-children-preserve.tsx
@@ -1,4 +1,5 @@
-import { Button, Tooltip, TooltipGroup } from '@lobehub/ui';
+import { Tooltip, TooltipGroup } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Flexbox } from '@/Flex';

--- a/src/base-ui/Tooltip/demos/group-remove-trigger.tsx
+++ b/src/base-ui/Tooltip/demos/group-remove-trigger.tsx
@@ -1,4 +1,5 @@
-import { Button, Tooltip, TooltipGroup } from '@lobehub/ui';
+import { Tooltip, TooltipGroup } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { StoryBook, useCreateStore } from '@lobehub/ui/storybook';
 import { useEffect, useRef, useState } from 'react';
 

--- a/src/base-ui/Tooltip/demos/group-shared.tsx
+++ b/src/base-ui/Tooltip/demos/group-shared.tsx
@@ -1,4 +1,5 @@
-import { Button, Tooltip, TooltipGroup } from '@lobehub/ui';
+import { Tooltip, TooltipGroup } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { StoryBook, useCreateStore } from '@lobehub/ui/storybook';
 
 import { Flexbox } from '@/Flex';

--- a/src/base-ui/Tooltip/demos/group.tsx
+++ b/src/base-ui/Tooltip/demos/group.tsx
@@ -1,4 +1,5 @@
-import { Button, Tooltip, TooltipGroup } from '@lobehub/ui';
+import { Tooltip, TooltipGroup } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { StoryBook, useCreateStore } from '@lobehub/ui/storybook';
 
 import { Flexbox } from '@/Flex';

--- a/src/base-ui/Tooltip/demos/index.tsx
+++ b/src/base-ui/Tooltip/demos/index.tsx
@@ -1,4 +1,5 @@
-import { Button, Tooltip, type TooltipProps } from '@lobehub/ui';
+import { Tooltip, type TooltipProps } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { StoryBook, useControls, useCreateStore } from '@lobehub/ui/storybook';
 
 export default () => {

--- a/src/base-ui/Tooltip/demos/tooltip.tsx
+++ b/src/base-ui/Tooltip/demos/tooltip.tsx
@@ -1,4 +1,5 @@
-import { Button, Tooltip } from '@lobehub/ui';
+import { Tooltip } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 
 export default () => (
   <Tooltip hotkey="mod+k" title="Search">

--- a/src/base-ui/index.ts
+++ b/src/base-ui/index.ts
@@ -16,6 +16,7 @@ export {
   updateContextMenuItems,
 } from './ContextMenu';
 export { controlHeight, type ControlSize } from './controlSize';
+export * from './Drawer';
 export * from './DropdownMenu';
 export * from './FloatingPanel';
 export * from './FloatingSheet';


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] ✨ feat
- [x] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Adds `Drawer` to `@lobehub/ui/base-ui`, plus two fixes the work surfaced.

**`✨ feat(base-ui)`: Drawer built on Base UI dialog primitives**

An edge-anchored panel with four placements, an optional sidebar layout, and nested push behaviour. It owns its dialog primitives rather than reusing `Modal`, so the popup anchors to an edge instead of centring, while still sharing the layered z-index stack — drawers and modals interleave by open order.

Two layers are exported, matching `Modal`: the primitives (`DrawerRoot`, `DrawerPortal`, `DrawerBackdrop`, `DrawerPopup`, `DrawerHeader`, `DrawerTitle`, `DrawerContent`, `DrawerFooter`, `DrawerClose`, `DrawerTrigger`) and a ready-made `<Drawer />`. Props follow antd naming, as `ModalComponentProps` already does.

The surface adapts to how the drawer is used rather than applying one fixed elevation:

- the shadow casts **along the placement axis** toward the content it covers, not downward like a centred dialog
- only the edges **facing that content** are rounded; the anchored edge stays flush
- a drawer **filling the viewport** drops both shadow and radius — there is nothing to cast onto and a rounded corner would expose the backdrop
- **`mask={false}`** deepens the cast, since no backdrop is doing the separating
- an ancestor **pushed aside** by a nested drawer lightens, so stacked panels don't silt up

Direction and weight are separate CSS custom properties, so the four placements and three weights compose without a class per combination.

`push` matches antd (`180px` default, `push={false}` to opt out). The offset rides on motion's `animate` rather than a separate transform, otherwise it fights the slide-in over the same channel.

**`🐛 fix(docs-kit)`: demo floating layers were trapped in the sandbox stacking context**

`ThemeProvider` isolates its `<App>` into its own stacking context, and the docs site nests one per demo for local appearance switching. That trapped every floating layer a demo opened below the site header and TOC — verified that even `z-index: 2147483647` inside the sandbox loses to the header, while the same element under `document.body` wins. `Modal` has the same ancestor chain; centred dialogs simply never overlap that region, which is why it only surfaced with an edge-anchored panel.

The demo `ThemeProvider` now opts out of the isolation. Library behaviour is untouched.

**`♻️ refactor(base-ui)`: demos now use the Base UI `Button`**

Demos for Base UI components imported `Button` from the antd-backed top-level entry, so they showcased the wrong component. 36 files switched.

`Popover`, `Tooltip`, `DropdownMenu`, `toast` and `ScrollArea` needed no change — those top-level entries are already `export * from '@/base-ui/...'`, so importing them from `@lobehub/ui` yields the Base UI implementation. `Flexbox`, `Text`, `Tag`, `ActionIcon`, `Avatar` and `Icon` have no Base UI counterpart and stay as they are.

One `Input` also moved; its antd-only `onPressEnter` became an `onKeyDown` Enter check.

#### 📝 补充信息 | Additional Information

**Verified in the browser** across both themes: four placements anchor and size correctly, enter and exit animate along the right axis, sidebar renders two independently scrolling columns, nested push offsets the ancestor by exactly 180px and restores it on close, an oversized `width` clamps to the viewport while staying flush to its edge, and mask click / `Escape` / `keyboard={false}` / scroll lock / focus all behave. No console errors.

Three defects were found and fixed during that pass:

1. **Exit animated along the wrong axis.** The panel lives inside `AnimatePresence` and keeps its props while exiting, but the popup re-renders with whatever the consumer passes now — so changing `placement` on close teleported the panel to the new edge mid-exit. The geometry is now frozen during exit; changes while open still apply immediately.
2. **`max-width: 100dvw` sat on the panel instead of the popup**, so an oversized `width` clamped the panel and detached it from its anchored edge (measured: `width: 2000` put a right-anchored panel at `x: -720`).
3. **Dark themes lost the panel edge entirely.** `colorBgContainer` is `rgb(13,13,13)` against a `rgb(13,13,15)` page, and a black cast over a black page is invisible — with the border gone there was nothing left. Switched to `colorBgElevated` (what `Modal` already uses), dividers to the translucent `colorSplit`, and the sidebar fill to `colorFillTertiary`.

The drawer backdrop uses `colorBgMask` rather than the `color-mix(colorBgContainer 60%)` that `Modal` uses — in light themes the latter is translucent white over a white page and does not dim anything, which matters more for a side panel than a centred dialog. `Modal` is left alone.

`Modal`'s demo page shows two `__codeInspectorProps is not defined` failures. Those are pre-existing dev-tooling errors, unchanged in count by this PR.

24 Drawer tests, 104 across `base-ui`. `type-check`, `lint:circular` and `eslint` clean.
