### PR TITLE
🐛 fix(draggable-panel): size stable layout by placement

### DIFF
--- a/src/DraggablePanel/DraggablePanel.test.tsx
+++ b/src/DraggablePanel/DraggablePanel.test.tsx
@@ -58,6 +58,31 @@ describe('DraggablePanel stableLayout', () => {
     expect(getResizable(aside)).not.toBeNull();
   });
 
+  it.each(['top', 'bottom'] as const)(
+    'keeps a fixed %s panel from occupying the parent height outside its stable outer layer',
+    (placement) => {
+      const { rerender } = render(
+        <DraggablePanel expand defaultSize={{ height: 200 }} placement={placement}>
+          Panel body
+        </DraggablePanel>,
+      );
+
+      const aside = getAside();
+      expect(aside.style.height).toBe('');
+      expect(aside.style.width).toBe('100%');
+      expect(getStableOuter(aside)!.style.height).toBe('200px');
+
+      rerender(
+        <DraggablePanel defaultSize={{ height: 200 }} expand={false} placement={placement}>
+          Panel body
+        </DraggablePanel>,
+      );
+
+      expect(aside.style.height).toBe('');
+      expect(getStableOuter(aside)!.style.height).toBe('0px');
+    },
+  );
+
   it('can opt out of stableLayout and zeros resizable size when collapsed', () => {
     const { rerender } = render(
       <DraggablePanel expand defaultSize={{ width: 200 }} placement="left" stableLayout={false}>

--- a/src/DraggablePanel/DraggablePanel.tsx
+++ b/src/DraggablePanel/DraggablePanel.tsx
@@ -519,12 +519,13 @@ const DraggablePanel = memo<DraggablePanelProps>(
         ? { height: '100%', width: '100%' }
         : { width: '100%' };
 
+    const stableAsideFixedSize: CSSProperties = isVertical ? { width: '100%' } : { height: '100%' };
     const stableAsideStyle: CSSProperties = usesStableLayout
       ? {
           display: 'flex',
           flexDirection: 'column',
           minHeight: 0,
-          ...(mode === 'fixed' ? { height: '100%' } : {}),
+          ...(mode === 'fixed' ? stableAsideFixedSize : {}),
         }
       : {};
 


### PR DESCRIPTION
## Summary

- size stable fixed panels on their cross axis according to placement
- retain height: 100% for left/right panels
- use width: 100% for top/bottom panels so their outer stable container exclusively controls height
- cover expanded and collapsed top/bottom layouts with regression tests

## Root cause

DraggablePanel v5.29 enabled stableLayout by default. Its fixed aside always received height: 100%, which is correct for left/right panels but causes top/bottom panels inside column layouts to consume the full parent height even when the stable outer layer is collapsed to 0px.

This surfaced downstream as lobehub/lobehub#18015.

## Verification

- pnpm vitest run src/DraggablePanel/DraggablePanel.test.tsx: 6 tests passed
- pnpm exec eslint on the changed source and test: no errors; one existing default-export warning
- pnpm type-check: passed
- regression test before the implementation: both top and bottom cases failed with aside height 100% instead of an unset height