### PR TITLE
fix(ThemeProvider): derive KaTeX CSS version from installed katex to fix broken math rendering

### DIFF
--- a/src/ThemeProvider/ThemeProvider.tsx
+++ b/src/ThemeProvider/ThemeProvider.tsx
@@ -8,7 +8,7 @@ import {
   ThemeProvider as AntdThemeProvider,
 } from 'antd-style';
 import { merge } from 'es-toolkit/compat';
-import { version as katexVersion } from 'katex';
+import katexPkg from 'katex/package.json';
 import { memo, useCallback, useMemo, useState } from 'react';
 
 import { useCdnFn } from '@/ConfigProvider';
@@ -63,7 +63,7 @@ const ThemeProvider = memo<ThemeProviderProps>(
           genCdnUrl({
             path: 'dist/katex.min.css',
             pkg: 'katex',
-            version: katexVersion,
+            version: katexPkg.version,
           }),
         ],
       [customFonts, genCdnUrl],

--- a/src/ThemeProvider/ThemeProvider.tsx
+++ b/src/ThemeProvider/ThemeProvider.tsx
@@ -8,6 +8,7 @@ import {
   ThemeProvider as AntdThemeProvider,
 } from 'antd-style';
 import { merge } from 'es-toolkit/compat';
+import { version as katexVersion } from 'katex';
 import { memo, useCallback, useMemo, useState } from 'react';
 
 import { useCdnFn } from '@/ConfigProvider';
@@ -62,7 +63,7 @@ const ThemeProvider = memo<ThemeProviderProps>(
           genCdnUrl({
             path: 'dist/katex.min.css',
             pkg: 'katex',
-            version: '0.18.1',
+            version: katexVersion,
           }),
         ],
       [customFonts, genCdnUrl],


### PR DESCRIPTION
## 问题

https://app.lobehub.com/share/t/oLuHdsuE

<img width="917" height="501" alt="image" src="https://github.com/user-attachments/assets/7d78aeb9-6fa1-4de9-833b-9d60a715a291" />

`ThemeProvider` 加载 KaTeX CSS 时把版本硬编码成了 `0.18.1`：

```ts
genCdnUrl({
  path: 'dist/katex.min.css',
  pkg: 'katex',
  version: '0.18.1', // 硬编码
})
```

但 Markdown/LaTeX 渲染端是通过 caret 范围（`"katex": "^0.18.1"`）引入 katex 的。在 pnpm 提升的依赖图里——例如 LobeHub 这类下游应用——真正被打进客户端、负责渲染公式的 katex 可能是另一个小版本（比如 `0.16.47`）。渲染端产出的 HTML 于是配上了另一个小版本的 CSS，像 `.sizing.reset-size6.size3` 这类字号/定位规则不再匹配（新版本 CSS 的 selector 是 `.katex-sizing.reset-size6.size3`），最终表现为角标、二重积分符号渲染错乱。

## 修复

让 CSS 版本直接取自渲染端实际打包进客户端的那个 katex 模块，只读其轻量元数据、不引入渲染器运行时：

```ts
import katexPkg from 'katex/package.json';
...
genCdnUrl({
  path: 'dist/katex.min.css',
  pkg: 'katex',
  version: katexPkg.version,
})
```

`katex` 的 `package.json` 经 exports 通配可解析，并在 `moduleResolution: bundler` + `resolveJsonModule` 下类型安全。这样样式表 URL 永远跟打包进来的渲染端版本一致，这类版本漂移不会再复发；同时也避免了在根 `ThemeProvider` 里 import 整个 katex 运行时（那样会给所有使用该组件的页面入口带上渲染器体积）。

## 整体解决方案（建议）

本 PR 修的是"CSS 与渲染端版本跟随"，能根治运行时错位；但更彻底的方案是**上下游统一到 katex 0.18**，让依赖树里根本不再出现旧版本。

- **下游应用（如 LobeHub）**：在 `pnpm-workspace.yaml` 加 `overrides: katex: ^0.18.1`，强制整棵依赖树（含 `rehype-katex@7`、`remark-math@6` → `micromark-extension-math@3.1.0`，这些包目前仍硬依赖 `katex ^0.16.0`）统一解析到 0.18。这样应用内只剩一个 katex，CSS 与渲染端天然一致，且无需任何运行时判断。
- **上游第三方包**：`rehype-katex`、`micromark-extension-math` 目前把 katex 锁死在 `^0.16.0`，只能靠 overrides 强推。长期建议让这两个包放开 katex 范围（如 `^0.16 || ^0.18`）或改为 peerDependency。`rehype-katex@7.0.1` 只调用 `katex.renderToString`，0.16 与 0.18 该 API 兼容，强制升级无兼容性风险——上游 lobe-ui 的 `9be1bf97` 也已在自身构建里验证过这一点。

## 备注

- `katex` 本来就是本包的直接依赖。

## 背景

上游 [9be1bf97](https://github.com/lobehub/lobe-ui/commit/9be1bf97)（`⬆️ fix: upgrade katex to v0.18 and align class names`，2026-07-26）已把 lobe-ui 自身的 `katex` 升到 `^0.18.1`，并在 `pnpm-workspace.yaml` 用 `overrides: katex: ^0.18.1` 强制 `rehype-katex`（硬依赖 `^0.16`）也解析到 0.18，同时修正了 0.18 的类名变化（`.katex-html > .base` → `.katex-html > .katex-base`）。

但该 overrides 只对 lobe-ui 仓库自身的 pnpm 解析生效，**不会传导给下游应用**。LobeHub 这类下游应用独立解析依赖树，`rehype-katex@7.0.1` 仍会把 `katex` 解析到 `0.16.x`，与 lobe-ui 硬编码的 `0.18.1` CSS 版本错配，于是出现角标、二重积分符号渲染错乱。本 PR 通过让 CSS 版本跟随实际打包进客户端的 katex 版本，补齐了 `9be1bf97` 未覆盖的下游场景，使这类错位不再复发。
