### PR TITLE
✨ feat(base-ui): migrate Alert

### DIFF
--- a/compatibility.json
+++ b/compatibility.json
@@ -3337,6 +3337,42 @@
       "source": "src/awesome/TypewriterEffect/demos/variableSpeed.tsx"
     },
     {
+      "document": "src/base-ui/Alert/index.mdx",
+      "legacyId": "src-base-ui-alert-demo-demos",
+      "legacyRouteId": "components/base-ui/Alert/index",
+      "options": {
+        "inline": false,
+        "isolated": false,
+        "layout": "bare"
+      },
+      "pathname": "/components/base-ui/alert",
+      "source": "src/base-ui/Alert/demos/index.tsx"
+    },
+    {
+      "document": "src/base-ui/Alert/index.mdx",
+      "legacyId": "src-base-ui-alert-demo-extra",
+      "legacyRouteId": "components/base-ui/Alert/index",
+      "options": {
+        "inline": false,
+        "isolated": false,
+        "layout": "bare"
+      },
+      "pathname": "/components/base-ui/alert",
+      "source": "src/base-ui/Alert/demos/Extra.tsx"
+    },
+    {
+      "document": "src/base-ui/Alert/index.mdx",
+      "legacyId": "src-base-ui-alert-demo-playground",
+      "legacyRouteId": "components/base-ui/Alert/index",
+      "options": {
+        "inline": false,
+        "isolated": false,
+        "layout": "bare"
+      },
+      "pathname": "/components/base-ui/alert",
+      "source": "src/base-ui/Alert/demos/Playground.tsx"
+    },
+    {
       "document": "src/base-ui/Button/index.mdx",
       "legacyId": "src-base-ui-button-demo-demos",
       "legacyRouteId": "components/base-ui/Button/index",
@@ -7021,6 +7057,15 @@
       "section": "Awesome",
       "source": "src/awesome/TypewriterEffect/index.mdx",
       "title": "TypewriterEffect"
+    },
+    {
+      "category": "Feedback",
+      "description": "Semantic inline feedback with actions, dismissal, and expandable diagnostic detail.",
+      "legacyRouteId": "components/base-ui/Alert/index",
+      "pathname": "/components/base-ui/alert",
+      "section": "Base UI",
+      "source": "src/base-ui/Alert/index.mdx",
+      "title": "Alert"
     },
     {
       "category": "General",

--- a/navigationSections.json
+++ b/navigationSections.json
@@ -86,6 +86,7 @@
   "src/awesome/Spotlight/index.mdx": "Awesome",
   "src/awesome/SpotlightCard/index.mdx": "Awesome",
   "src/awesome/TypewriterEffect/index.mdx": "Awesome",
+  "src/base-ui/Alert/index.mdx": "Base UI",
   "src/base-ui/Button/index.mdx": "Base UI",
   "src/base-ui/ContextMenu/index.mdx": "Base UI",
   "src/base-ui/Drawer/index.mdx": "Base UI",

--- a/packages/docs-kit/site/content/navigation.test.ts
+++ b/packages/docs-kit/site/content/navigation.test.ts
@@ -167,8 +167,8 @@ describe('reviewed documentation navigation', () => {
       compactEntries.map(([source, section]) => [sourceIdentity(source), section]),
     );
 
-    expect(compactEntries).toHaveLength(162);
-    expect(compactBySource.size).toBe(162);
+    expect(compactEntries).toHaveLength(163);
+    expect(compactBySource.size).toBe(163);
     for (const frozenDocument of compatibility.documents) {
       expect(compactBySource.get(sourceIdentity(frozenDocument.source))).toBe(
         frozenDocument.section,
@@ -177,7 +177,7 @@ describe('reviewed documentation navigation', () => {
   });
 
   it('assigns every frozen source to exactly one section while keeping overview links separate', () => {
-    expect(compatibility.documents).toHaveLength(160);
+    expect(compatibility.documents).toHaveLength(161);
 
     const documents = compatibility.documents.map((record) =>
       document({
@@ -199,7 +199,7 @@ describe('reviewed documentation navigation', () => {
       .map(({ source }) => sourceIdentity(source))
       .toSorted();
 
-    expect(nestedDocuments).toHaveLength(158);
+    expect(nestedDocuments).toHaveLength(159);
     expect(nestedDocuments.map(({ source }) => sourceIdentity(source)).toSorted()).toEqual(
       frozenComponentSources,
     );

--- a/src/base-ui/Alert/Alert.tsx
+++ b/src/base-ui/Alert/Alert.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import { cx } from 'antd-style';
+import { AlertTriangle, CheckCircle, ChevronRight, Info, X, XCircle } from 'lucide-react';
+import { memo, useEffect, useRef, useState } from 'react';
+
+import Icon from '@/Icon';
+
+import {
+  extraHeaderVariants,
+  extraVariants,
+  integratedVariants,
+  rootVariants,
+  styles,
+  toneVariants,
+} from './style';
+import type { AlertCloseConfig, AlertProps, AlertType } from './type';
+
+const typeIcons = {
+  error: XCircle,
+  info: Info,
+  secondary: AlertTriangle,
+  success: CheckCircle,
+  warning: AlertTriangle,
+} satisfies Record<AlertType, typeof Info>;
+
+const Alert = memo<AlertProps>(
+  ({
+    action,
+    afterClose,
+    banner = false,
+    className,
+    classNames,
+    closable = false,
+    closeIcon,
+    closeText,
+    colorfulText = false,
+    description,
+    extra,
+    extraDefaultExpand = false,
+    extraIsolate = false,
+    glass = false,
+    icon,
+    iconProps,
+    message,
+    onClose,
+    ref,
+    role = 'alert',
+    rootClassName,
+    showIcon = true,
+    style,
+    styles: customStyles,
+    text,
+    title,
+    type = 'info',
+    variant = 'soft',
+    ...rest
+  }) => {
+    const [closed, setClosed] = useState(false);
+    const [extraExpanded, setExtraExpanded] = useState(extraDefaultExpand);
+    const resolvedTitle = title ?? message;
+    const hasDescription = description !== undefined && description !== null;
+    const integratedExtra = Boolean(extra && !extraIsolate);
+    const closeConfig: AlertCloseConfig = typeof closable === 'object' ? closable : {};
+    const isClosable = Boolean(closable);
+    const {
+      afterClose: configuredAfterClose,
+      closeIcon: configuredCloseIcon,
+      className: closeClassName,
+      disabled: closeDisabled,
+      onClose: configuredOnClose,
+      style: closeStyle,
+      ...closeButtonProps
+    } = closeConfig;
+    const afterCloseRef = useRef(configuredAfterClose ?? afterClose);
+    afterCloseRef.current = configuredAfterClose ?? afterClose;
+
+    useEffect(() => {
+      if (closed) afterCloseRef.current?.();
+    }, [closed]);
+
+    if (closed) return null;
+
+    const handleClose: NonNullable<AlertCloseConfig['onClose']> = (event) => {
+      (configuredOnClose ?? onClose)?.(event);
+      setClosed(true);
+    };
+
+    const root = (
+      <div
+        {...rest}
+        data-alert-type={type}
+        data-alert-variant={variant}
+        ref={ref}
+        role={role}
+        className={cx(
+          toneVariants({ type }),
+          rootVariants({
+            banner,
+            colorfulText,
+            glass: integratedExtra ? false : glass,
+            hasDescription,
+            hasExtra: integratedExtra,
+            variant,
+          }),
+          classNames?.root,
+          classNames?.alert,
+          rootClassName,
+          className,
+        )}
+        style={{
+          ...style,
+          ...customStyles?.root,
+          ...customStyles?.alert,
+        }}
+      >
+        {showIcon && (
+          <span
+            aria-hidden="true"
+            className={cx(styles.icon, classNames?.icon)}
+            style={customStyles?.icon}
+          >
+            <Icon icon={icon ?? typeIcons[type]} size={hasDescription ? 20 : 18} {...iconProps} />
+          </span>
+        )}
+        <div
+          className={cx(styles.content, classNames?.section, classNames?.content)}
+          style={{ ...customStyles?.section, ...customStyles?.content }}
+        >
+          {resolvedTitle !== undefined && resolvedTitle !== null && (
+            <div
+              style={customStyles?.title}
+              className={cx(
+                styles.title,
+                hasDescription && styles.titleDetailed,
+                classNames?.title,
+              )}
+            >
+              {resolvedTitle}
+            </div>
+          )}
+          {hasDescription && (
+            <div
+              className={cx(styles.description, classNames?.description)}
+              style={customStyles?.description}
+            >
+              {description}
+            </div>
+          )}
+        </div>
+        {action && (
+          <div
+            className={cx(styles.action, styles.wrappedAction, classNames?.action)}
+            style={customStyles?.action}
+          >
+            {action}
+          </div>
+        )}
+        {isClosable && (
+          <button
+            {...closeButtonProps}
+            aria-label={closeButtonProps['aria-label'] ?? 'Close alert'}
+            className={cx(styles.close, classNames?.close, closeClassName)}
+            disabled={closeDisabled}
+            style={{ ...customStyles?.close, ...closeStyle }}
+            type="button"
+            onClick={handleClose}
+          >
+            {configuredCloseIcon ?? closeIcon ?? closeText ?? <X size={14} />}
+          </button>
+        )}
+      </div>
+    );
+
+    if (!extra) return root;
+
+    if (extraIsolate) {
+      return (
+        <div
+          className={cx(styles.container, toneVariants({ type }), classNames?.container)}
+          style={{ gap: 8, ...customStyles?.container }}
+        >
+          {root}
+          {extra}
+        </div>
+      );
+    }
+
+    return (
+      <div
+        style={customStyles?.container}
+        className={cx(
+          styles.container,
+          toneVariants({ type }),
+          integratedVariants({ banner, glass, variant }),
+          classNames?.container,
+        )}
+      >
+        {root}
+        <div
+          className={cx(extraVariants({ banner, variant }), classNames?.extra)}
+          style={customStyles?.extra}
+        >
+          <details
+            open={extraExpanded}
+            onToggle={(event) => setExtraExpanded(event.currentTarget.open)}
+          >
+            <summary
+              className={cx(extraHeaderVariants({ variant }), classNames?.extraHeader)}
+              style={customStyles?.extraHeader}
+            >
+              <ChevronRight
+                aria-hidden="true"
+                className={cx(styles.extraIndicator, classNames?.extraIndicator)}
+                size={14}
+                style={customStyles?.extraIndicator}
+              />
+              <span>{text?.detail ?? 'Show Details'}</span>
+            </summary>
+            <div
+              className={cx(styles.extraContent, classNames?.extraContent)}
+              style={customStyles?.extraContent}
+            >
+              {extra}
+            </div>
+          </details>
+        </div>
+      </div>
+    );
+  },
+);
+
+Alert.displayName = 'BaseAlert';
+
+export default Alert;

--- a/src/base-ui/Alert/__tests__/Alert.test.tsx
+++ b/src/base-ui/Alert/__tests__/Alert.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import Alert from '../Alert';
+
+describe('Alert', () => {
+  test('exposes alert semantics and renders each content region', () => {
+    render(
+      <Alert
+        action={<button type="button">Retry</button>}
+        description="The connection could not be established."
+        title="Connection failed"
+        type="warning"
+        variant="outlined"
+      />,
+    );
+
+    const alert = screen.getByRole('alert');
+
+    expect(alert.dataset.alertType).toBe('warning');
+    expect(alert.dataset.alertVariant).toBe('outlined');
+    expect(screen.getByText('Connection failed')).toBeTruthy();
+    expect(screen.getByText('The connection could not be established.')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeTruthy();
+  });
+
+  test('retains the message alias and forwards the native root ref', () => {
+    let root: HTMLDivElement | null = null;
+
+    render(
+      <Alert
+        message="Legacy message"
+        ref={(node) => {
+          root = node;
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Legacy message')).toBeTruthy();
+    expect(root).toBe(screen.getByRole('alert'));
+  });
+
+  test('dismisses through the close configuration and reports both lifecycle callbacks', () => {
+    const afterClose = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <Alert
+        title="Connection warning"
+        closable={{
+          'aria-label': 'Dismiss connection warning',
+          afterClose,
+          onClose,
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss connection warning' }));
+
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(afterClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('keeps the alert visible when its close affordance is disabled', () => {
+    render(<Alert closable={{ disabled: true }} title="Persistent warning" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close alert' }));
+
+    expect(screen.getByRole('alert')).toBeTruthy();
+  });
+
+  test('reveals integrated details through an accessible disclosure', () => {
+    render(<Alert extra={<pre>ECONNREFUSED 127.0.0.1</pre>} title="Request failed" />);
+
+    const detailRegion = screen
+      .getByText('ECONNREFUSED 127.0.0.1')
+      .closest<HTMLDetailsElement>('details');
+
+    expect(detailRegion?.open).toBe(false);
+
+    fireEvent.click(screen.getByText('Show Details').closest('summary')!);
+
+    expect(detailRegion?.open).toBe(true);
+  });
+});

--- a/src/base-ui/Alert/demos/Extra.tsx
+++ b/src/base-ui/Alert/demos/Extra.tsx
@@ -1,0 +1,32 @@
+import { Flexbox, Highlighter } from '@lobehub/ui';
+import { Alert } from '@lobehub/ui/base-ui';
+
+const details = {
+  code: 'ECONNREFUSED',
+  endpoint: 'https://api.example.com/v1/models',
+  requestId: 'req_7f9a2d',
+};
+
+export default () => (
+  <Flexbox gap={16} padding={16}>
+    <Alert
+      extraDefaultExpand
+      description="Check the service status before retrying."
+      text={{ detail: 'Show technical details' }}
+      title="The model registry could not be reached."
+      type="error"
+      extra={
+        <Highlighter actionIconSize="small" language="json" padding={0} variant="borderless">
+          {JSON.stringify(details, null, 2)}
+        </Highlighter>
+      }
+    />
+    <Alert
+      extraIsolate
+      extra={<span>Check the service status before retrying the request.</span>}
+      title="Maintenance is in progress."
+      type="warning"
+      variant="outlined"
+    />
+  </Flexbox>
+);

--- a/src/base-ui/Alert/demos/Playground.tsx
+++ b/src/base-ui/Alert/demos/Playground.tsx
@@ -1,0 +1,104 @@
+import { Flexbox } from '@lobehub/ui';
+import { Alert, type AlertType, type AlertVariant, Button } from '@lobehub/ui/base-ui';
+import { StoryBook, useControls, useCreateStore } from '@lobehub/ui/storybook';
+import { SlidersHorizontal } from 'lucide-react';
+import { useState } from 'react';
+
+interface PlaygroundControls {
+  banner: boolean;
+  closable: boolean;
+  colorfulText: boolean;
+  description: string;
+  detailsExpanded: boolean;
+  glass: boolean;
+  showIcon: boolean;
+  title: string;
+  type: AlertType;
+  variant: Exclude<AlertVariant, 'borderless' | 'filled'>;
+  withAction: boolean;
+  withDetails: boolean;
+}
+
+const diagnosticDetails = [
+  ['Environment', 'Production'],
+  ['Build', '2026.08.14-rc.3'],
+  ['Request', 'req_7f9a2d'],
+] as const;
+
+export default () => {
+  const store = useCreateStore();
+  const [alertKey, setAlertKey] = useState(0);
+  const control = useControls(
+    {
+      banner: false,
+      closable: true,
+      colorfulText: false,
+      description: 'Review the release notes before promoting this build.',
+      detailsExpanded: false,
+      glass: false,
+      showIcon: true,
+      title: 'A new deployment is ready for review.',
+      type: {
+        label: 'Semantic tone',
+        options: ['info', 'success', 'warning', 'error', 'secondary'],
+        value: 'info',
+      },
+      variant: {
+        label: 'Surface',
+        options: ['soft', 'outlined', 'plain'],
+        value: 'soft',
+      },
+      withAction: true,
+      withDetails: true,
+    },
+    { store },
+  ) as PlaygroundControls;
+
+  const { closable, detailsExpanded, withAction, withDetails, ...alertProps } = control;
+
+  return (
+    <StoryBook levaStore={store}>
+      <Flexbox gap={20} padding={16} style={{ width: '100%' }}>
+        <Flexbox gap={6}>
+          <Flexbox horizontal align="center" gap={8}>
+            <SlidersHorizontal aria-hidden="true" size={16} />
+            <strong>Interactive playground</strong>
+          </Flexbox>
+          <span style={{ fontSize: 13, opacity: 0.65 }}>
+            Adjust the controls to test semantic tone, surface, actions, and diagnostic detail.
+          </span>
+        </Flexbox>
+
+        <Alert
+          {...alertProps}
+          action={withAction ? <Button size="small">Review</Button> : undefined}
+          closable={closable ? { 'aria-label': 'Dismiss playground alert' } : false}
+          extraDefaultExpand={detailsExpanded}
+          key={`${alertKey}-${detailsExpanded}`}
+          text={{ detail: 'Show technical details' }}
+          extra={
+            withDetails ? (
+              <Flexbox gap={6} style={{ fontSize: 12 }}>
+                {diagnosticDetails.map(([label, value]) => (
+                  <Flexbox horizontal justify="space-between" key={label}>
+                    <span style={{ opacity: 0.6 }}>{label}</span>
+                    <code>{value}</code>
+                  </Flexbox>
+                ))}
+              </Flexbox>
+            ) : undefined
+          }
+        />
+
+        <Button
+          aria-label="Restore playground alert"
+          size="small"
+          style={{ alignSelf: 'flex-start' }}
+          onClick={() => setAlertKey((value) => value + 1)}
+        >
+          Restore alert
+        </Button>
+      </Flexbox>
+    </StoryBook>
+  );
+};

--- a/src/base-ui/Alert/demos/index.tsx
+++ b/src/base-ui/Alert/demos/index.tsx
@@ -1,0 +1,54 @@
+import { Flexbox } from '@lobehub/ui';
+import { Alert, Button } from '@lobehub/ui/base-ui';
+import { useState } from 'react';
+
+const types = ['info', 'success', 'warning', 'error', 'secondary'] as const;
+
+export default () => {
+  const [alertKey, setAlertKey] = useState(0);
+
+  return (
+    <Flexbox gap={20} padding={16}>
+      <Flexbox gap={8}>
+        <span style={{ fontSize: 12, opacity: 0.6 }}>Neutral-first semantic tones</span>
+        {types.map((type) => (
+          <Alert
+            description="The supporting description keeps the next action clear."
+            key={type}
+            type={type}
+            title={
+              type === 'secondary'
+                ? 'Neutral notice'
+                : `${type[0].toUpperCase()}${type.slice(1)} notice`
+            }
+          />
+        ))}
+      </Flexbox>
+
+      <Flexbox gap={8}>
+        <span style={{ fontSize: 12, opacity: 0.6 }}>Surface variants</span>
+        <Alert title="Soft surface" type="success" variant="soft" />
+        <Alert title="Outlined surface" type="warning" variant="outlined" />
+        <Alert title="Plain surface" type="secondary" variant="plain" />
+      </Flexbox>
+
+      <Flexbox gap={8}>
+        <span style={{ fontSize: 12, opacity: 0.6 }}>Dismissal and action</span>
+        <Alert
+          action={<Button size="small">Review</Button>}
+          closable={{ 'aria-label': 'Dismiss deployment notice' }}
+          key={alertKey}
+          title="A new deployment is ready for review."
+          type="info"
+        />
+        <Button
+          size="small"
+          style={{ alignSelf: 'flex-start' }}
+          onClick={() => setAlertKey((v) => v + 1)}
+        >
+          Restore dismissed alert
+        </Button>
+      </Flexbox>
+    </Flexbox>
+  );
+};

--- a/src/base-ui/Alert/index.mdx
+++ b/src/base-ui/Alert/index.mdx
@@ -1,0 +1,59 @@
+---
+title: Alert
+description: Neutral-first inline feedback with restrained semantic color, actions, dismissal, and expandable diagnostic detail.
+category: Feedback
+---
+
+import DemoIndex from './demos/index.tsx?demo';
+import DemoExtra from './demos/Extra.tsx?demo';
+import DemoPlayground from './demos/Playground.tsx?demo';
+
+## Playground
+
+<Demo of={DemoPlayground} layout="bare" />
+
+## Visual system
+
+<Demo of={DemoIndex} layout="bare" />
+
+## Diagnostic detail
+
+<Demo of={DemoExtra} layout="bare" />
+
+## API
+
+<Api name="Alert" from=".." />
+
+`Alert` renders a native `role="alert"` region. Default icons are decorative because the semantic type is already expressed by the message and visual tone. Custom `role`, `aria-*`, `data-*`, event handlers, and `ref` are forwarded to the root `<div>`.
+
+The default `soft` surface keeps text and controls neutral while reserving semantic color for the icon and a low-opacity background tint. `outlined` adds a neutral hairline and `plain` removes the surrounding surface. Deprecated `filled` and `borderless` values remain as aliases for `soft` and `plain` during migration.
+
+### Migrating from antd Alert
+
+The core migration is an import replacement:
+
+```tsx | pure
+import { Alert } from '@lobehub/ui/base-ui';
+
+<Alert
+  action={<button>Retry</button>}
+  description="Confirm the endpoint and try again."
+  title="Connection failed"
+  type="error"
+/>;
+```
+
+`message` remains as a deprecated alias for `title`. Boolean `closable`, object-form `closable`, `closeIcon`, `closeText`, top-level `onClose`, and `afterClose` are retained so existing call sites can migrate without losing behavior. Prefer the object form for new code:
+
+```tsx | pure
+<Alert
+  closable={{
+    'aria-label': 'Dismiss connection warning',
+    'afterClose': () => console.log('removed'),
+    'onClose': () => console.log('dismissed'),
+  }}
+  title="Connection warning"
+/>
+```
+
+`extra` adds a compact disclosure for diagnostics. Set `extraIsolate` when the detail is an independent block that should remain visible instead of participating in the disclosure.

--- a/src/base-ui/Alert/index.ts
+++ b/src/base-ui/Alert/index.ts
@@ -1,0 +1,12 @@
+export { default } from './Alert';
+export { default as Alert } from './Alert';
+export { styles as alertStyles } from './style';
+export type {
+  AlertClassNames,
+  AlertCloseConfig,
+  AlertProps,
+  AlertRef,
+  AlertStyles,
+  AlertType,
+  AlertVariant,
+} from './type';

--- a/src/base-ui/Alert/style.ts
+++ b/src/base-ui/Alert/style.ts
@@ -1,0 +1,391 @@
+import { createStaticStyles } from 'antd-style';
+import { cva } from 'class-variance-authority';
+
+import { lobeStaticStylish } from '@/styles';
+
+export const styles = createStaticStyles(({ css, cssVar }) => ({
+  action: css`
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+
+    min-height: 32px;
+    margin-inline-start: auto;
+  `,
+  close: css`
+    cursor: pointer;
+
+    position: relative;
+    scale: 1;
+
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+
+    width: 32px;
+    height: 32px;
+    margin: 0;
+    padding: 0;
+    border: none;
+    border-radius: ${cssVar.borderRadiusSM};
+
+    color: ${cssVar.colorTextTertiary};
+
+    background: transparent;
+
+    transition:
+      color 160ms ${cssVar.motionEaseOut},
+      background-color 160ms ${cssVar.motionEaseOut},
+      scale 160ms ${cssVar.motionEaseOut};
+
+    &::after {
+      content: '';
+
+      position: absolute;
+      inset-block-start: 50%;
+      inset-inline-start: 50%;
+      translate: -50% -50%;
+
+      width: 40px;
+      height: 40px;
+    }
+
+    &:hover:not(:disabled) {
+      color: ${cssVar.colorText};
+      background: ${cssVar.colorFillTertiary};
+    }
+
+    &:active:not(:disabled) {
+      scale: 0.96;
+    }
+
+    &:focus-visible {
+      outline: 2px solid ${cssVar.colorPrimaryBorder};
+      outline-offset: 1px;
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.45;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      transition-duration: 0s;
+    }
+  `,
+  colorfulText: css`
+    color: var(--lobe-alert-accent);
+  `,
+  container: css`
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    max-width: 100%;
+  `,
+  content: css`
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-width: 0;
+  `,
+  description: css`
+    font-size: 13px;
+    line-height: 20px;
+    color: ${cssVar.colorTextSecondary};
+    text-wrap: pretty;
+    overflow-wrap: anywhere;
+  `,
+  detailed: css`
+    padding-block: 12px;
+    padding-inline: 14px;
+  `,
+  extra: css`
+    position: relative;
+    max-width: 100%;
+    color: ${cssVar.colorText};
+  `,
+  extraBanner: css`
+    border-radius: 0;
+  `,
+  extraContent: css`
+    overflow: hidden;
+
+    margin-block: 0 12px;
+    margin-inline: 12px;
+    padding: 8px;
+    border-radius: ${cssVar.borderRadiusSM};
+
+    font-size: 12px;
+    color: ${cssVar.colorText};
+
+    background: ${cssVar.colorFillQuaternary};
+  `,
+  extraHeader: css`
+    cursor: pointer;
+    user-select: none;
+
+    display: flex;
+    gap: 6px;
+    align-items: center;
+
+    min-height: 40px;
+    padding-block: 8px;
+    padding-inline: 14px;
+    border-block-start: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: 0;
+
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 20px;
+    color: ${cssVar.colorTextSecondary};
+
+    background: transparent;
+
+    transition:
+      color 160ms ${cssVar.motionEaseOut},
+      background-color 160ms ${cssVar.motionEaseOut};
+
+    &::marker,
+    &::-webkit-details-marker {
+      content: '';
+      display: none;
+    }
+
+    &:hover {
+      color: ${cssVar.colorText};
+      background: ${cssVar.colorFillQuaternary};
+    }
+
+    &:focus-visible {
+      outline: 2px solid ${cssVar.colorPrimaryBorder};
+      outline-offset: -2px;
+    }
+  `,
+  extraHeaderPlain: css`
+    margin-block-start: 6px;
+    padding-inline: 0;
+    border-block-start-color: ${cssVar.colorBorderSecondary};
+  `,
+  extraIndicator: css`
+    flex-shrink: 0;
+    color: ${cssVar.colorTextTertiary};
+    transition: transform 160ms ${cssVar.motionEaseOut};
+
+    details[open] > summary > & {
+      transform: rotate(90deg);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      transition-duration: 0s;
+    }
+  `,
+  extraPlain: css`
+    background: transparent;
+  `,
+  icon: css`
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+
+    height: 20px;
+
+    color: var(--lobe-alert-accent);
+  `,
+  integrated: css`
+    overflow: hidden;
+    border-radius: ${cssVar.borderRadius};
+  `,
+  neutralText: css`
+    color: ${cssVar.colorText};
+  `,
+  root: css`
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+    align-items: flex-start;
+
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 100%;
+    padding-block: 10px;
+    padding-inline: 12px;
+    border: none;
+    border-radius: ${cssVar.borderRadius};
+
+    font-size: 14px;
+    color: ${cssVar.colorText};
+
+    background: var(--lobe-alert-background);
+    box-shadow: inset 0 0 0 1px var(--lobe-alert-soft-border);
+
+    @media (width <= 480px) {
+      flex-wrap: wrap;
+    }
+  `,
+  soft: css`
+    background: var(--lobe-alert-background);
+    box-shadow: inset 0 0 0 1px var(--lobe-alert-soft-border);
+  `,
+  outlined: css`
+    background: transparent;
+    box-shadow: inset 0 0 0 1px ${cssVar.colorBorderSecondary};
+  `,
+  plain: css`
+    padding-block: 2px;
+    padding-inline: 0;
+    background: transparent;
+    box-shadow: none;
+  `,
+  title: css`
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 20px;
+    color: inherit;
+    text-wrap: pretty;
+    overflow-wrap: anywhere;
+  `,
+  titleDetailed: css`
+    font-weight: 500;
+  `,
+  toneError: css`
+    --lobe-alert-accent: ${cssVar.colorError};
+    --lobe-alert-background: color-mix(
+      in srgb,
+      ${cssVar.colorError} 5%,
+      ${cssVar.colorBgContainer}
+    );
+    --lobe-alert-soft-border: color-mix(in srgb, ${cssVar.colorError} 14%, transparent);
+  `,
+  toneInfo: css`
+    --lobe-alert-accent: ${cssVar.colorInfo};
+    --lobe-alert-background: color-mix(in srgb, ${cssVar.colorInfo} 5%, ${cssVar.colorBgContainer});
+    --lobe-alert-soft-border: color-mix(in srgb, ${cssVar.colorInfo} 14%, transparent);
+  `,
+  toneSecondary: css`
+    --lobe-alert-accent: ${cssVar.colorTextSecondary};
+    --lobe-alert-background: color-mix(
+      in srgb,
+      ${cssVar.colorTextSecondary} 4%,
+      ${cssVar.colorBgContainer}
+    );
+    --lobe-alert-soft-border: color-mix(in srgb, ${cssVar.colorTextSecondary} 12%, transparent);
+  `,
+  toneSuccess: css`
+    --lobe-alert-accent: ${cssVar.colorSuccess};
+    --lobe-alert-background: color-mix(
+      in srgb,
+      ${cssVar.colorSuccess} 5%,
+      ${cssVar.colorBgContainer}
+    );
+    --lobe-alert-soft-border: color-mix(in srgb, ${cssVar.colorSuccess} 14%, transparent);
+  `,
+  toneWarning: css`
+    --lobe-alert-accent: ${cssVar.colorWarning};
+    --lobe-alert-background: color-mix(
+      in srgb,
+      ${cssVar.colorWarning} 5%,
+      ${cssVar.colorBgContainer}
+    );
+    --lobe-alert-soft-border: color-mix(in srgb, ${cssVar.colorWarning} 14%, transparent);
+  `,
+  unifiedRoot: css`
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+  `,
+  banner: css`
+    border-radius: 0;
+    box-shadow: none;
+  `,
+  wrappedAction: css`
+    @media (width <= 480px) {
+      order: 4;
+      width: calc(100% - 30px);
+      margin-block-start: -2px;
+      margin-inline-start: 30px;
+    }
+  `,
+}));
+
+export const toneVariants = cva('', {
+  defaultVariants: { type: 'info' },
+  variants: {
+    type: {
+      error: styles.toneError,
+      info: styles.toneInfo,
+      secondary: styles.toneSecondary,
+      success: styles.toneSuccess,
+      warning: styles.toneWarning,
+    },
+  },
+});
+
+export const rootVariants = cva(styles.root, {
+  compoundVariants: [{ class: styles.unifiedRoot, hasExtra: true }],
+  defaultVariants: {
+    banner: false,
+    colorfulText: false,
+    glass: false,
+    hasDescription: false,
+    hasExtra: false,
+    variant: 'soft',
+  },
+  variants: {
+    banner: { false: null, true: styles.banner },
+    colorfulText: { false: styles.neutralText, true: styles.colorfulText },
+    glass: { false: null, true: lobeStaticStylish.blur },
+    hasDescription: { false: null, true: styles.detailed },
+    hasExtra: { false: null, true: null },
+    variant: {
+      borderless: styles.plain,
+      filled: styles.soft,
+      outlined: styles.outlined,
+      plain: styles.plain,
+      soft: styles.soft,
+    },
+  },
+});
+
+export const integratedVariants = cva(styles.integrated, {
+  defaultVariants: { banner: false, glass: false, variant: 'soft' },
+  variants: {
+    banner: { false: null, true: styles.banner },
+    glass: { false: null, true: lobeStaticStylish.blur },
+    variant: {
+      borderless: styles.extraPlain,
+      filled: styles.soft,
+      outlined: styles.outlined,
+      plain: styles.extraPlain,
+      soft: styles.soft,
+    },
+  },
+});
+
+export const extraVariants = cva(styles.extra, {
+  defaultVariants: { banner: false, variant: 'soft' },
+  variants: {
+    banner: { false: null, true: styles.extraBanner },
+    variant: {
+      borderless: styles.extraPlain,
+      filled: null,
+      outlined: null,
+      plain: styles.extraPlain,
+      soft: null,
+    },
+  },
+});
+
+export const extraHeaderVariants = cva(styles.extraHeader, {
+  defaultVariants: { variant: 'soft' },
+  variants: {
+    variant: {
+      borderless: styles.extraHeaderPlain,
+      filled: null,
+      outlined: null,
+      plain: styles.extraHeaderPlain,
+      soft: null,
+    },
+  },
+});

--- a/src/base-ui/Alert/type.ts
+++ b/src/base-ui/Alert/type.ts
@@ -1,0 +1,129 @@
+import type {
+  ButtonHTMLAttributes,
+  CSSProperties,
+  HTMLAttributes,
+  MouseEventHandler,
+  ReactNode,
+  Ref,
+} from 'react';
+
+import type { IconProps } from '@/Icon';
+
+export type AlertType = 'success' | 'info' | 'warning' | 'error' | 'secondary';
+export type AlertVariant =
+  | 'soft'
+  | 'outlined'
+  | 'plain'
+  /** @deprecated Use `soft` instead. */
+  | 'filled'
+  /** @deprecated Use `plain` instead. */
+  | 'borderless';
+export type AlertRef = HTMLDivElement;
+
+export interface AlertCloseConfig extends Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  'children' | 'onClick' | 'type'
+> {
+  /** Called after the alert has been removed from the document. */
+  afterClose?: () => void;
+  /** Custom close affordance. */
+  closeIcon?: ReactNode;
+  /** Called when the close affordance is activated. */
+  onClose?: MouseEventHandler<HTMLButtonElement>;
+}
+
+export interface AlertClassNames {
+  action?: string;
+  /** @deprecated Use `root` instead. */
+  alert?: string;
+  close?: string;
+  container?: string;
+  content?: string;
+  description?: string;
+  extra?: string;
+  extraContent?: string;
+  extraHeader?: string;
+  extraIndicator?: string;
+  icon?: string;
+  root?: string;
+  /** Alias for `content`, matching the former antd semantic part. */
+  section?: string;
+  title?: string;
+}
+
+export interface AlertStyles {
+  action?: CSSProperties;
+  /** @deprecated Use `root` instead. */
+  alert?: CSSProperties;
+  close?: CSSProperties;
+  container?: CSSProperties;
+  content?: CSSProperties;
+  description?: CSSProperties;
+  extra?: CSSProperties;
+  extraContent?: CSSProperties;
+  extraHeader?: CSSProperties;
+  extraIndicator?: CSSProperties;
+  icon?: CSSProperties;
+  root?: CSSProperties;
+  /** Alias for `content`, matching the former antd semantic part. */
+  section?: CSSProperties;
+  title?: CSSProperties;
+}
+
+interface AlertOwnProps {
+  /** Optional action rendered after the message content. */
+  action?: ReactNode;
+  /** @deprecated Use `closable.afterClose` instead. */
+  afterClose?: () => void;
+  /** Removes the side border and radius for full-width notices. */
+  banner?: boolean;
+  classNames?: AlertClassNames;
+  /** Whether the alert can be dismissed. */
+  closable?: AlertCloseConfig | boolean;
+  /** @deprecated Use `closable.closeIcon` instead. */
+  closeIcon?: ReactNode;
+  /** @deprecated Use `closable.closeIcon` instead. */
+  closeText?: ReactNode;
+  /** Whether the title adopts the semantic color. Neutral text is used by default. */
+  colorfulText?: boolean;
+  /** Supporting detail displayed beneath the title. */
+  description?: ReactNode;
+  /** Optional expandable or isolated detail content. */
+  extra?: ReactNode;
+  /** Whether expandable detail content starts open. */
+  extraDefaultExpand?: boolean;
+  /** Renders detail content as an independent sibling instead of a disclosure. */
+  extraIsolate?: boolean;
+  /** Enables backdrop blur for translucent host surfaces. */
+  glass?: boolean;
+  /** Custom semantic icon. */
+  icon?: IconProps['icon'];
+  /** Props forwarded to the Icon component. */
+  iconProps?: Omit<IconProps, 'icon'>;
+  /** @deprecated Use `title` instead. */
+  message?: ReactNode;
+  /** @deprecated Use `closable.onClose` instead. */
+  onClose?: MouseEventHandler<HTMLButtonElement>;
+  ref?: Ref<AlertRef>;
+  /** Alias for `className`, retained for migration compatibility. */
+  rootClassName?: string;
+  /** Whether the semantic icon is rendered. */
+  showIcon?: boolean;
+  styles?: AlertStyles;
+  text?: {
+    detail?: string;
+  };
+  /** Primary message content. */
+  title?: ReactNode;
+  /** Semantic tone. */
+  type?: AlertType;
+  /** Surface treatment. `filled` and `borderless` remain as migration aliases. */
+  variant?: AlertVariant;
+}
+
+type NativeAlertProps = Omit<
+  HTMLAttributes<HTMLDivElement>,
+  keyof AlertOwnProps | 'children' | 'title'
+>;
+
+export type AlertProps = AlertOwnProps & NativeAlertProps;

--- a/src/base-ui/index.ts
+++ b/src/base-ui/index.ts
@@ -1,3 +1,4 @@
+export * from './Alert';
 export * from './AutoComplete';
 export { default as Button } from './Button';
 export * from './Button';


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

- Add the Base UI Alert implementation with neutral-first semantic surfaces, actions, dismissal, and expandable diagnostic detail.
- Preserve migration compatibility for legacy Alert properties and variants while exposing the component from `@lobehub/ui/base-ui`.
- Add static examples, an interactive Playground, API and migration documentation, and the corresponding navigation and compatibility records.
- Use the standard 8px design-system radius for both standalone and integrated diagnostic Alert surfaces.

This migration replaces the Ant Design-dependent Alert surface with a first-party Base UI component while retaining the compatibility required for incremental adoption. The documentation demonstrates the intended visual hierarchy and permits direct testing of tone, surface, action, dismissal, and diagnostic states.

#### 📝 补充信息 | Additional Information

Validation:

- Focused Vitest suite: 3 files, 29 tests passed
- Library and documentation TypeScript configurations passed
- ESLint, Stylelint, circular dependency analysis, formatting, and `git diff --check` passed
- Production documentation build passed; canonical and standalone Alert routes were prerendered
- Browser verification passed in light, dark, and 390×844 mobile viewports
- [Alert acceptance: 4/4 checks passed](https://app.lobehub.com/verify/3e704bf4-ac01-4e3e-9499-b07f94ef5d26)
