### PR TITLE
🐛 fix(mobile): size ChatHeader to its container instead of the viewport

### DIFF
--- a/src/mobile/ChatHeader/index.mdx
+++ b/src/mobile/ChatHeader/index.mdx
@@ -8,7 +8,7 @@ import DemoIndex from './demos/index.tsx?demo';
 
 ## Default
 
-<Demo of={DemoIndex} layout="center" />
+<Demo of={DemoIndex} layout="bare" />
 
 ## APIs
 

--- a/src/mobile/ChatHeader/style.ts
+++ b/src/mobile/ChatHeader/style.ts
@@ -8,7 +8,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => {
     container: css`
       overflow: hidden;
       flex: none;
-      width: 100vw;
+      width: 100%;
       background: ${cssVar.colorBgLayout};
     `,
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

`ChatHeader` used `width: 100vw`, so it sized to the browser window instead of its parent and overflowed any narrower container. On the docs page this clipped the title text and added a horizontal scrollbar. Changed to `width: 100%`.

Also switched the demo to `layout="bare"`, since `layout="center"` shrink-wraps a full-width bar. Matches `ChatInputArea` and `TabBar`.

**Before:** header rendered 1200px wide inside a 543px frame, so `Title` was cut to `Titl` and a horizontal scrollbar appeared.

https://github.com/user-attachments/assets/31bcca84-03ec-4dd4-bac2-05325099c262


**After:** header fills its 543px frame, text intact, no overflow.

https://github.com/user-attachments/assets/d03dc176-75e7-4091-b415-d9888b83caa3


#### 📝 补充信息 | Additional Information

`TabBar` and `SafeArea` have the same `100vw`; left out to keep this scoped.
