### PR TITLE
✨ feat(base-ui): let toasts deduplicate by id and return to the front

### DIFF
--- a/src/base-ui/Toast/dedupe.test.tsx
+++ b/src/base-ui/Toast/dedupe.test.tsx
@@ -1,0 +1,92 @@
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { __resetToastHostRegistryForTests } from './hostGuard';
+import { __resetToastStateForTests, toast, ToastHost } from './imperative';
+
+const titles = () => [...document.querySelectorAll('h2')].map((el) => el.textContent);
+
+const show = (options: Parameters<typeof toast.error>[0]) => {
+  act(() => {
+    toast.error(options);
+  });
+};
+
+beforeEach(() => {
+  __resetToastHostRegistryForTests();
+  __resetToastStateForTests();
+});
+
+afterEach(() => {
+  __resetToastHostRegistryForTests();
+  __resetToastStateForTests();
+});
+
+describe('toast dedupe by id', () => {
+  it('replaces the toast in place when the same id is shown again', () => {
+    render(<ToastHost />);
+
+    show({ id: 'network', title: 'first' });
+    show({ id: 'network', title: 'second' });
+
+    expect(titles()).toEqual(['second']);
+  });
+
+  it('keeps toasts with distinct ids stacked', () => {
+    render(<ToastHost />);
+
+    show({ id: 'a', title: 'a' });
+    show({ id: 'b', title: 'b' });
+
+    expect(titles()).toEqual(['b', 'a']);
+  });
+
+  it('moves a repeated toast back to the front of the stack', () => {
+    render(<ToastHost />);
+
+    show({ id: 'a', title: 'a' });
+    show({ id: 'b', title: 'b' });
+    show({ id: 'a', title: 'a again' });
+
+    expect(titles()).toEqual(['a again', 'b']);
+  });
+
+  it('does not report a close or removal when a toast is superseded', () => {
+    render(<ToastHost />);
+
+    const onClose = vi.fn();
+    const onRemove = vi.fn();
+
+    show({ id: 'a', onClose, onRemove, title: 'a' });
+    show({ id: 'b', title: 'b' });
+    show({ id: 'a', title: 'a again' });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onRemove).not.toHaveBeenCalled();
+  });
+
+  it('still reports a close for a superseded toast once it is dismissed for real', () => {
+    render(<ToastHost />);
+
+    const onClose = vi.fn();
+
+    show({ id: 'a', onClose, title: 'a' });
+    show({ id: 'b', title: 'b' });
+    show({ id: 'a', onClose, title: 'a again' });
+
+    act(() => {
+      toast.dismiss('a');
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves toasts without an id untouched', () => {
+    render(<ToastHost />);
+
+    show({ title: 'same' });
+    show({ title: 'same' });
+
+    expect(titles()).toEqual(['same', 'same']);
+  });
+});

--- a/src/base-ui/Toast/demos/dedupe.tsx
+++ b/src/base-ui/Toast/demos/dedupe.tsx
@@ -1,0 +1,29 @@
+import { Flexbox, toast } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
+import { StoryBook, useCreateStore } from '@lobehub/ui/storybook';
+import { useRef } from 'react';
+
+export default () => {
+  const store = useCreateStore();
+  const attemptRef = useRef(0);
+
+  const showNetworkError = () => {
+    attemptRef.current += 1;
+    toast.error({
+      description: 'Check your firewall, proxy or VPN settings and try again.',
+      id: 'network-error',
+      title: `Connection refused (attempt ${attemptRef.current})`,
+    });
+  };
+
+  return (
+    <StoryBook levaStore={store}>
+      <Flexbox horizontal gap={8} style={{ flexWrap: 'wrap' }}>
+        <Button type="primary" onClick={showNetworkError}>
+          Retry failing request
+        </Button>
+        <Button onClick={() => toast.info('Another notification')}>Show another toast</Button>
+      </Flexbox>
+    </StoryBook>
+  );
+};

--- a/src/base-ui/Toast/imperative.tsx
+++ b/src/base-ui/Toast/imperative.tsx
@@ -62,13 +62,17 @@ const toastManagers: Record<ToastPosition, ReturnType<typeof BaseToast.createToa
   'top-right': BaseToast.createToastManager(),
 };
 
