### PR TITLE
♻️ refactor(base-ui): enforce migrated form controls

### DIFF
--- a/src/base-ui/AutoComplete/AutoComplete.tsx
+++ b/src/base-ui/AutoComplete/AutoComplete.tsx
@@ -6,6 +6,7 @@ import { XIcon } from 'lucide-react';
 import { memo, useMemo, useRef } from 'react';
 
 import { inputStyles, inputVariants } from '@/base-ui/Input';
+import { useLayerZIndex } from '@/base-ui/zIndex';
 import Icon from '@/Icon';
 import { useAppElement } from '@/ThemeProvider';
 
@@ -35,6 +36,7 @@ const AutoComplete = memo<AutoCompleteProps>(
     const { isDarkMode } = useThemeMode();
     const appElement = useAppElement();
     const anchorRef = useRef<HTMLDivElement>(null);
+    const { ref: positionerRef, zIndex } = useLayerZIndex<HTMLDivElement>('floating');
     const mergedVariant = variant || (isDarkMode ? 'filled' : 'outlined');
 
     const items = useMemo<AutoCompleteOption[]>(
@@ -74,7 +76,13 @@ const AutoComplete = memo<AutoCompleteProps>(
           {suffix && <span className={inputStyles.slot}>{suffix}</span>}
         </div>
         <Autocomplete.Portal container={appElement ?? undefined}>
-          <Autocomplete.Positioner anchor={anchorRef} className={styles.positioner} sideOffset={4}>
+          <Autocomplete.Positioner
+            anchor={anchorRef}
+            className={styles.positioner}
+            ref={positionerRef}
+            sideOffset={4}
+            style={zIndex === undefined ? undefined : { zIndex }}
+          >
             <Autocomplete.Popup
               className={cx(styles.popup, classNames?.popup)}
               style={customStyles?.popup}

--- a/src/eslint/index.ts
+++ b/src/eslint/index.ts
@@ -1,4 +1,37 @@
-const DEPRECATED_UI_COMPONENTS = ['Button', 'Drawer', 'Modal', 'Segmented', 'Select', 'Tabs'];
+const DEPRECATED_UI_COMPONENTS = [
+  'AutoComplete',
+  'Button',
+  'Checkbox',
+  'CheckboxGroup',
+  'Drawer',
+  'Modal',
+  'Radio',
+  'RadioGroup',
+  'Segmented',
+  'Select',
+  'Slider',
+  'SliderWithInput',
+  'Tabs',
+];
+
+const DEPRECATED_ANTD_COMPONENT_PATHS = [
+  'antd/es/auto-complete',
+  'antd/es/auto-complete/*',
+  'antd/es/checkbox',
+  'antd/es/checkbox/*',
+  'antd/es/radio',
+  'antd/es/radio/*',
+  'antd/es/slider',
+  'antd/es/slider/*',
+  'antd/lib/auto-complete',
+  'antd/lib/auto-complete/*',
+  'antd/lib/checkbox',
+  'antd/lib/checkbox/*',
+  'antd/lib/radio',
+  'antd/lib/radio/*',
+  'antd/lib/slider',
+  'antd/lib/slider/*',
+];
 
 export const restrictedImports = {
   rules: {
@@ -20,9 +53,15 @@ export const restrictedImports = {
           },
           {
             importNames: DEPRECATED_UI_COMPONENTS,
-            message:
-              'Direct antd import is deprecated. Import from "@lobehub/ui" or "@lobehub/ui/base-ui" instead.',
+            message: 'Direct antd import is deprecated. Import from "@lobehub/ui/base-ui" instead.',
             name: 'antd',
+          },
+        ],
+        patterns: [
+          {
+            group: DEPRECATED_ANTD_COMPONENT_PATHS,
+            message:
+              'Direct antd component import is deprecated. Import from "@lobehub/ui/base-ui" instead.',
           },
         ],
       },


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

- Add AutoComplete, Checkbox, Radio, and Slider families to the restricted legacy imports exposed by the ESLint preset.
- Reject direct Ant Design deep imports for the migrated component families and direct consumers to `@lobehub/ui/base-ui`.
- Move the Base AutoComplete positioner into the shared floating layer so its suggestion popup renders above Sheet and Modal content.

The downstream migration has removed the legacy imports for these component families. This PR turns that migration boundary into an enforceable lint rule. Actual business UI verification also exposed an AutoComplete stacking issue inside the custom MCP Sheet; using the shared layer z-index resolves the integration issue without component-specific constants.

#### 📝 补充信息 | Additional Information

Validation:

- `pnpm exec prettier --check src/base-ui/AutoComplete/AutoComplete.tsx src/eslint/index.ts`
- `pnpm exec eslint src/base-ui/AutoComplete/AutoComplete.tsx src/eslint/index.ts` (0 errors; 2 pre-existing default-export warnings)
- `pnpm run type-check`
- `git diff --check`
- [Downstream business UI acceptance: 4/4 screenshots passed](https://app.lobehub.com/verify/e41ff6c9-89c1-41f5-91eb-267a670594e2)

Related downstream migration: lobehub/lobehub#18296
