### PR TITLE
🐛 fix(alert): align single-line actions

### DIFF
--- a/src/Alert/Alert.test.tsx
+++ b/src/Alert/Alert.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+
+import Button from '@/Button';
+
+import Alert from './Alert';
+
+describe('Alert', () => {
+  test('centers single-line content with its action and close control', () => {
+    render(
+      <Alert
+        closable
+        action={<Button size={'small'}>Regenerate</Button>}
+        title={'Provider connection failed during the final response'}
+      />,
+    );
+
+    expect(getComputedStyle(screen.getByRole('alert')).alignItems).toBe('center');
+  });
+
+  test('keeps multi-line content top-aligned', () => {
+    render(
+      <Alert
+        action={<Button size={'small'}>Review</Button>}
+        description={'The provider rejected the request.'}
+        title={'Connection failed'}
+      />,
+    );
+
+    expect(getComputedStyle(screen.getByRole('alert')).alignItems).toBe('flex-start');
+  });
+});

--- a/src/Alert/demos/Extra.tsx
+++ b/src/Alert/demos/Extra.tsx
@@ -1,5 +1,6 @@
-import { Alert, type AlertProps, Highlighter } from '@lobehub/ui';
+import { Alert, type AlertProps, Button, Highlighter } from '@lobehub/ui';
 import { StoryBook, useControls, useCreateStore } from '@lobehub/ui/storybook';
+import { RefreshCw } from 'lucide-react';
 
 const demoError = {
   details: {
@@ -18,13 +19,13 @@ export default () => {
   const control = useControls(
     {
       banner: false,
-      closable: false,
+      closable: true,
       colorfulText: true,
-      description: 'Alert Title',
+      description: '',
       extraIsolate: false,
       glass: false,
       showIcon: true,
-      title: 'Informational Notes',
+      title: 'Provider connection failed during the final response',
       type: {
         options: ['info', 'success', 'warning', 'error', 'secondary'],
         value: 'secondary',
@@ -39,6 +40,11 @@ export default () => {
   return (
     <StoryBook levaStore={store}>
       <Alert
+        action={
+          <Button icon={RefreshCw} size={'small'}>
+            Regenerate
+          </Button>
+        }
         extra={
           <Highlighter
             actionIconSize={'small'}

--- a/src/Alert/style.ts
+++ b/src/Alert/style.ts
@@ -85,6 +85,9 @@ export const styles = createStaticStyles(({ css, cssVar }) => {
         margin: 0;
       }
     `,
+    rootSingleLine: css`
+      align-items: center;
+    `,
     rootNoTitleNoIconNoClosable: css`
       gap: 8px;
       padding-block: 8px;
@@ -296,7 +299,7 @@ export const rootVariants = cva(styles.rootBase, {
       true: styles.glass,
     },
     hasTitle: {
-      false: null,
+      false: styles.rootSingleLine,
       true: null,
     },
     showIcon: {


### PR DESCRIPTION
## Summary

- vertically center single-line Alert titles, icons, actions, and close controls
- preserve top alignment for Alerts with descriptions
- update the Extra demo to reproduce the downstream title/action/closable/extra composition
- add regression coverage for both layout modes

## Root cause

The Alert root always used `align-items: flex-start`. A single-line title uses a 24px line box while its action control is taller, so top alignment placed their visual centers on different axes.

## Validation

- `bun x vitest run src/Alert/Alert.test.tsx`
- `bun run type-check`
- focused ESLint: 0 errors (one existing demo default-export warning)
- focused Stylelint and Prettier
- `git diff --check`
- browser verification on the manifest-backed Alert demo in light/dark desktop and 390×844 mobile viewports; desktop title/icon/action/close center deltas are 0px