### PR TITLE
♻️ refactor(eslint): ban legacy Alert imports

### DIFF
--- a/src/eslint/index.test.ts
+++ b/src/eslint/index.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+
+import { Linter } from 'eslint';
+
+import { restrictedImports } from './index';
+
+const lint = (code: string) => {
+  const linter = new Linter({ configType: 'flat' });
+
+  return linter.verify(code, {
+    languageOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+    rules: {
+      'no-restricted-imports': restrictedImports.rules['no-restricted-imports'] as Linter.RuleEntry,
+    },
+  });
+};
+
+describe('restrictedImports', () => {
+  it.each([
+    [
+      '@lobehub/ui root',
+      "import { Alert } from '@lobehub/ui';",
+      'The antd-based wrapper is deprecated.',
+    ],
+    ['antd', "import { Alert } from 'antd';", 'Direct antd import is deprecated.'],
+    [
+      'antd component path',
+      "import Alert from 'antd/es/alert';",
+      'Direct antd component import is deprecated.',
+    ],
+  ])('rejects Alert from %s', (_, code, message) => {
+    expect(lint(code)).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining(message),
+        ruleId: 'no-restricted-imports',
+        severity: 2,
+      }),
+    ]);
+  });
+
+  it('allows Alert from the Base UI entrypoint', () => {
+    expect(lint("import { Alert } from '@lobehub/ui/base-ui';")).toEqual([]);
+  });
+});

--- a/src/eslint/index.ts
+++ b/src/eslint/index.ts
@@ -1,4 +1,5 @@
 const DEPRECATED_UI_COMPONENTS = [
+  'Alert',
   'AutoComplete',
   'Button',
   'Checkbox',
@@ -15,6 +16,8 @@ const DEPRECATED_UI_COMPONENTS = [
 ];
 
 const DEPRECATED_ANTD_COMPONENT_PATHS = [
+  'antd/es/alert',
+  'antd/es/alert/*',
   'antd/es/auto-complete',
   'antd/es/auto-complete/*',
   'antd/es/checkbox',
@@ -23,6 +26,8 @@ const DEPRECATED_ANTD_COMPONENT_PATHS = [
   'antd/es/radio/*',
   'antd/es/slider',
   'antd/es/slider/*',
+  'antd/lib/alert',
+  'antd/lib/alert/*',
   'antd/lib/auto-complete',
   'antd/lib/auto-complete/*',
   'antd/lib/checkbox',


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

- Add `Alert` to the restricted imports for the legacy `@lobehub/ui` entrypoint and direct `antd` imports.
- Restrict `antd/es/alert` and `antd/lib/alert` deep imports.
- Add behavior-oriented ESLint tests that reject legacy entrypoints while allowing `@lobehub/ui/base-ui`.

This prevents new usages of the antd-backed Alert after the Base UI implementation became available.

#### 📝 补充信息 | Additional Information

Validation:

- `vitest run src/eslint/index.test.ts` — 4 tests passed
- `tsc --noEmit --pretty false`
- `eslint src/eslint/index.ts src/eslint/index.test.ts` — 0 errors
- `git diff --check`