-const activeToastIds: Record<ToastPosition, Set<string>> = {
-  'bottom': new Set(),
-  'bottom-left': new Set(),
-  'bottom-right': new Set(),
-  'top': new Set(),
-  'top-left': new Set(),
-  'top-right': new Set(),
+interface ActiveToast {
+  superseded: boolean;
+}
+
+const activeToasts: Record<ToastPosition, Map<string, ActiveToast>> = {
+  'bottom': new Map(),
+  'bottom-left': new Map(),
+  'bottom-right': new Map(),
+  'top': new Map(),
+  'top-left': new Map(),
+  'top-right': new Map(),
 };
 
 const getManager = (position: ToastPosition) => toastManagers[position];
@@ -76,6 +80,13 @@ const getManager = (position: ToastPosition) => toastManagers[position];
 let toastIdCounter = 0;
 const generateToastId = (): string =>
   `toast-${Date.now().toString(36)}-${(toastIdCounter++).toString(36)}`;
+
+const findActivePosition = (id: string) => ALL_POSITIONS.find((pos) => activeToasts[pos].has(id));
+
+// Base UI prepends every new toast, so the last entry we registered is the one
+// currently rendered at the front of the stack.
+const isFrontMost = (position: ToastPosition, id: string) =>
+  Array.from(activeToasts[position].keys()).at(-1) === id;
 
 const normalizeOptions = (
   optionsOrMessage: Omit<ToastOptions, 'type'> | string,
@@ -117,17 +128,40 @@ const createToastInstance = (id: string, position: ToastPosition): ToastInstance
 const addToast = (options: ToastOptions): ToastInstance => {
   const position = options.placement ?? globalState.position;
   const manager = getManager(position);
-  const onRemove = options.onRemove;
-  const id = generateToastId();
-  activeToastIds[position].add(id);
+  const { id: dedupeId, onClose, onRemove } = options;
+
+  if (dedupeId) {
+    const prevPosition = findActivePosition(dedupeId);
+    // Already the front-most toast: let Base UI upsert it in place so it only
+    // refreshes its content and timer, without replaying the slide-in animation.
+    const shouldPromote =
+      prevPosition && !(prevPosition === position && isFrontMost(position, dedupeId));
+
+    if (shouldPromote) {
+      // Closing marks the toast as `ending`, which makes the following `add`
+      // drop it and prepend a fresh one — Base UI's own upsert keeps the
+      // original slot instead.
+      activeToasts[prevPosition].get(dedupeId)!.superseded = true;
+      activeToasts[prevPosition].delete(dedupeId);
+      runWhenToastHostReady(() => getManager(prevPosition).close(dedupeId));
+    }
+  }
+
+  const id = dedupeId ?? generateToastId();
+  const active: ActiveToast = { superseded: false };
+  activeToasts[position].set(id, active);
   runWhenToastHostReady(() => {
     manager.add({
       id,
       data: options,
       description: options.description,
-      onClose: options.onClose,
+      onClose: () => {
+        if (active.superseded) return;
+        onClose?.();
+      },
       onRemove: () => {
-        activeToastIds[position].delete(id);
+        if (active.superseded) return;
+        activeToasts[position].delete(id);
         onRemove?.();
       },
       timeout: options.duration ?? globalState.duration,
@@ -141,14 +175,14 @@ const dismissToast = (id?: string) => {
   if (id) {
     // Try to close from all managers since we don't know which position the toast is in
     for (const [position, manager] of Object.entries(toastManagers)) {
-      activeToastIds[position as ToastPosition].delete(id);
+      activeToasts[position as ToastPosition].delete(id);
       runWhenToastHostReady(() => manager.close(id));
     }
   } else {
     // Clear all toasts
     for (const [position, manager] of Object.entries(toastManagers)) {
-      const ids = Array.from(activeToastIds[position as ToastPosition]);
-      activeToastIds[position as ToastPosition].clear();
+      const ids = Array.from(activeToasts[position as ToastPosition].keys());
+      activeToasts[position as ToastPosition].clear();
       runWhenToastHostReady(() => {
         for (const toastId of ids) {
           manager.close(toastId);
@@ -371,7 +405,7 @@ export const __resetToastStateForTests = (): void => {
   };
   for (const position of ALL_POSITIONS) {
     toastManagers[position] = BaseToast.createToastManager();
-    activeToastIds[position].clear();
+    activeToasts[position].clear();
   }
   __resetPendingToastQueueForTests();
 };

--- a/src/base-ui/Toast/index.mdx
+++ b/src/base-ui/Toast/index.mdx
@@ -8,6 +8,7 @@ import DemoIndex from './demos/index.tsx?demo';
 import DemoActions from './demos/actions.tsx?demo';
 import DemoPromise from './demos/promise.tsx?demo';
 import DemoPosition from './demos/position.tsx?demo';
+import DemoDedupe from './demos/dedupe.tsx?demo';
 
 ## Default
 
@@ -24,6 +25,10 @@ import DemoPosition from './demos/position.tsx?demo';
 ## Position
 
 <Demo of={DemoPosition} layout="bare" />
+
+## Deduplication
+
+<Demo of={DemoDedupe} layout="bare" />
 
 ## Usage
 
@@ -68,6 +73,21 @@ toast.promise(fetchData(), {
   loading: 'Loading data...',
   success: (data) => `Data: ${data}`,
   error: (err) => `Error: ${err.message}`,
+});
+```
+
+### Deduplicated Toast
+
+Give a toast a stable `id` when the same event can fire repeatedly (a failing request, a retried upload). Showing it again refreshes the visible toast and resets its timer instead of stacking another copy, and brings it back to the front of the stack if newer toasts have pushed it down.
+
+```tsx | pure
+import { toast } from '@lobehub/ui/base-ui';
+
+// Every retry refreshes one toast rather than stacking six of them
+toast.error({
+  description: 'Check your firewall, proxy or VPN settings and try again.',
+  id: 'network-error',
+  title: 'Connection refused',
 });
 ```
 
@@ -121,6 +141,7 @@ toast.dismiss();
 | closable        | Whether closable                           | `boolean`           | `true`      |
 | hideCloseButton | Hide the close button                      | `boolean`           | `false`     |
 | icon            | Custom icon                                | `IconProps['icon']` | -           |
+| id              | Stable id used to deduplicate toasts       | `string`            | -           |
 | placement       | Toast placement, overrides global position | `ToastPosition`     | -           |
 | onClose         | Callback when closed                       | `() => void`        | -           |
 | onRemove        | Callback when removed                      | `() => void`        | -           |

--- a/src/base-ui/Toast/type.ts
+++ b/src/base-ui/Toast/type.ts
@@ -6,12 +6,7 @@ import type { IconProps } from '@/Icon';
 export type ToastType = 'success' | 'info' | 'warning' | 'error' | 'loading' | 'default';
 
 export type ToastPosition =
-  | 'top'
-  | 'top-left'
-  | 'top-right'
-  | 'bottom'
-  | 'bottom-left'
-  | 'bottom-right';
+  'top' | 'top-left' | 'top-right' | 'bottom' | 'bottom-left' | 'bottom-right';
 
 export type ToastActionVariant = 'primary' | 'secondary' | 'text' | 'danger' | 'ghost';
 
@@ -76,6 +71,13 @@ export interface ToastOptions {
    * Custom icon
    */
   icon?: IconProps['icon'];
+  /**
+   * Stable identifier used to deduplicate toasts. Showing a toast with an id
+   * that is already visible refreshes it in place and resets its timer instead
+   * of stacking a second copy; if it is no longer the newest toast it is also
+   * moved back to the front of the stack.
+   */
+  id?: string;
   /**
    * Callback when toast is closed
    */


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

重复触发的事件（重试失败的请求、轮询失败、断网重连）目前每次都会新叠一条 toast，很快就把 viewport 塞满：

`ToastOptions` 新增可选的 `id`：

- **去重** — 传入的 `id` 若已在展示中，则原地刷新内容并重置倒计时，而不是再叠一条
- **回到栈顶** — 若它已被更新的 toast 挤下去，会重新移到栈首；若它本来就是栈顶，则走原地更新，不重放入场动画，避免无谓的抖动
- **回调保持安静** — 因为「被同 id 顶替」而关闭时，不会触发业务方的 `onClose` / `onRemove`，只有真正被 dismiss / 超时移除时才会通知

用法：

```ts
// 每次重试只刷新同一条，而不是叠出六条
toast.error({
  id: 'network-error',
  title: 'Connection refused',
  description: 'Check your firewall, proxy or VPN settings and try again.',
});
```

#### 📝 补充信息 | Additional Information

**实现说明**

`@base-ui/react` 的 toast manager 本身已经支持 `add({ id })`（同 id 会 upsert + 重置 timer），所以去重部分主要是把 `id` 透传下去。

但 upsert 走的是 `toasts.map(...)`，**位置原地保留**，不会前移。要实现「移回栈顶」需要先 `close(id)`：这会同步把 store 里的 `transitionStatus` 置为 `ending`，紧接着的 `add({ id })` 就会丢弃旧的并前插一条新的。副作用是 `closeToast` 会调用该 toast 的 `onClose`，所以内部用一个 `superseded` 标记把这次回调吞掉——这也是 `activeToastIds: Set` 换成 `activeToasts: Map` 的原因（Map 同时保存该标记，且插入顺序刚好对应栈的顺序，可以判断某个 id 是否已经在栈顶）。

**测试**

`src/base-ui/Toast/__tests__/dedupe.test.tsx` 新增 6 个用例，覆盖去重、前移、无 id 时保持原样、superseded 时不触发回调、以及 superseded 之后真实 dismiss 仍会触发 `onClose`。回退实现后其中 3 个会失败。

- `vitest run src/base-ui` — 21 files / 110 tests 全过
- `tsc --noEmit` — 干净
