### PR TITLE
🐛 fix(base-ui): make FloatingSheet draggable by touch

### DIFF
--- a/src/base-ui/FloatingSheet/FloatingSheetHeader.tsx
+++ b/src/base-ui/FloatingSheet/FloatingSheetHeader.tsx
@@ -5,7 +5,7 @@ import { styles } from './style';
 
 interface FloatingSheetHeaderProps {
   handleProps: {
-    onMouseDown: (e: React.MouseEvent<HTMLDivElement>) => void;
+    onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
   };
   headerActions?: ReactNode;
   isDragging: boolean;

--- a/src/base-ui/FloatingSheet/__tests__/useSheetDrag.test.ts
+++ b/src/base-ui/FloatingSheet/__tests__/useSheetDrag.test.ts
@@ -2,6 +2,33 @@ import { act, renderHook } from '@testing-library/react';
 
 import { useSheetDrag } from '../useSheetDrag';
 
+const handle = () => {
+  const element = document.createElement('div');
+  element.setPointerCapture ??= vi.fn();
+  element.hasPointerCapture ??= () => false;
+  element.releasePointerCapture ??= vi.fn();
+  return element;
+};
+
+const downEvent = (
+  overrides: Partial<{ isPrimary: boolean; pointerId: number; target: HTMLElement }> = {},
+) => {
+  const element = handle();
+  return {
+    button: 0,
+    clientY: 500,
+    currentTarget: element,
+    isPrimary: true,
+    pointerId: 1,
+    preventDefault: vi.fn(),
+    target: element,
+    ...overrides,
+  } as unknown as React.PointerEvent<HTMLDivElement>;
+};
+
+const pointerEvent = (type: string, init: { clientY?: number; pointerId?: number } = {}) =>
+  new PointerEvent(type, { bubbles: true, pointerId: 1, ...init });
+
 describe('useSheetDrag', () => {
   test('returns drag handler props', () => {
     const { result } = renderHook(() =>
@@ -12,7 +39,7 @@ describe('useSheetDrag', () => {
       }),
     );
 
-    expect(result.current.handleProps).toHaveProperty('onMouseDown');
+    expect(result.current.handleProps).toHaveProperty('onPointerDown');
     expect(result.current.isDragging).toBe(false);
   });
 
@@ -25,15 +52,8 @@ describe('useSheetDrag', () => {
       }),
     );
 
-    const mockEvent = {
-      button: 0,
-      clientY: 500,
-      preventDefault: vi.fn(),
-      target: document.createElement('div'),
-    } as unknown as React.MouseEvent<HTMLDivElement>;
-
     act(() => {
-      result.current.handleProps.onMouseDown(mockEvent);
+      result.current.handleProps.onPointerDown(downEvent());
     });
 
     expect(result.current.isDragging).toBe(false);
@@ -50,15 +70,25 @@ describe('useSheetDrag', () => {
 
     const button = document.createElement('button');
     button.setAttribute('data-no-drag', '');
-    const mockEvent = {
-      button: 0,
-      clientY: 500,
-      preventDefault: vi.fn(),
-      target: button,
-    } as unknown as React.MouseEvent<HTMLDivElement>;
 
     act(() => {
-      result.current.handleProps.onMouseDown(mockEvent);
+      result.current.handleProps.onPointerDown(downEvent({ target: button }));
+    });
+
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  test('ignores a non-primary pointer so a second finger cannot hijack the drag', () => {
+    const { result } = renderHook(() =>
+      useSheetDrag({
+        enabled: true,
+        onDragChange: vi.fn(),
+        onDragEnd: vi.fn(),
+      }),
+    );
+
+    act(() => {
+      result.current.handleProps.onPointerDown(downEvent({ isPrimary: false, pointerId: 2 }));
     });
 
     expect(result.current.isDragging).toBe(false);
@@ -75,32 +105,72 @@ describe('useSheetDrag', () => {
       }),
     );
 
-    const mockEvent = {
-      button: 0,
-      clientY: 500,
-      preventDefault: vi.fn(),
-      target: document.createElement('div'),
-    } as unknown as React.MouseEvent<HTMLDivElement>;
-
     act(() => {
-      result.current.handleProps.onMouseDown(mockEvent);
+      result.current.handleProps.onPointerDown(downEvent());
     });
 
     expect(result.current.isDragging).toBe(true);
 
-    // Simulate mouse move on document
     act(() => {
-      document.dispatchEvent(new MouseEvent('mousemove', { clientY: 450 }));
+      document.dispatchEvent(pointerEvent('pointermove', { clientY: 450 }));
     });
 
     expect(onDragChange).toHaveBeenCalledWith(50); // 500 - 450 = 50 (upward)
 
-    // Simulate mouse up on document
     act(() => {
-      document.dispatchEvent(new MouseEvent('mouseup', { clientY: 450 }));
+      document.dispatchEvent(pointerEvent('pointerup', { clientY: 450 }));
     });
 
     expect(onDragEnd).toHaveBeenCalled();
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  test('ignores document events from a different pointer', () => {
+    const onDragChange = vi.fn();
+    const { result } = renderHook(() =>
+      useSheetDrag({
+        enabled: true,
+        onDragChange,
+        onDragEnd: vi.fn(),
+      }),
+    );
+
+    act(() => {
+      result.current.handleProps.onPointerDown(downEvent());
+    });
+
+    act(() => {
+      document.dispatchEvent(pointerEvent('pointermove', { clientY: 450, pointerId: 2 }));
+    });
+
+    expect(onDragChange).not.toHaveBeenCalled();
+    expect(result.current.isDragging).toBe(true);
+  });
+
+  test('settles without a fling when the gesture is cancelled', () => {
+    const onDragEnd = vi.fn();
+    const { result } = renderHook(() =>
+      useSheetDrag({
+        enabled: true,
+        onDragChange: vi.fn(),
+        onDragEnd,
+      }),
+    );
+
+    act(() => {
+      result.current.handleProps.onPointerDown(downEvent());
+    });
+
+    act(() => {
+      document.dispatchEvent(pointerEvent('pointermove', { clientY: 300 }));
+    });
+
+    act(() => {
+      document.dispatchEvent(pointerEvent('pointercancel', { clientY: 300 }));
+    });
+
+    // Zero distance and zero velocity: return to where the drag started.
+    expect(onDragEnd).toHaveBeenCalledWith(0, 0);
     expect(result.current.isDragging).toBe(false);
   });
 });

--- a/src/base-ui/FloatingSheet/style.ts
+++ b/src/base-ui/FloatingSheet/style.ts
@@ -43,6 +43,9 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     visibility: hidden;
   `,
   header: css`
+    /* Stops the browser claiming the vertical gesture as a scroll,
+       which would fire pointercancel and kill the drag. */
+    touch-action: none;
     cursor: grab;
     user-select: none;
 

--- a/src/base-ui/FloatingSheet/useSheetDrag.ts
+++ b/src/base-ui/FloatingSheet/useSheetDrag.ts
@@ -11,6 +11,8 @@ export function useSheetDrag({ onDragChange, onDragEnd, enabled }: UseSheetDragO
   const startY = useRef(0);
   const startTime = useRef(0);
   const draggingRef = useRef(false);
+  const pointerIdRef = useRef<number | null>(null);
+  const captureTargetRef = useRef<HTMLElement | null>(null);
 
   // Store latest callbacks in refs to avoid stale closures in document listeners
   const onDragChangeRef = useRef(onDragChange);
@@ -21,39 +23,76 @@ export function useSheetDrag({ onDragChange, onDragEnd, enabled }: UseSheetDragO
   useEffect(() => {
     if (!draggingRef.current) return;
 
-    const onMouseMove = (e: MouseEvent) => {
-      e.preventDefault();
+    // A second finger landing mid-drag must not steer the sheet.
+    const isActivePointer = (e: PointerEvent) =>
+      pointerIdRef.current === null || e.pointerId === pointerIdRef.current;
+
+    const releaseCapture = () => {
+      const target = captureTargetRef.current;
+      const pointerId = pointerIdRef.current;
+      if (target && pointerId !== null && target.hasPointerCapture?.(pointerId)) {
+        target.releasePointerCapture(pointerId);
+      }
+      captureTargetRef.current = null;
+      pointerIdRef.current = null;
+    };
+
+    const onPointerMove = (e: PointerEvent) => {
+      if (!isActivePointer(e)) return;
+      // Touch moves are non-cancelable once the gesture is committed.
+      if (e.cancelable) e.preventDefault();
       const draggedDistance = startY.current - e.clientY;
       onDragChangeRef.current(draggedDistance);
     };
 
-    const onMouseUp = (e: MouseEvent) => {
+    const onPointerUp = (e: PointerEvent) => {
+      if (!isActivePointer(e)) return;
       draggingRef.current = false;
       setIsDragging(false);
 
       const draggedDistance = startY.current - e.clientY;
       const elapsed = Date.now() - startTime.current;
       const velocity = elapsed > 0 ? Math.abs(draggedDistance) / elapsed : 0;
+      releaseCapture();
       onDragEndRef.current(draggedDistance, velocity);
     };
 
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
+    // The browser can revoke an in-flight gesture (scroll takeover, an
+    // incoming call). Settle back rather than leaving the sheet stuck mid-drag.
+    const onPointerCancel = (e: PointerEvent) => {
+      if (!isActivePointer(e)) return;
+      draggingRef.current = false;
+      setIsDragging(false);
+      releaseCapture();
+      onDragEndRef.current(0, 0);
+    };
+
+    document.addEventListener('pointermove', onPointerMove, { passive: false });
+    document.addEventListener('pointerup', onPointerUp);
+    document.addEventListener('pointercancel', onPointerCancel);
     return () => {
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup', onMouseUp);
+      document.removeEventListener('pointermove', onPointerMove);
+      document.removeEventListener('pointerup', onPointerUp);
+      document.removeEventListener('pointercancel', onPointerCancel);
     };
   }, [isDragging]);
 
-  const onMouseDown = useCallback(
-    (event: React.MouseEvent<HTMLDivElement>) => {
+  const onPointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
       if (!enabled) return;
-      if (event.button !== 0) return; // left click only
+      if (!event.isPrimary) return;
+      if (event.button !== 0) return; // left click / first contact only
 
       const target = event.target as HTMLElement;
       if (target.closest?.('[data-no-drag]')) return;
 
       event.preventDefault(); // prevent text selection during drag
+
+      const handle = event.currentTarget;
+      pointerIdRef.current = event.pointerId;
+      captureTargetRef.current = handle;
+      // Keeps the drag alive when the finger leaves the handle.
+      handle.setPointerCapture?.(event.pointerId);
 
       startY.current = event.clientY;
       startTime.current = Date.now();
@@ -66,7 +105,7 @@ export function useSheetDrag({ onDragChange, onDragEnd, enabled }: UseSheetDragO
   return {
     isDragging,
     handleProps: {
-      onMouseDown,
+      onPointerDown,
     },
   };
 }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🐛 fix

#### 🔀 变更说明 | Description of Change

`useSheetDrag` binds `onMouseDown` plus document `mousemove`/`mouseup` and nothing else, so on a touch device the sheet cannot be dragged at all — `snapPoints`, `closeThreshold` and dismiss-by-drag are all unreachable by finger.

Verified on an Android device: CDP-synthesised touch events and a kernel-level `adb shell input swipe` both moved the sheet **0px**, while CDP mouse events moved it correctly.

This switches the drag handle to pointer events, which cover mouse, touch and pen in one path — the same idiom `Modal`, `FloatingPanel`, `Switch` and `Select` already use in this package. `FloatingSheet` was the only hand-rolled raw-mouse drag left.

- `onPointerDown` on the handle, with `setPointerCapture` so the drag survives the finger leaving the handle
- document `pointermove` / `pointerup` / `pointercancel`, filtered by `pointerId` so a second finger cannot steer an in-flight drag
- `pointercancel` settles back to the pre-drag height instead of leaving the sheet stuck mid-drag when the browser revokes the gesture
- `touch-action: none` on the handle — without it the browser claims the vertical gesture as a scroll and immediately fires `pointercancel`, which reads on device as "the drag works for 100ms then dies"

#### 📝 补充信息 | Additional Information

**Mouse behaviour is unchanged.** Pointer events fire for mouse input too, and the `button !== 0` guard still restricts dragging to the left button. `handleProps` is internal to `FloatingSheet` and never appears in the published typings, so this is not a breaking change for consumers.

`__tests__/useSheetDrag.test.ts` is updated to drive pointer events, plus three new cases: non-primary pointer rejection, foreign-`pointerId` rejection, and the `pointercancel` settle path. `src/base-ui/FloatingSheet` is green (32 tests), `tsc --noEmit` reports nothing for the directory, and eslint/stylelint are clean apart from pre-existing warnings.

Happy to adjust the approach if you'd rather this go through `framer-motion` `dragControls` the way `Modal` does — the raw pointer path was chosen to keep the existing snap/velocity maths untouched.