### PR TITLE
✨ feat(base-ui): support programmatic open for PopoverGroup members

### DIFF
--- a/src/base-ui/Popover/PopoverInGroup.tsx
+++ b/src/base-ui/Popover/PopoverInGroup.tsx
@@ -39,6 +39,7 @@ export const PopoverInGroup: FC<PopoverProps> = ({ children, ref: refProp, ...pr
     delay: resolvedOpenDelay,
     disabled,
     openOnHover: openOnHover && !disabled,
+    ...item.triggerProps,
     payload: item,
   };
 

--- a/src/base-ui/Popover/__tests__/groupProgrammaticOpen.test.tsx
+++ b/src/base-ui/Popover/__tests__/groupProgrammaticOpen.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { motion } from 'motion/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import ConfigProvider from '@/ConfigProvider';
+
+import { usePopoverGroupHandle } from '../groupContext';
+import Popover from '../Popover';
+import PopoverGroup from '../PopoverGroup';
+
+vi.mock('antd-style', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('antd-style')>();
+  return {
+    ...actual,
+    createStaticStyles: vi.fn((fn: any) => {
+      const result = fn({ css: () => '', cssVar: {} });
+      return new Proxy(result, {
+        get: (target, key) => target[key as keyof typeof target] || '',
+      });
+    }),
+  };
+});
+
+const renderWithProvider = (node: ReactNode) =>
+  render(<ConfigProvider motion={motion}>{node}</ConfigProvider>);
+
+const OpenByIdButton = ({ targetId }: { targetId: string }) => {
+  const handle = usePopoverGroupHandle();
+
+  return (
+    <button type="button" onClick={() => handle?.open(targetId)}>
+      open-remotely
+    </button>
+  );
+};
+
+describe('PopoverGroup programmatic open', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('forwards triggerProps to the grouped trigger', () => {
+    renderWithProvider(
+      <PopoverGroup>
+        <Popover content={<div>card</div>} triggerProps={{ id: 'row-1' }}>
+          <button type="button">row</button>
+        </Popover>
+      </PopoverGroup>,
+    );
+
+    expect(screen.getByRole('button', { name: 'row' }).id).toBe('row-1');
+  });
+
+  it('opens a grouped popover by trigger id through the group handle', async () => {
+    renderWithProvider(
+      <PopoverGroup>
+        <Popover content={<div>card-1</div>} trigger="click" triggerProps={{ id: 'row-1' }}>
+          <button type="button">row-1</button>
+        </Popover>
+        <Popover content={<div>card-2</div>} trigger="click" triggerProps={{ id: 'row-2' }}>
+          <button type="button">row-2</button>
+        </Popover>
+        <OpenByIdButton targetId="row-2" />
+      </PopoverGroup>,
+    );
+
+    expect(screen.queryByText('card-2')).toBeNull();
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'open-remotely' }).click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('card-2')).toBeTruthy();
+    });
+
+    expect(screen.queryByText('card-1')).toBeNull();
+  });
+
+  it('returns null outside a group so callers can fall back', () => {
+    const seen: unknown[] = [];
+    const Probe = () => {
+      seen.push(usePopoverGroupHandle());
+      return null;
+    };
+
+    renderWithProvider(<Probe />);
+
+    expect(seen).toEqual([null]);
+  });
+});

--- a/src/base-ui/Popover/groupContext.ts
+++ b/src/base-ui/Popover/groupContext.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import type { Popover as BasePopover } from '@base-ui/react/popover';
-import { createContext } from 'react';
+import { createContext, use } from 'react';
 
 import type { PopoverProps } from './type';
 
@@ -32,3 +32,10 @@ export type PopoverGroupHandle = ReturnType<typeof BasePopover.createHandle<Popo
 
 export const PopoverGroupHandleContext = createContext<PopoverGroupHandle | null>(null);
 export const PopoverGroupPropsContext = createContext<PopoverGroupSharedProps | null>(null);
+
+/**
+ * Handle of the enclosing `PopoverGroup`, or `null` outside one. Lets a trigger's
+ * neighbourhood drive the shared popup imperatively — `open(triggerId)` needs the
+ * trigger to carry a matching `triggerProps.id`.
+ */
+export const usePopoverGroupHandle = () => use(PopoverGroupHandleContext);

--- a/src/base-ui/Popover/index.mdx
+++ b/src/base-ui/Popover/index.mdx
@@ -124,3 +124,30 @@ type PopoverContextValue = {
 | disableDestroyOnInvalidTrigger | Disable auto-destroy when the active trigger becomes invalid (e.g. disconnected / `display: none`) | `boolean` | `false` |
 | disableZeroOriginGuard | Disable the visual guard that hides the popup when it falls back to viewport (0,0) | `boolean` | `false` |
 | ...props | Shared popover props applied to each group member | `Omit<PopoverProps, 'children' \| 'defaultOpen' \| 'open' \| 'ref' \| 'content'>` | - |
+
+### usePopoverGroupHandle
+
+Returns the enclosing `PopoverGroup`'s handle, or `null` outside one. Use it to drive the shared popup imperatively — for example opening a member from a keyboard shortcut or a context menu, which the group's own `hover` / `click` triggers cannot express.
+
+`open()` addresses a member by its trigger id, so give that member a `triggerProps.id`:
+
+```tsx
+const handle = usePopoverGroupHandle();
+
+<PopoverGroup>
+  <Popover content={<Menu />} trigger="click" triggerProps={{ id: 'row-1' }}>
+    <button type="button">Row 1</button>
+  </Popover>
+</PopoverGroup>;
+
+handle?.open('row-1');
+handle?.close();
+```
+
+```ts
+type PopoverGroupHandle = {
+  open: (triggerId: string) => void;
+  close: () => void;
+  readonly isOpen: boolean;
+};
+```

--- a/src/base-ui/Popover/index.ts
+++ b/src/base-ui/Popover/index.ts
@@ -17,6 +17,8 @@ export {
 } from './atoms';
 export type { PopoverContextValue } from './context';
 export { PopoverProvider, usePopoverContext } from './context';
+export type { PopoverGroupHandle, PopoverGroupItem } from './groupContext';
+export { usePopoverGroupHandle } from './groupContext';
 export { default, parseTrigger } from './Popover';
 export { default as PopoverGroup } from './PopoverGroup';
 export { usePopoverPortalContainer } from './PopoverPortal';

--- a/src/index.ts
+++ b/src/index.ts
@@ -287,6 +287,8 @@ export {
   PopoverBackdrop,
   type PopoverContextValue,
   PopoverGroup,
+  type PopoverGroupHandle,
+  type PopoverGroupItem,
   type PopoverPlacement,
   PopoverPopup,
   type PopoverPopupAtomProps,
@@ -303,6 +305,7 @@ export {
   PopoverViewport,
   type PopoverViewportAtomProps,
   usePopoverContext,
+  usePopoverGroupHandle,
   usePopoverPortalContainer,
 } from './Popover';
 export { I18nProvider, type I18nProviderProps, LobeUIProvider, useTranslation } from './Provider';


### PR DESCRIPTION
## What

`PopoverGroup` gives N triggers a single shared popup, which makes "at most one open" a structural guarantee instead of a convention. But two gaps kept that guarantee out of reach for anything beyond plain `hover` / `click`:

1. **`PopoverInGroup` silently dropped `triggerProps`.** `useMergedPopoverProps` computes it, `PopoverStandalone` spreads it — the group branch never used it. So a grouped member could not be given a trigger `id`.
2. **The group handle was never exposed.** `PopoverGroup` creates it internally and `PopoverGroupHandleContext` was not exported, so `open(triggerId)` / `close()` were unreachable from consumer code.

Together those meant any interaction the group's own triggers cannot express — context menu, keyboard shortcut, "open this row's menu from elsewhere" — forced callers back onto `standalone` popovers plus hand-rolled mutual exclusion.

## Changes

- `PopoverInGroup`: forward `item.triggerProps`, matching `PopoverStandalone`'s existing `...triggerProps` spread. `payload` stays last, and the prop type already omits `payload` / `handle`, so the group wiring can't be clobbered.
- Export `usePopoverGroupHandle()` (plus `PopoverGroupHandle` / `PopoverGroupItem` types) from `@lobehub/ui` and `@lobehub/ui/base-ui`. Returns `null` outside a group so callers can fall back.
- Document both in `Popover/index.mdx`.

```tsx
const handle = usePopoverGroupHandle();

<PopoverGroup>
  <Popover content={<Menu />} trigger="click" triggerProps={{ id: 'row-1' }}>
    <button type="button">Row 1</button>
  </Popover>
</PopoverGroup>;

handle?.open('row-1');
```

## Why it matters

Found while fixing a bug in lobe-chat's skill list: a row's hover detail card and that row's "..." menu are anchored to the same spot, and because z-index is newest-wins, the hover card could open on top of the menu and swallow the click meant for it. The list had grown ~40 independent `standalone` popovers plus a `window` event bus and a 600ms suppression window to fake mutual exclusion — machinery that `PopoverGroup` makes unnecessary, except the policy menu needs programmatic open and therefore couldn't join the group.

## Test plan

- New `src/base-ui/Popover/__tests__/groupProgrammaticOpen.test.tsx` — 3 cases: `triggerProps` reaches the DOM trigger, `handle.open(id)` opens that member (and closes the previously open one), hook returns `null` outside a group. Reverting the `...item.triggerProps` line fails 2 of the 3.
- `vitest run src/base-ui` — 25 files / 137 tests pass.
- `tsc --noEmit` clean, `eslint` clean, `dpdm` reports no circular dependency.

> Note: running vitest at the repo root also globs into `.claude/worktrees/fix-bun-workspaces`, which carries its own mismatched `node_modules/.bun` and fails ~48 unrelated tests. Results above exclude it.