### PR TITLE
🐛 fix(image): keep the viewer backdrop when it opens from a dialog

### DIFF
--- a/src/Image/viewer/ImageViewer.nested.test.tsx
+++ b/src/Image/viewer/ImageViewer.nested.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { motion } from 'motion/react';
+import { type ReactNode, useState } from 'react';
+
+import { Drawer } from '@/base-ui/Drawer';
+import ConfigProvider from '@/ConfigProvider';
+
+import ImageComponent from '../Image';
+
+vi.mock('antd-style', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('antd-style')>();
+  return {
+    ...actual,
+    createStaticStyles: vi.fn((fn: any) => {
+      const result = fn({ css: () => '', cssVar: new Proxy({}, { get: () => '' }) });
+      return new Proxy(result, { get: (_target, key) => String(key) });
+    }),
+  };
+});
+
+class FakePreloader {
+  private handlers = new Map<string, Set<() => void>>();
+  src = '';
+
+  addEventListener(type: string, handler: () => void) {
+    const set = this.handlers.get(type) ?? new Set();
+    set.add(handler);
+    this.handlers.set(type, set);
+  }
+
+  removeEventListener(type: string, handler: () => void) {
+    this.handlers.get(type)?.delete(handler);
+  }
+}
+
+const stubRect = (element: HTMLElement, rect: Partial<DOMRect>) => {
+  const resolved = { height: 150, left: 100, top: 50, width: 200, ...rect };
+  element.getBoundingClientRect = () =>
+    ({
+      ...resolved,
+      bottom: resolved.top + resolved.height,
+      right: resolved.left + resolved.width,
+      toJSON: () => resolved,
+      x: resolved.left,
+      y: resolved.top,
+    }) as DOMRect;
+};
+
+const renderWithMotion = (node: ReactNode) =>
+  render(<ConfigProvider motion={motion}>{node}</ConfigProvider>);
+
+const getViewerBackdrop = () => document.querySelector<HTMLElement>('.viewerBackdrop');
+const getViewerPopup = () => document.querySelector<HTMLElement>('.viewerPopup');
+
+const openViewer = () => {
+  const thumbnail = screen.getByAltText('cat') as HTMLImageElement;
+  Object.defineProperty(thumbnail, 'naturalWidth', { configurable: true, value: 400 });
+  Object.defineProperty(thumbnail, 'naturalHeight', { configurable: true, value: 300 });
+  stubRect(thumbnail, {});
+  fireEvent.click(thumbnail);
+};
+
+const DrawerWithImage = () => {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <Drawer open={open} placement={'right'} title={'Attachments'} onClose={() => setOpen(false)}>
+      <ImageComponent alt={'cat'} src={'https://example.com/cat.png'} />
+    </Drawer>
+  );
+};
+
+beforeEach(() => {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1024, writable: true });
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 768, writable: true });
+  vi.stubGlobal('Image', FakePreloader);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('viewer backdrop', () => {
+  it('renders on its own', () => {
+    renderWithMotion(<ImageComponent alt={'cat'} src={'https://example.com/cat.png'} />);
+    openViewer();
+
+    expect(getViewerPopup()).not.toBeNull();
+    expect(getViewerBackdrop()).not.toBeNull();
+  });
+
+  it('still renders when the viewer opens from inside a drawer', () => {
+    renderWithMotion(<DrawerWithImage />);
+    openViewer();
+
+    expect(getViewerPopup()).not.toBeNull();
+    // Base UI drops a nested dialog's backdrop by default, which would leave the
+    // viewer relying on whatever surface it happens to open above.
+    expect(getViewerBackdrop()).not.toBeNull();
+  });
+});

--- a/src/Image/viewer/ImageViewer.tsx
+++ b/src/Image/viewer/ImageViewer.tsx
@@ -287,7 +287,12 @@ const ImageViewer = memo<ImageViewerProps>(({ entries, index, openerFocusElement
   return (
     <Dialog.Root modal open onOpenChange={handleDialogOpenChange}>
       <Dialog.Portal container={appElement ?? undefined}>
+        {/* Base UI drops a nested dialog's backdrop so overlays don't stack. The viewer is
+            not an overlay on the surface it opened from — it replaces the screen — so it
+            keeps its own scrim, or a viewer opened from a maskless drawer would show the
+            page straight through the letterbox around the image. */}
         <Dialog.Backdrop
+          forceRender
           className={styles.viewerBackdrop}
           ref={backdropRef}
           style={zIndex === undefined ? undefined : { zIndex }}


### PR DESCRIPTION
Base UI drops a nested dialog's backdrop by default, so overlays don't stack. That is right for a dialog layered *over* another surface — but the image viewer is not that. It replaces the screen.

Opened from inside a `Drawer` or `Modal`, the viewer lost its own scrim and inherited whatever the host surface happened to provide:

| Host | Backdrop the viewer actually got |
| --- | --- |
| page (no dialog) | its own — `color-mix(… 90%)` + `blur(8px)` ✅ |
| masked `Drawer` | the drawer's `rgba(0,0,0,0.44)`, no blur |
| maskless `Drawer` | **none** — the page shows straight through the letterbox around the image |

The last row is the visible one: the viewer only covers the image's own box, so with a small image the surrounding area stayed fully legible.

`forceRender` on `Dialog.Backdrop` is Base UI's own opt-out for exactly this case.

#### Test

Two tests, one per path — the standalone one already passed, the nested one reproduced the bug before the fix:

```
src/Image/viewer/ImageViewer.nested.test.tsx
  ✓ renders on its own
  ✓ still renders when the viewer opens from inside a drawer
```

Also driven in the docs demo with an image inside the Drawer demo, measured through `getComputedStyle`:

| Case | Layers after clicking the in-drawer image |
| --- | --- |
| masked drawer | drawer backdrop 1220 `rgba(0,0,0,0.44)` → drawer popup 1221 → **viewer backdrop 1240 `srgb 0 0 0 / 0.9` + `blur(8px)`** → viewer popup 1241 |
| maskless drawer | drawer popup 1261 → **viewer backdrop 1280 `srgb 0 0 0 / 0.9` + `blur(8px)`** → viewer popup 1281 |

`src/Image` and `src/base-ui/Drawer` suites: 288 passed. `tsc --noEmit` clean; eslint clean on the touched files.

Found while migrating lobehub/lobehub's drawers onto `base-ui` `Drawer` — before that migration those drawers were antd-backed, so the viewer was the only Base UI dialog on screen and always drew its own backdrop.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed