### PR TITLE
🐛 fix(base-ui): open click triggers inside a PopoverGroup

### DIFF
--- a/src/base-ui/Popover/PopoverGroup.tsx
+++ b/src/base-ui/Popover/PopoverGroup.tsx
@@ -25,7 +25,7 @@ import {
   PopoverGroupPropsContext,
   type PopoverGroupSharedProps,
 } from './groupContext';
-import { shouldCancelHoverOnlyPressOpen } from './hoverOnlyPress';
+import { isHoverOnlyTriggerElement, shouldCancelHoverOnlyPressOpen } from './hoverOnlyPress';
 import { usePopoverPortalContainer } from './PopoverPortal';
 
 type PopoverGroupProps = PopoverGroupSharedProps & {
@@ -57,9 +57,20 @@ const PopoverGroup: FC<PopoverGroupProps> = ({
   const contextValue = useMemo(() => ({ close }), [close]);
 
   const handleOpenChange = useCallback(
-    (nextOpen: boolean, eventDetails?: { cancel?: () => void; reason?: string }) => {
+    (
+      nextOpen: boolean,
+      eventDetails?: { cancel?: () => void; reason?: string; trigger?: unknown },
+    ) => {
       const item = activeItemRef.current;
-      const { openOnClick } = parseTrigger(item?.trigger ?? 'hover');
+      // The press belongs to the trigger that fired it, which is not necessarily
+      // the member currently showing — judging by `activeItemRef` cancels every
+      // click member's first press, since the active one is a hover member (or
+      // none, which also reads as hover-only).
+      const hoverOnlyTrigger = isHoverOnlyTriggerElement(eventDetails?.trigger);
+      const openOnClick =
+        hoverOnlyTrigger === null
+          ? parseTrigger(item?.trigger ?? 'hover').openOnClick
+          : !hoverOnlyTrigger;
 
       if (shouldCancelHoverOnlyPressOpen(openOnClick, nextOpen, eventDetails?.reason)) {
         eventDetails?.cancel?.();

--- a/src/base-ui/Popover/PopoverInGroup.tsx
+++ b/src/base-ui/Popover/PopoverInGroup.tsx
@@ -11,6 +11,7 @@ import { useNativeButton } from '@/hooks/useNativeButton';
 import { parseTrigger } from '@/utils/parseTrigger';
 
 import { PopoverGroupHandleContext } from './groupContext';
+import { HOVER_ONLY_TRIGGER_ATTR } from './hoverOnlyPress';
 import { type PopoverProps } from './type';
 import { useMergedPopoverProps } from './useMergedPopoverProps';
 
@@ -18,7 +19,10 @@ export const PopoverInGroup: FC<PopoverProps> = ({ children, ref: refProp, ...pr
   const group = use(PopoverGroupHandleContext);
   const item = useMergedPopoverProps(props);
 
-  const { openOnHover } = useMemo(() => parseTrigger(item.trigger ?? 'hover'), [item.trigger]);
+  const { openOnClick, openOnHover } = useMemo(
+    () => parseTrigger(item.trigger ?? 'hover'),
+    [item.trigger],
+  );
 
   const resolvedOpenDelay = item.openDelay ?? (item.mouseEnterDelay ?? 0.1) * 1000;
   const resolvedCloseDelay = item.closeDelay ?? (item.mouseLeaveDelay ?? 0.1) * 1000;
@@ -35,6 +39,7 @@ export const PopoverInGroup: FC<PopoverProps> = ({ children, ref: refProp, ...pr
   }
 
   const triggerProps = {
+    [HOVER_ONLY_TRIGGER_ATTR]: openOnClick ? undefined : '',
     closeDelay: resolvedCloseDelay,
     delay: resolvedOpenDelay,
     disabled,

--- a/src/base-ui/Popover/__tests__/groupClickTrigger.test.tsx
+++ b/src/base-ui/Popover/__tests__/groupClickTrigger.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { motion } from 'motion/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import ConfigProvider from '@/ConfigProvider';
+
+import Popover from '../Popover';
+import PopoverGroup from '../PopoverGroup';
+
+vi.mock('antd-style', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('antd-style')>();
+  return {
+    ...actual,
+    createStaticStyles: vi.fn((fn: any) => {
+      const result = fn({ css: () => '', cssVar: {} });
+      return new Proxy(result, {
+        get: (target, key) => target[key as keyof typeof target] || '',
+      });
+    }),
+  };
+});
+
+const renderWithProvider = (node: ReactNode) =>
+  render(<ConfigProvider motion={motion}>{node}</ConfigProvider>);
+
+describe('PopoverGroup click triggers', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('opens a click member on the first press', async () => {
+    renderWithProvider(
+      <PopoverGroup>
+        <Popover content={<div>hover-card</div>}>
+          <button type="button">hover-row</button>
+        </Popover>
+        <Popover content={<div>click-menu</div>} trigger="click">
+          <button type="button">click-row</button>
+        </Popover>
+      </PopoverGroup>,
+    );
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'click-row' }).click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('click-menu')).toBeTruthy();
+    });
+  });
+
+  it('opens a click member while a hover member is the active one', async () => {
+    const { container } = renderWithProvider(
+      <PopoverGroup>
+        <Popover content={<div>hover-card</div>} mouseEnterDelay={0}>
+          <button type="button">hover-row</button>
+        </Popover>
+        <Popover content={<div>click-menu</div>} trigger="click">
+          <button type="button">click-row</button>
+        </Popover>
+      </PopoverGroup>,
+    );
+
+    const hoverRow = screen.getByRole('button', { name: 'hover-row' });
+    await act(async () => {
+      hoverRow.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+      hoverRow.dispatchEvent(new MouseEvent('mousemove', { bubbles: true }));
+    });
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'click-row' }).click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('click-menu')).toBeTruthy();
+    });
+    expect(container).toBeTruthy();
+  });
+});

--- a/src/base-ui/Popover/hoverOnlyPress.ts
+++ b/src/base-ui/Popover/hoverOnlyPress.ts
@@ -11,3 +11,17 @@ export function shouldCancelHoverOnlyPressOpen(
 ): boolean {
   return !openOnClick && nextOpen && reason === 'trigger-press';
 }
+
+/**
+ * Stamped on a grouped trigger that only opens on hover. The group arbitrates
+ * open changes for every member from one handler, and the event only carries the
+ * trigger element — without this it cannot tell which member the press belongs to
+ * and would judge it by whichever member happens to be active.
+ */
+export const HOVER_ONLY_TRIGGER_ATTR = 'data-hover-only-trigger';
+
+export function isHoverOnlyTriggerElement(trigger: unknown): boolean | null {
+  if (typeof Element === 'undefined' || !(trigger instanceof Element)) return null;
+
+  return trigger.hasAttribute(HOVER_ONLY_TRIGGER_ATTR);
+}


### PR DESCRIPTION
A `Popover` with `trigger="click"` inside a `PopoverGroup` never opens on press.

### Why

`PopoverGroup` arbitrates every member's open change in one handler, and that handler decided whether the press was allowed by reading the trigger mode off `activeItemRef` — the member currently showing, not the one being pressed:

```ts
const item = activeItemRef.current;
const { openOnClick } = parseTrigger(item?.trigger ?? 'hover');

if (shouldCancelHoverOnlyPressOpen(openOnClick, nextOpen, eventDetails?.reason)) {
  eventDetails?.cancel?.();   // ← cancels the open
```

With the shared popup closed, `activeItemRef.current` is `null`, which falls back to `'hover'` → `openOnClick: false`. A press then arrives as `reason: 'trigger-press'` with `nextOpen: true`, the hover-only guard matches, and the open is cancelled. Same outcome when a hover card is the active member. Only a click member pressed while *another click member* was active ever got through — which is why this looked intermittent.

Observed in an app before the cause was clear: the press reached the button (`pointerdown`/`mousedown`/`click` all fired on it), `openMethod` was updated, but `store.state.open` stayed `false` and no popup element was ever inserted. `handle.open(triggerId)` on the same member worked, because its reason is `imperative-action`.

### Fix

The press belongs to the trigger that fired it, and `eventDetails.trigger` carries that element — so hover-only members stamp `data-hover-only-trigger` on their trigger, and the group reads the flag off the incoming element instead of the active item. When no element is available it falls back to the previous behaviour.

The marker and the rule live together in `hoverOnlyPress.ts`.

### Test

`__tests__/groupClickTrigger.test.tsx`, two cases — both fail before this change (`aria-expanded="false"` after the click), both pass after:

- a click member opens on its first press
- a click member opens while a hover member is the active one

```
groupClickTrigger   2 passed   (2 failed before)
Popover suite       8 passed
```

Also verified against a real app: with a locally built `es/`, pressing a grouped click trigger inside a menu now yields `open: true`, `activeTriggerId` set, `reason: trigger-press`, and the popup mounts.
