### PR TITLE
✨ feat(static-css): add static antd css extraction entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,22 @@
       "types": "./es/eslint/index.d.mts",
       "import": "./es/eslint/index.mjs"
     },
+    "./static-css": {
+      "types": "./es/static-css/index.d.mts",
+      "import": "./es/static-css/index.mjs"
+    },
+    "./static-css/emit": {
+      "types": "./es/static-css/emit/index.d.mts",
+      "import": "./es/static-css/emit/index.mjs"
+    },
+    "./static-css/runtime": {
+      "types": "./es/static-css/runtime/index.d.mts",
+      "import": "./es/static-css/runtime/index.mjs"
+    },
+    "./static-css/vite": {
+      "types": "./es/static-css/vite/index.d.mts",
+      "import": "./es/static-css/vite/index.mjs"
+    },
     "./es/*": {
       "types": "./es/*.d.mts",
       "import": "./es/*.mjs"

--- a/src/static-css/README.md
+++ b/src/static-css/README.md
@@ -1,0 +1,87 @@
+# @lobehub/ui/static-css
+
+Build-time extraction of antd component styles and LobeHub theme token palettes into cacheable static stylesheets, so SSR HTML no longer carries them inline on every page.
+
+Requires antd v6 cssVar mode: extracted style rules are theme-agnostic `var(--ant-*)` references. The probe theme and the runtime `ConfigProvider` theme must be the same object shape — the token hash decides whether SSR style keys match the extracted ones.
+
+## Entries
+
+| Entry                            | Runs at                | Purpose                                                                              |
+| -------------------------------- | ---------------------- | ------------------------------------------------------------------------------------ |
+| `@lobehub/ui/static-css`         | build time (Node only) | `buildAntdStaticCss`, `buildThemeVarsCss`, probe registry, usage scanner             |
+| `@lobehub/ui/static-css/runtime` | SSR server             | `buildInlineAntdStyle` — swaps antd-style's inline antd entry                        |
+| `@lobehub/ui/static-css/vite`    | vite config            | virtual modules `virtual:lobehub/antd-static-css` + `virtual:lobehub/theme-vars-css` |
+| `@lobehub/ui/static-css/emit`    | dedicated build script | writes `antd.css` / `theme-vars.css` / manifest under production semantics           |
+
+## Vite
+
+```ts
+import { lobeStaticCssPlugin } from '@lobehub/ui/static-css/vite';
+
+export default defineConfig({
+  plugins: [lobeStaticCssPlugin()],
+});
+```
+
+```ts
+import { css, href, styleKeys } from 'virtual:lobehub/antd-static-css';
+```
+
+Ambient types for the virtual modules:
+
+```ts
+declare module 'virtual:lobehub/antd-static-css' {
+  export const css: string;
+  export const href: string;
+  export const styleKeys: string[];
+}
+
+declare module 'virtual:lobehub/theme-vars-css' {
+  export const css: string;
+  export const href: string;
+}
+```
+
+Serve `css` from a route at `href`'s pathname, link it render-blocking, and cache it immutable — the href embeds a content hash.
+
+## SSR
+
+```ts
+import { extractStaticStyle } from 'antd-style';
+import { buildInlineAntdStyle } from '@lobehub/ui/static-css/runtime';
+
+const { html, uncovered } = buildInlineAntdStyle(extractStaticStyle.cache, { styleKeys });
+// inject `html` into <head>; `uncovered` names components that fell back inline —
+// add them to `extraIncluded` (or the registry) so their rules ship statically.
+```
+
+Component css-var blocks always stay inline (their values are the light-theme truth for the render); only `style` rules move to the stylesheet. A missed probe is never fatal — its rules fall back inline.
+
+## Probe selection
+
+`included: 'auto'` (default) scans the project source for antd imports and expands them through the probe registry; any `@lobehub/ui` import additionally unions `lobeUiAntdBaseline` — the antd components lobe-ui internals can render, kept in sync with the source tree by `baseline.test.ts`. Detection is by import source, never by component name, so a Base UI `Modal` from `@lobehub/ui` does not pull antd modal rules.
+
+```ts
+lobeStaticCssPlugin({
+  antd: {
+    extraIncluded: ['table'], // dynamically rendered, invisible to the scanner
+    theme: myAntdTheme, // must equal the SSR ConfigProvider theme
+  },
+  themeVars: {
+    appearanceSelector: (a) => `html[data-theme='${a}']`, // default
+  },
+});
+```
+
+Over-inclusion is harmless (a few KB in one cached file); under-inclusion self-heals via the inline fallback and is reported in `uncovered` / `failedProbes` / `unmatchedComponents` as data, never as console noise.
+
+## Non-Vite build (Next.js etc.)
+
+```ts
+// dedicated script — the emit entry forces NODE_ENV=production before React/antd load,
+// so import it before anything that imports them
+import { emitStaticCssAssets } from '@lobehub/ui/static-css/emit';
+
+await emitStaticCssAssets({ outDir: 'public' });
+// writes public/antd.css, public/theme-vars.css, public/static-css.manifest.json
+```

--- a/src/static-css/baseline.test.ts
+++ b/src/static-css/baseline.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { lobeUiAntdBaseline } from './baseline';
+import { expandComponentsToProbes } from './registry';
+import { scanAntdUsage } from './scan';
+
+const repoRoot = process.cwd();
+
+describe('lobeUiAntdBaseline', () => {
+  it('matches the antd usage of the lobe-ui source tree', () => {
+    const usage = scanAntdUsage({
+      cwd: repoRoot,
+      exclude: [
+        /node_modules/,
+        /\.test\./,
+        /\.d\.[cm]?ts$/,
+        /__tests__/,
+        /\/demos\//,
+        /src\/static-css\//,
+      ],
+      roots: ['src'],
+    });
+
+    expect(usage.wildcard).toBe(false);
+
+    const expanded = expandComponentsToProbes(usage.components);
+
+    expect(expanded.unmatched).toEqual([]);
+    expect(expanded.probes).toEqual([...lobeUiAntdBaseline].sort());
+  });
+});

--- a/src/static-css/baseline.ts
+++ b/src/static-css/baseline.ts
@@ -1,0 +1,38 @@
+import type { AntdProbeName } from './registry';
+
+// The antd components @lobehub/ui internals can render. Kept in sync with the
+// source tree by baseline.test.ts — a failure there means this list must change.
+export const lobeUiAntdBaseline: AntdProbeName[] = [
+  'alert',
+  'anchor',
+  'app',
+  'auto-complete',
+  'avatar',
+  'button',
+  'collapse',
+  'color-picker',
+  'date-picker',
+  'divider',
+  'drawer',
+  'dropdown',
+  'empty',
+  'form',
+  'image',
+  'input',
+  'input-number',
+  'input-textarea',
+  'menu',
+  'modal',
+  'popover',
+  'progress',
+  'segmented',
+  'select',
+  'skeleton',
+  'slider',
+  'space',
+  'tabs',
+  'tag',
+  'tag-preset',
+  'tag-status',
+  'upload',
+];

--- a/src/static-css/buildAntdStaticCss.ts
+++ b/src/static-css/buildAntdStaticCss.ts
@@ -1,0 +1,113 @@
+import { createCache, extractStyle as extractCssinjsStyle } from '@ant-design/cssinjs';
+import type { ThemeConfig } from 'antd';
+import { ConfigProvider, theme as antdTheme } from 'antd';
+import { StyleProvider } from 'antd-style';
+import type { ReactElement } from 'react';
+import { createElement } from 'react';
+import { renderToString } from 'react-dom/server';
+
+import { createLobeAntdTheme } from '@/styles/theme/antdTheme';
+
+import { lobeUiAntdBaseline } from './baseline';
+import { hashCss } from './hash';
+import type { AntdProbeName } from './registry';
+import { antdProbeNames, antdProbeRegistry, expandComponentsToProbes } from './registry';
+import type { ScanAntdUsageOptions } from './scan';
+import { scanAntdUsage } from './scan';
+import { styleKeysOf } from './shared';
+
+export interface AntdStaticCssOptions {
+  /** escape hatch for render paths the registry has no probe for */
+  customProbes?: [name: string, render: () => ReactElement][];
+  /** extra probes on top of 'auto' scan results */
+  extraIncluded?: AntdProbeName[];
+  hrefTemplate?: (hash: string) => string;
+  included?: 'auto' | AntdProbeName[];
+  scan?: ScanAntdUsageOptions;
+  /** must equal the ConfigProvider theme used at SSR — token hash decides styleKeys matching */
+  theme?: ThemeConfig;
+}
+
+export interface AntdStaticCssPayload {
+  css: string;
+  failedProbes: string[];
+  hash: string;
+  href: string;
+  probes: string[];
+  styleKeys: string[];
+  /** antd exports found by 'auto' scan that no registry probe covers */
+  unmatchedComponents: string[];
+}
+
+export const createProbeAntdTheme = (): ThemeConfig => {
+  const config = createLobeAntdTheme({ appearance: 'light' });
+  return {
+    ...config,
+    algorithm: [antdTheme.defaultAlgorithm, config.algorithm ?? []].flat(),
+  };
+};
+
+const resolveProbes = (options: AntdStaticCssOptions) => {
+  const { included = 'auto', extraIncluded = [], customProbes = [], scan } = options;
+
+  const names = new Set<AntdProbeName>();
+  const unmatchedComponents: string[] = [];
+
+  if (included === 'auto') {
+    const usage = scanAntdUsage(scan);
+    if (usage.wildcard) {
+      for (const name of antdProbeNames) names.add(name);
+    } else {
+      const expanded = expandComponentsToProbes(usage.components);
+      for (const name of expanded.probes) names.add(name);
+      unmatchedComponents.push(...expanded.unmatched);
+    }
+    if (usage.importsLobeUi) for (const name of lobeUiAntdBaseline) names.add(name);
+  } else {
+    for (const name of included) names.add(name);
+  }
+
+  for (const name of extraIncluded) names.add(name);
+
+  const probes: [string, () => ReactElement][] = [...names]
+    .sort()
+    .map((name) => [name, antdProbeRegistry[name].render]);
+
+  return { probes: [...probes, ...customProbes], unmatchedComponents };
+};
+
+export const buildAntdStaticCss = (options: AntdStaticCssOptions = {}): AntdStaticCssPayload => {
+  const { theme = createProbeAntdTheme(), hrefTemplate = (hash) => `/antd.css?v=${hash}` } =
+    options;
+
+  const { probes, unmatchedComponents } = resolveProbes(options);
+
+  const cache = createCache();
+  const failedProbes: string[] = [];
+
+  for (const [name, probe] of probes) {
+    try {
+      renderToString(
+        createElement(StyleProvider, {
+          cache,
+          children: createElement(ConfigProvider, { theme }, probe()),
+        }),
+      );
+    } catch {
+      failedProbes.push(name);
+    }
+  }
+
+  const css = extractCssinjsStyle(cache, { plain: true, types: ['style'] });
+  const hash = hashCss(css);
+
+  return {
+    css,
+    failedProbes,
+    hash,
+    href: hrefTemplate(hash),
+    probes: probes.map(([name]) => name),
+    styleKeys: styleKeysOf(cache as unknown as { cache: Map<string, unknown> }).sort(),
+    unmatchedComponents,
+  };
+};

--- a/src/static-css/emit/index.ts
+++ b/src/static-css/emit/index.ts
@@ -1,0 +1,60 @@
+// react-dom/server, @ant-design/cssinjs and antd-style pick their dev/prod flavor
+// at import time and the dev flavor emits different CSS, so production must be
+// forced before any React/antd module loads — hence this entry has no static
+// imports of them and must be imported before anything that does.
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { AntdStaticCssOptions, AntdStaticCssPayload } from '../buildAntdStaticCss';
+import type { ThemeVarsCssOptions, ThemeVarsCssPayload } from '../themeVars';
+
+process.env.NODE_ENV = 'production';
+
+export interface EmitStaticCssOptions {
+  antd?: AntdStaticCssOptions | false;
+  manifestPath?: string;
+  outDir: string;
+  themeVars?: ThemeVarsCssOptions | false;
+}
+
+export interface EmitStaticCssResult {
+  antd?: AntdStaticCssPayload;
+  files: string[];
+  themeVars?: ThemeVarsCssPayload;
+}
+
+export const emitStaticCssAssets = async (
+  options: EmitStaticCssOptions,
+): Promise<EmitStaticCssResult> => {
+  const { outDir, manifestPath = path.join(outDir, 'static-css.manifest.json') } = options;
+
+  await mkdir(outDir, { recursive: true });
+
+  const result: EmitStaticCssResult = { files: [] };
+  const manifest: Record<string, unknown> = {};
+
+  if (options.antd !== false) {
+    const { buildAntdStaticCss } = await import('../buildAntdStaticCss');
+    const payload = buildAntdStaticCss(options.antd);
+    const file = path.join(outDir, 'antd.css');
+    await writeFile(file, payload.css, 'utf8');
+    result.antd = payload;
+    result.files.push(file);
+    manifest.antd = { hash: payload.hash, href: payload.href, styleKeys: payload.styleKeys };
+  }
+
+  if (options.themeVars !== false) {
+    const { buildThemeVarsCss } = await import('../themeVars');
+    const payload = buildThemeVarsCss(options.themeVars);
+    const file = path.join(outDir, 'theme-vars.css');
+    await writeFile(file, payload.css, 'utf8');
+    result.themeVars = payload;
+    result.files.push(file);
+    manifest.themeVars = { hash: payload.hash, href: payload.href };
+  }
+
+  await writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
+  result.files.push(manifestPath);
+
+  return result;
+};

--- a/src/static-css/hash.ts
+++ b/src/static-css/hash.ts
@@ -1,0 +1,4 @@
+import { createHash } from 'node:crypto';
+
+export const hashCss = (css: string): string =>
+  createHash('sha256').update(css).digest('hex').slice(0, 8);

--- a/src/static-css/index.ts
+++ b/src/static-css/index.ts
@@ -1,0 +1,14 @@
+export { lobeUiAntdBaseline } from './baseline';
+export type { AntdStaticCssOptions, AntdStaticCssPayload } from './buildAntdStaticCss';
+export { buildAntdStaticCss, createProbeAntdTheme } from './buildAntdStaticCss';
+export type { AntdProbeDef, AntdProbeName, ExpandedProbes } from './registry';
+export {
+  antdProbeNames,
+  antdProbeRegistry,
+  expandComponentsToProbes,
+  nonProbeAntdExports,
+} from './registry';
+export type { AntdUsageScanResult, ScanAntdUsageOptions } from './scan';
+export { scanAntdUsage } from './scan';
+export type { ThemeVarsCssOptions, ThemeVarsCssPayload } from './themeVars';
+export { buildThemeVarsCss } from './themeVars';

--- a/src/static-css/registry.test.ts
+++ b/src/static-css/registry.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildAntdStaticCss } from './buildAntdStaticCss';
+import { antdProbeNames } from './registry';
+
+describe('antdProbeRegistry', () => {
+  it('renders every probe and extracts style rules', () => {
+    const payload = buildAntdStaticCss({ included: antdProbeNames });
+
+    expect(payload.failedProbes).toEqual([]);
+    expect(payload.styleKeys.length).toBeGreaterThan(0);
+    expect(payload.css.length).toBeGreaterThan(1000);
+    expect(payload.href).toBe(`/antd.css?v=${payload.hash}`);
+  });
+
+  it('produces deterministic hash for identical input', () => {
+    const first = buildAntdStaticCss({ included: ['button'] });
+    const second = buildAntdStaticCss({ included: ['button'] });
+
+    expect(first.hash).toBe(second.hash);
+    expect(first.styleKeys).toEqual(second.styleKeys);
+  });
+
+  it('registers distinct style keys for tag color variants', () => {
+    const base = buildAntdStaticCss({ included: ['tag'] });
+    const withPreset = buildAntdStaticCss({ included: ['tag', 'tag-preset', 'tag-status'] });
+
+    expect(withPreset.styleKeys.length).toBeGreaterThan(base.styleKeys.length);
+  });
+});

--- a/src/static-css/registry.ts
+++ b/src/static-css/registry.ts
@@ -1,0 +1,221 @@
+import {
+  Alert,
+  Anchor,
+  App,
+  AutoComplete,
+  Avatar,
+  Badge,
+  Breadcrumb,
+  Button,
+  Card,
+  Checkbox,
+  Col,
+  Collapse,
+  ColorPicker,
+  DatePicker,
+  Divider,
+  Drawer,
+  Dropdown,
+  Empty,
+  Flex,
+  FloatButton,
+  Form,
+  Image,
+  Input,
+  InputNumber,
+  Mentions,
+  Menu,
+  Modal,
+  Pagination,
+  Popover,
+  Progress,
+  QRCode,
+  Radio,
+  Rate,
+  Row,
+  Segmented,
+  Select,
+  Skeleton,
+  Slider,
+  Space,
+  Spin,
+  Steps,
+  Switch,
+  Table,
+  Tabs,
+  Tag,
+  Tooltip,
+  Tree,
+  Typography,
+  Upload,
+} from 'antd';
+import type { ReactElement } from 'react';
+import { createElement } from 'react';
+
+export interface AntdProbeDef {
+  /** antd export name whose usage activates this probe during auto scan */
+  detect: string;
+  render: () => ReactElement;
+}
+
+const PROBE_NAMES = [
+  'alert',
+  'anchor',
+  'app',
+  'auto-complete',
+  'avatar',
+  'badge',
+  'breadcrumb',
+  'button',
+  'card',
+  'checkbox',
+  'collapse',
+  'color-picker',
+  'date-picker',
+  'divider',
+  'drawer',
+  'dropdown',
+  'empty',
+  'flex',
+  'float-button',
+  'form',
+  'grid-col',
+  'grid-row',
+  'image',
+  'input',
+  'input-number',
+  'input-textarea',
+  'mentions',
+  'menu',
+  'modal',
+  'pagination',
+  'popover',
+  'progress',
+  'qrcode',
+  'radio',
+  'rate',
+  'segmented',
+  'select',
+  'skeleton',
+  'slider',
+  'space',
+  'spin',
+  'steps',
+  'switch',
+  'table',
+  'tabs',
+  'tag',
+  'tag-preset',
+  'tag-status',
+  'tooltip',
+  'tree',
+  'typography',
+  'upload',
+] as const;
+
+export type AntdProbeName = (typeof PROBE_NAMES)[number];
+
+export const antdProbeNames: AntdProbeName[] = [...PROBE_NAMES];
+
+export const antdProbeRegistry: Record<AntdProbeName, AntdProbeDef> = {
+  'alert': { detect: 'Alert', render: () => createElement(Alert, { message: '-' }) },
+  'anchor': { detect: 'Anchor', render: () => createElement(Anchor, { items: [] }) },
+  'app': { detect: 'App', render: () => createElement(App, null, '-') },
+  'auto-complete': { detect: 'AutoComplete', render: () => createElement(AutoComplete) },
+  'avatar': { detect: 'Avatar', render: () => createElement(Avatar) },
+  'badge': { detect: 'Badge', render: () => createElement(Badge, { count: 1 }) },
+  'breadcrumb': { detect: 'Breadcrumb', render: () => createElement(Breadcrumb, { items: [] }) },
+  'button': { detect: 'Button', render: () => createElement(Button, null, '-') },
+  'card': { detect: 'Card', render: () => createElement(Card, null, '-') },
+  'checkbox': { detect: 'Checkbox', render: () => createElement(Checkbox) },
+  'collapse': { detect: 'Collapse', render: () => createElement(Collapse, { items: [] }) },
+  'color-picker': { detect: 'ColorPicker', render: () => createElement(ColorPicker) },
+  'date-picker': { detect: 'DatePicker', render: () => createElement(DatePicker) },
+  'divider': { detect: 'Divider', render: () => createElement(Divider) },
+  'drawer': { detect: 'Drawer', render: () => createElement(Drawer, { open: false }) },
+  'dropdown': {
+    detect: 'Dropdown',
+    render: () => createElement(Dropdown, { menu: { items: [] } }, createElement('span')),
+  },
+  'empty': { detect: 'Empty', render: () => createElement(Empty) },
+  'flex': { detect: 'Flex', render: () => createElement(Flex, null, createElement('span')) },
+  'float-button': { detect: 'FloatButton', render: () => createElement(FloatButton) },
+  'form': {
+    detect: 'Form',
+    render: () =>
+      createElement(Form, null, createElement(Form.Item, { label: '-' }, createElement('span'))),
+  },
+  'grid-col': { detect: 'Col', render: () => createElement(Col, { span: 1 }) },
+  'grid-row': { detect: 'Row', render: () => createElement(Row) },
+  'image': { detect: 'Image', render: () => createElement(Image, { src: '' }) },
+  'input': { detect: 'Input', render: () => createElement(Input) },
+  'input-number': { detect: 'InputNumber', render: () => createElement(InputNumber) },
+  'input-textarea': { detect: 'Input', render: () => createElement(Input.TextArea) },
+  'mentions': { detect: 'Mentions', render: () => createElement(Mentions) },
+  'menu': { detect: 'Menu', render: () => createElement(Menu, { items: [] }) },
+  'modal': { detect: 'Modal', render: () => createElement(Modal, { open: false }) },
+  'pagination': { detect: 'Pagination', render: () => createElement(Pagination) },
+  'popover': {
+    detect: 'Popover',
+    render: () => createElement(Popover, null, createElement('span')),
+  },
+  'progress': { detect: 'Progress', render: () => createElement(Progress, { percent: 0 }) },
+  'qrcode': { detect: 'QRCode', render: () => createElement(QRCode, { value: '-' }) },
+  'radio': { detect: 'Radio', render: () => createElement(Radio) },
+  'rate': { detect: 'Rate', render: () => createElement(Rate) },
+  'segmented': { detect: 'Segmented', render: () => createElement(Segmented, { options: ['-'] }) },
+  'select': { detect: 'Select', render: () => createElement(Select) },
+  'skeleton': { detect: 'Skeleton', render: () => createElement(Skeleton) },
+  'slider': { detect: 'Slider', render: () => createElement(Slider) },
+  'space': { detect: 'Space', render: () => createElement(Space, null, createElement('span')) },
+  'spin': { detect: 'Spin', render: () => createElement(Spin) },
+  'steps': { detect: 'Steps', render: () => createElement(Steps, { items: [] }) },
+  'switch': { detect: 'Switch', render: () => createElement(Switch) },
+  'table': { detect: 'Table', render: () => createElement(Table, { columns: [], dataSource: [] }) },
+  'tabs': { detect: 'Tabs', render: () => createElement(Tabs, { items: [] }) },
+  'tag': { detect: 'Tag', render: () => createElement(Tag, null, '-') },
+  'tag-preset': { detect: 'Tag', render: () => createElement(Tag, { color: 'blue' }, '-') },
+  'tag-status': { detect: 'Tag', render: () => createElement(Tag, { color: 'success' }, '-') },
+  'tooltip': {
+    detect: 'Tooltip',
+    render: () => createElement(Tooltip, { title: '-' }, createElement('span')),
+  },
+  'tree': { detect: 'Tree', render: () => createElement(Tree, { treeData: [] }) },
+  'typography': { detect: 'Typography', render: () => createElement(Typography.Text, null, '-') },
+  'upload': { detect: 'Upload', render: () => createElement(Upload) },
+};
+
+// Imperative or unstyled antd exports the scanner may find but no probe should cover.
+export const nonProbeAntdExports = new Set([
+  'ConfigProvider',
+  'Grid',
+  'message',
+  'notification',
+  'theme',
+  // kebabToPascal('antd/es/theme') during deep-import scan
+  'Theme',
+  'version',
+]);
+
+export interface ExpandedProbes {
+  probes: AntdProbeName[];
+  unmatched: string[];
+}
+
+export const expandComponentsToProbes = (components: Iterable<string>): ExpandedProbes => {
+  const probes = new Set<AntdProbeName>();
+  const unmatched: string[] = [];
+
+  for (const component of components) {
+    let matched = false;
+    for (const name of antdProbeNames) {
+      if (antdProbeRegistry[name].detect === component) {
+        probes.add(name);
+        matched = true;
+      }
+    }
+    if (!matched && !nonProbeAntdExports.has(component)) unmatched.push(component);
+  }
+
+  return { probes: [...probes].sort(), unmatched: unmatched.sort() };
+};

--- a/src/static-css/runtime.test.ts
+++ b/src/static-css/runtime.test.ts
@@ -1,0 +1,57 @@
+import { createCache } from '@ant-design/cssinjs';
+import { Button, ConfigProvider, Rate } from 'antd';
+import { StyleProvider } from 'antd-style';
+import { createElement } from 'react';
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { buildAntdStaticCss, createProbeAntdTheme } from './buildAntdStaticCss';
+import { buildInlineAntdStyle } from './runtime';
+
+const renderWithCache = (children: Parameters<typeof createElement>[2][]) => {
+  const cache = createCache();
+  renderToString(
+    createElement(StyleProvider, {
+      cache,
+      children: createElement(
+        ConfigProvider,
+        { theme: createProbeAntdTheme() },
+        createElement('div', null, ...children),
+      ),
+    }),
+  );
+  return cache;
+};
+
+describe('buildInlineAntdStyle', () => {
+  const payload = buildAntdStaticCss({ included: ['button'] });
+
+  it('keeps covered component rules out of the inline css', () => {
+    const cache = renderWithCache([createElement(Button, null, '-')]);
+
+    const result = buildInlineAntdStyle(cache, payload);
+
+    expect(result.uncovered).toEqual([]);
+    expect(result.css).not.toContain('.ant-btn:hover');
+  });
+
+  it('inlines fallback rules for uncovered components and names them', () => {
+    const cache = renderWithCache([createElement(Button, null, '-'), createElement(Rate)]);
+
+    const result = buildInlineAntdStyle(cache, payload);
+
+    expect(result.uncovered.length).toBe(1);
+    expect(result.css).toContain('.ant-rate');
+    expect(result.css).not.toContain('.ant-btn:hover');
+    expect(result.html.startsWith('<style data-rc-order="prepend"')).toBe(true);
+  });
+
+  it('accepts styleKeys as an array or a set', () => {
+    const cache = renderWithCache([createElement(Button, null, '-')]);
+
+    const fromSet = buildInlineAntdStyle(cache, { styleKeys: new Set(payload.styleKeys) });
+    const fromArray = buildInlineAntdStyle(cache, { styleKeys: [...payload.styleKeys] });
+
+    expect(fromSet.css).toBe(fromArray.css);
+  });
+});

--- a/src/static-css/runtime/index.ts
+++ b/src/static-css/runtime/index.ts
@@ -1,0 +1,54 @@
+import { extractStyle as extractCssinjsStyle } from '@ant-design/cssinjs';
+
+import { styleKeysOf } from '../shared';
+
+interface CssinjsCache {
+  cache: Map<string, unknown>;
+  extracted: Set<string>;
+  updateTimes: Map<string, number>;
+}
+
+export interface InlineAntdStyleResult {
+  css: string;
+  /** css wrapped in a prepend-ordered style tag, '' when empty */
+  html: string;
+  /** probe-uncovered components whose rules fell back inline */
+  uncovered: string[];
+}
+
+// Replaces antd-style's inline antd entry: component css-var blocks always stay
+// inline (their values are the light-theme truth for this render), while style
+// rules ship via the static stylesheet — except components the probe set missed,
+// which fall back to inline rules.
+export const buildInlineAntdStyle = (
+  runtimeCache: unknown,
+  payload: { styleKeys: Iterable<string> },
+): InlineAntdStyleResult => {
+  const staticKeys =
+    payload.styleKeys instanceof Set ? payload.styleKeys : new Set(payload.styleKeys);
+  const cssinjsCache = runtimeCache as CssinjsCache;
+
+  const cssVarCss = extractCssinjsStyle(cssinjsCache as never, {
+    plain: true,
+    types: ['cssVar'],
+  });
+
+  const uncoveredKeys = styleKeysOf(cssinjsCache).filter((key) => !staticKeys.has(key));
+  let uncoveredCss = '';
+  if (uncoveredKeys.length > 0) {
+    const pseudoCache = {
+      cache: new Map(uncoveredKeys.map((key) => [key, cssinjsCache.cache.get(key)])),
+      extracted: new Set<string>(),
+      updateTimes: cssinjsCache.updateTimes,
+    };
+    uncoveredCss = extractCssinjsStyle(pseudoCache as never, { plain: true, types: ['style'] });
+  }
+
+  const css = cssVarCss + uncoveredCss;
+
+  return {
+    css,
+    html: css ? `<style data-rc-order="prepend" data-rc-priority="-9999">${css}</style>` : '',
+    uncovered: uncoveredKeys.map((key) => key.split('%')[2] ?? key),
+  };
+};

--- a/src/static-css/scan.test.ts
+++ b/src/static-css/scan.test.ts
@@ -1,0 +1,77 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { scanAntdUsage } from './scan';
+
+const fixtureRoot = mkdtempSync(path.join(tmpdir(), 'static-css-scan-'));
+
+afterAll(() => {
+  rmSync(fixtureRoot, { force: true, recursive: true });
+});
+
+const writeFixture = (name: string, content: string) => {
+  writeFileSync(path.join(fixtureRoot, name), content, 'utf8');
+};
+
+describe('scanAntdUsage', () => {
+  it('collects named value imports, strips aliases and type specifiers', () => {
+    writeFixture(
+      'named.tsx',
+      `import { Button, type ButtonProps, Tag as AntTag } from 'antd';\n` +
+        `import type { ModalProps } from 'antd';\n`,
+    );
+
+    const result = scanAntdUsage({ cwd: fixtureRoot, roots: ['.'] });
+
+    expect(result.components).toContain('Button');
+    expect(result.components).toContain('Tag');
+    expect(result.components).not.toContain('ButtonProps');
+    expect(result.components).not.toContain('ModalProps');
+    expect(result.components).not.toContain('AntTag');
+  });
+
+  it('handles multiline named imports without crossing statements', () => {
+    writeFixture(
+      'multiline.ts',
+      `import { A } from 'other';\nimport {\n  Select,\n  Slider,\n} from 'antd';\n`,
+    );
+
+    const result = scanAntdUsage({ cwd: fixtureRoot, roots: ['.'] });
+
+    expect(result.components).toContain('Select');
+    expect(result.components).toContain('Slider');
+    expect(result.components).not.toContain('A');
+  });
+
+  it('maps deep imports to pascal-case component names', () => {
+    writeFixture(
+      'deep.ts',
+      `import TextArea from 'antd/es/input/TextArea';\nimport tokens from 'antd/lib/input-number/style/token';\n`,
+    );
+
+    const result = scanAntdUsage({ cwd: fixtureRoot, roots: ['.'] });
+
+    expect(result.components).toContain('Input');
+    expect(result.components).toContain('InputNumber');
+  });
+
+  it('flags namespace and default imports as wildcard', () => {
+    writeFixture('wildcard.ts', `import * as antd from 'antd';\n`);
+
+    const result = scanAntdUsage({ cwd: fixtureRoot, roots: ['.'] });
+
+    expect(result.wildcard).toBe(true);
+  });
+
+  it('detects @lobehub/ui imports', () => {
+    writeFixture('lobe.ts', `import { Modal } from '@lobehub/ui';\n`);
+
+    const result = scanAntdUsage({ cwd: fixtureRoot, roots: ['.'] });
+
+    expect(result.importsLobeUi).toBe(true);
+    expect(result.components).not.toContain('Modal');
+  });
+});

--- a/src/static-css/scan.ts
+++ b/src/static-css/scan.ts
@@ -1,0 +1,115 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+export interface ScanAntdUsageOptions {
+  cwd?: string;
+  exclude?: RegExp[];
+  extensions?: string[];
+  roots?: string[];
+}
+
+export interface AntdUsageScanResult {
+  /** PascalCase antd export names found in value imports */
+  components: string[];
+  importsLobeUi: boolean;
+  scannedFiles: number;
+  /** a namespace/default antd import was found — usage is not statically enumerable */
+  wildcard: boolean;
+}
+
+const DEFAULT_EXTENSIONS = ['ts', 'tsx', 'js', 'jsx', 'mjs', 'mts', 'cjs', 'cts'];
+const DEFAULT_EXCLUDE = [/node_modules/, /\.test\./, /\.spec\./, /\.d\.[cm]?ts$/, /__tests__/];
+
+// clause alternatives ({named} / Default / Default, {named} / * as ns) deliberately
+// exclude statement-crossing text so one match never spans two imports
+const NAMED_IMPORT_RE =
+  /import\s+(type\s+)?((?:[\w$]+\s*,\s*)?\{[^}]*\}|[\w$]+|\*\s+as\s+[\w$]+)\s+from\s+['"]antd['"]/g;
+// type-only deep imports are included too — over-approximation is harmless here
+const DEEP_IMPORT_RE = /from\s+['"]antd\/(?:es|lib)\/([\w-]+)/g;
+const LOBE_UI_RE = /from\s+['"]@lobehub\/ui(?:['"]|\/)/;
+
+const kebabToPascal = (name: string) =>
+  name
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+
+const parseImportClause = (clause: string, components: Set<string>): boolean => {
+  const braceStart = clause.indexOf('{');
+
+  const bare = (braceStart === -1 ? clause : clause.slice(0, braceStart)).trim();
+  const wildcard = bare.length > 0;
+
+  if (braceStart === -1) return wildcard;
+
+  const inner = clause.slice(braceStart + 1, clause.lastIndexOf('}'));
+  for (const rawSpecifier of inner.split(',')) {
+    const specifier = rawSpecifier.trim();
+    if (!specifier || specifier.startsWith('type ')) continue;
+    const name = specifier.split(/\s+as\s+/)[0]!.trim();
+    if (/^[A-Za-z_$][\w$]*$/.test(name)) components.add(name);
+  }
+
+  return wildcard;
+};
+
+const listFiles = (root: string, extensions: Set<string>, exclude: RegExp[]): string[] => {
+  let entries: string[];
+  try {
+    entries = readdirSync(root, { recursive: true }) as string[];
+  } catch {
+    return [];
+  }
+
+  return entries
+    .map((entry) => path.join(root, entry))
+    .filter((path) => {
+      if (exclude.some((pattern) => pattern.test(path))) return false;
+      const extension = path.split('.').pop();
+      if (!extension || !extensions.has(extension)) return false;
+      try {
+        return statSync(path).isFile();
+      } catch {
+        return false;
+      }
+    });
+};
+
+export const scanAntdUsage = (options: ScanAntdUsageOptions = {}): AntdUsageScanResult => {
+  const {
+    cwd = process.cwd(),
+    roots = ['src'],
+    extensions = DEFAULT_EXTENSIONS,
+    exclude = DEFAULT_EXCLUDE,
+  } = options;
+
+  const components = new Set<string>();
+  let importsLobeUi = false;
+  let wildcard = false;
+  let scannedFiles = 0;
+
+  for (const root of roots) {
+    for (const file of listFiles(path.resolve(cwd, root), new Set(extensions), exclude)) {
+      let source: string;
+      try {
+        source = readFileSync(file, 'utf8');
+      } catch {
+        continue;
+      }
+      scannedFiles += 1;
+
+      if (!importsLobeUi && LOBE_UI_RE.test(source)) importsLobeUi = true;
+
+      for (const match of source.matchAll(NAMED_IMPORT_RE)) {
+        if (match[1]) continue;
+        if (parseImportClause(match[2]!, components)) wildcard = true;
+      }
+
+      for (const match of source.matchAll(DEEP_IMPORT_RE)) {
+        components.add(kebabToPascal(match[1]!));
+      }
+    }
+  }
+
+  return { components: [...components].sort(), importsLobeUi, scannedFiles, wildcard };
+};

--- a/src/static-css/shared.ts
+++ b/src/static-css/shared.ts
@@ -1,0 +1,6 @@
+export interface CssinjsCacheLike {
+  cache: Map<string, unknown>;
+}
+
+export const styleKeysOf = (cache: CssinjsCacheLike): string[] =>
+  [...cache.cache.keys()].filter((key) => key.startsWith('style%'));

--- a/src/static-css/themeVars.test.ts
+++ b/src/static-css/themeVars.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildThemeVarsCss } from './themeVars';
+
+describe('buildThemeVarsCss', () => {
+  const payload = buildThemeVarsCss();
+
+  it('emits both palettes with antd shadow selectors', () => {
+    expect(payload.css).toContain(":root,html[data-theme='light'] [class*='css-var-']");
+    expect(payload.css).toContain(
+      "html[data-theme='dark'],html[data-theme='dark'] [class*='css-var-']",
+    );
+    expect(payload.css).toContain('--ant-color-primary:');
+    expect(payload.href).toBe(`/theme-vars.css?v=${payload.hash}`);
+  });
+
+  it('emits dark component token diffs', () => {
+    expect(payload.css).toMatch(/html\[data-theme='dark'] \[class\*='css-var-']\{--ant-\w/);
+  });
+
+  it('includes compat rules by default and drops them on demand', () => {
+    expect(payload.css).toContain('.ant-btn-primary:not(:disabled)');
+
+    const bare = buildThemeVarsCss({ compatRules: false });
+    expect(bare.css).not.toContain('.ant-btn-primary');
+    expect(bare.hash).not.toBe(payload.hash);
+  });
+
+  it('honors a custom appearance selector', () => {
+    const custom = buildThemeVarsCss({
+      appearanceSelector: (appearance) => `.theme-${appearance}`,
+    });
+
+    expect(custom.css).toContain('.theme-dark,');
+    expect(custom.css).not.toContain('data-theme');
+  });
+
+  it('reports skipped components instead of warning', () => {
+    expect(Array.isArray(payload.skippedComponents)).toBe(true);
+  });
+});

--- a/src/static-css/themeVars.ts
+++ b/src/static-css/themeVars.ts
@@ -1,0 +1,199 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+import type { ThemeConfig } from 'antd';
+import { theme as antdTheme } from 'antd';
+
+import { createLobeAntdTheme } from '@/styles/theme/antdTheme';
+
+import { hashCss } from './hash';
+
+type ThemeAppearance = 'dark' | 'light';
+
+export interface ThemeVarsCssOptions {
+  /** selector activating an appearance; default matches next-themes' data-theme attribute */
+  appearanceSelector?: (appearance: ThemeAppearance) => string;
+  /** dark fixups for lobe-ui antdOverride rules that keep literal polished-derived colors */
+  compatRules?: boolean;
+  hrefTemplate?: (hash: string) => string;
+  /** same theme factory the app hands to ConfigProvider/ThemeProvider */
+  theme?: (appearance: ThemeAppearance) => ThemeConfig;
+}
+
+export interface ThemeVarsCssPayload {
+  css: string;
+  hash: string;
+  href: string;
+  skippedComponents: string[];
+}
+
+const require = createRequire(import.meta.url);
+
+const unitless = new Set([
+  'fontWeightStrong',
+  'lineHeight',
+  'lineHeightHeading1',
+  'lineHeightHeading2',
+  'lineHeightHeading3',
+  'lineHeightHeading4',
+  'lineHeightHeading5',
+  'lineHeightLG',
+  'lineHeightSM',
+  'opacityImage',
+  'opacityLoading',
+  'zIndexBase',
+  'zIndexPopupBase',
+]);
+
+const ignoredTokens = new Set(['motionBase', 'motionUnit']);
+
+// same kebab algorithm as antd-style's toKebabCase, so names match antd's emitted vars
+export const toKebabCase = (str: string) =>
+  str
+    .replaceAll(/([a-z])([A-Z])/g, '$1-$2')
+    .replaceAll(/([a-z])(\d)/g, '$1-$2')
+    .replaceAll(/(\d)([A-Z])/g, '$1-$2')
+    .replaceAll(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    .toLowerCase();
+
+const defaultThemeFactory = (appearance: ThemeAppearance): ThemeConfig =>
+  createLobeAntdTheme({ appearance });
+
+const buildDesignToken = (
+  themeFactory: (appearance: ThemeAppearance) => ThemeConfig,
+  appearance: ThemeAppearance,
+) => {
+  const themeConfig = themeFactory(appearance);
+  return antdTheme.getDesignToken({
+    ...themeConfig,
+    algorithm: [
+      appearance === 'dark' ? antdTheme.darkAlgorithm : antdTheme.defaultAlgorithm,
+      themeConfig.algorithm ?? [],
+    ].flat(),
+  }) as unknown as Record<string, number | string>;
+};
+
+const toDeclarations = (token: Record<string, number | string>) =>
+  Object.entries(token)
+    .filter(
+      ([key, value]) =>
+        !key.startsWith('_') &&
+        !key.startsWith('screen') &&
+        !key.includes('-') &&
+        !ignoredTokens.has(key) &&
+        (typeof value === 'string' || typeof value === 'number'),
+    )
+    .map(([key, value]) => {
+      const cssValue =
+        typeof value === 'number' && !unitless.has(key) ? `${value}px` : String(value);
+      return `--ant-${toKebabCase(key)}: ${cssValue};`;
+    })
+    .join('\n');
+
+const isBrightColor = (value: string) => {
+  const hex = /^#([\da-f]{6})/i.exec(value)?.[1];
+  const rgb = /^rgba?\((\d+)[\s,]+(\d+)[\s,]+(\d+)/.exec(value);
+  const [r, g, b] = hex
+    ? [
+        Number.parseInt(hex.slice(0, 2), 16),
+        Number.parseInt(hex.slice(2, 4), 16),
+        Number.parseInt(hex.slice(4, 6), 16),
+      ]
+    : rgb
+      ? [Number(rgb[1]), Number(rgb[2]), Number(rgb[3])]
+      : [0, 0, 0];
+  return (r * 299 + g * 587 + b * 114) / 1000 > 128;
+};
+
+const loadAntdTokenModules = () => {
+  const antdLibDir = path.join(path.dirname(require.resolve('antd/package.json')), 'lib');
+
+  return readdirSync(antdLibDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort()
+    .map((name) => ({ component: name, path: path.join(antdLibDir, name, 'style', 'token.js') }))
+    .filter(({ path }) => existsSync(path));
+};
+
+const buildDarkComponentVars = (tokens: {
+  dark: Record<string, number | string>;
+  light: Record<string, number | string>;
+}) => {
+  const declarations: string[] = [];
+  const skipped: string[] = [];
+
+  for (const { component, path } of loadAntdTokenModules()) {
+    try {
+      const mod = require(path) as { prepareComponentToken?: unknown };
+      const prepare = mod.prepareComponentToken;
+      if (typeof prepare !== 'function') continue;
+
+      const light = prepare(tokens.light) as Record<string, unknown>;
+      const dark = prepare(tokens.dark) as Record<string, unknown>;
+
+      for (const [key, value] of Object.entries(dark)) {
+        if (typeof value !== 'string' || light[key] === value) continue;
+        declarations.push(`--ant-${component}-${toKebabCase(key)}:${value};`);
+      }
+    } catch {
+      skipped.push(component);
+    }
+  }
+
+  return { css: declarations.join(''), skipped };
+};
+
+const buildCompatRules = (
+  darkSelector: string,
+  darkToken: Record<string, number | string>,
+): string => {
+  // mirrors polished's readableColor for the antdOverride rules that keep colorPrimary literal
+  const readableOnPrimary = isBrightColor(String(darkToken.colorPrimary)) ? '#000' : '#fff';
+
+  return [
+    [
+      `${darkSelector} .ant-btn-primary:not(:disabled)`,
+      `${darkSelector} .ant-btn-primary:not(:disabled):hover`,
+      `${darkSelector} .ant-btn-primary:not(:disabled):active`,
+    ].join(',') + `{color:${readableOnPrimary} !important;}`,
+    `${darkSelector} .ant-checkbox-inner:after{border-color:${readableOnPrimary} !important;}`,
+    `${darkSelector} .ant-radio-wrapper .ant-radio-checked .ant-radio-inner:after{background:${readableOnPrimary};}`,
+  ].join('\n');
+};
+
+export const buildThemeVarsCss = (options: ThemeVarsCssOptions = {}): ThemeVarsCssPayload => {
+  const {
+    theme = defaultThemeFactory,
+    appearanceSelector = (appearance) => `html[data-theme='${appearance}']`,
+    compatRules = true,
+    hrefTemplate = (hash) => `/theme-vars.css?v=${hash}`,
+  } = options;
+
+  const tokens = {
+    dark: buildDesignToken(theme, 'dark'),
+    light: buildDesignToken(theme, 'light'),
+  };
+
+  const light = appearanceSelector('light');
+  const dark = appearanceSelector('dark');
+  const componentVars = buildDarkComponentVars(tokens);
+
+  // antd v6 cssVar mode re-declares all --ant-* with SSR-light literals on
+  // [class*='css-var-'] / .ant-app, which would shadow the html-level palettes
+  const blocks = [
+    [':root', `${light} [class*='css-var-']`, `${light} .ant-app`].join(',') +
+      `{${toDeclarations(tokens.light)}}`,
+    [dark, `${dark} [class*='css-var-']`, `${dark} .ant-app`].join(',') +
+      `{${toDeclarations(tokens.dark)}}`,
+    `${dark} [class*='css-var-']{${componentVars.css}}`,
+  ];
+
+  if (compatRules) blocks.push(buildCompatRules(dark, tokens.dark));
+
+  const css = blocks.join('\n');
+  const hash = hashCss(css);
+
+  return { css, hash, href: hrefTemplate(hash), skippedComponents: componentVars.skipped };
+};

--- a/src/static-css/vite/index.ts
+++ b/src/static-css/vite/index.ts
@@ -1,0 +1,49 @@
+import type { Plugin } from 'vite';
+
+import type { AntdStaticCssOptions, AntdStaticCssPayload } from '../buildAntdStaticCss';
+import type { ThemeVarsCssOptions, ThemeVarsCssPayload } from '../themeVars';
+
+export const ANTD_STATIC_CSS_MODULE_ID = 'virtual:lobehub/antd-static-css';
+export const THEME_VARS_CSS_MODULE_ID = 'virtual:lobehub/theme-vars-css';
+
+export interface StaticCssPluginOptions {
+  antd?: AntdStaticCssOptions | false;
+  themeVars?: ThemeVarsCssOptions | false;
+}
+
+const moduleSource = (payload: Record<string, unknown>) =>
+  [
+    ...Object.entries(payload).map(
+      ([key, value]) => `export const ${key} = ${JSON.stringify(value)};`,
+    ),
+    `export default ${JSON.stringify(payload)};`,
+  ].join('\n');
+
+export const lobeStaticCssPlugin = (options: StaticCssPluginOptions = {}): Plugin => {
+  let antdPayload: AntdStaticCssPayload | undefined;
+  let themeVarsPayload: ThemeVarsCssPayload | undefined;
+
+  return {
+    name: 'lobehub-static-css',
+    resolveId(id) {
+      if (id === ANTD_STATIC_CSS_MODULE_ID || id === THEME_VARS_CSS_MODULE_ID) return `\0${id}`;
+    },
+    async load(id) {
+      if (id === `\0${ANTD_STATIC_CSS_MODULE_ID}`) {
+        if (options.antd === false) return moduleSource({ css: '', href: '', styleKeys: [] });
+        const { buildAntdStaticCss } = await import('../buildAntdStaticCss');
+        antdPayload ??= buildAntdStaticCss(options.antd);
+        const { css, href, styleKeys } = antdPayload;
+        return moduleSource({ css, href, styleKeys });
+      }
+
+      if (id === `\0${THEME_VARS_CSS_MODULE_ID}`) {
+        if (options.themeVars === false) return moduleSource({ css: '', href: '' });
+        const { buildThemeVarsCss } = await import('../themeVars');
+        themeVarsPayload ??= buildThemeVarsCss(options.themeVars);
+        const { css, href } = themeVarsPayload;
+        return moduleSource({ css, href });
+      }
+    },
+  };
+};

--- a/src/static-css/vite/vite.test.ts
+++ b/src/static-css/vite/vite.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { ANTD_STATIC_CSS_MODULE_ID, lobeStaticCssPlugin, THEME_VARS_CSS_MODULE_ID } from './index';
+
+type Hook = (this: unknown, id: string) => unknown;
+
+const callHook = (hook: unknown, id: string) => (hook as Hook).call(undefined, id);
+
+describe('lobeStaticCssPlugin', () => {
+  it('resolves both virtual module ids', () => {
+    const plugin = lobeStaticCssPlugin();
+
+    expect(callHook(plugin.resolveId, ANTD_STATIC_CSS_MODULE_ID)).toBe(
+      `\0${ANTD_STATIC_CSS_MODULE_ID}`,
+    );
+    expect(callHook(plugin.resolveId, THEME_VARS_CSS_MODULE_ID)).toBe(
+      `\0${THEME_VARS_CSS_MODULE_ID}`,
+    );
+    expect(callHook(plugin.resolveId, 'other')).toBeUndefined();
+  });
+
+  it('serves antd payload with explicit probes', async () => {
+    const plugin = lobeStaticCssPlugin({ antd: { included: ['button'] }, themeVars: false });
+
+    const code = (await callHook(plugin.load, `\0${ANTD_STATIC_CSS_MODULE_ID}`)) as string;
+
+    expect(code).toContain('export const css = ');
+    expect(code).toContain('export const styleKeys = ');
+    expect(code).toContain('/antd.css?v=');
+  });
+
+  it('serves empty stubs when a target is disabled', async () => {
+    const plugin = lobeStaticCssPlugin({ antd: false, themeVars: false });
+
+    const antdCode = (await callHook(plugin.load, `\0${ANTD_STATIC_CSS_MODULE_ID}`)) as string;
+    const themeCode = (await callHook(plugin.load, `\0${THEME_VARS_CSS_MODULE_ID}`)) as string;
+
+    expect(antdCode).toContain('export const css = ""');
+    expect(themeCode).toContain('export const css = ""');
+  });
+});

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -13,6 +13,8 @@ const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as {
 const external = [
   ...Object.keys(pkg.dependencies ?? {}),
   ...Object.keys(pkg.peerDependencies ?? {}),
+  // type-only import in static-css/vite; not a dependency, so external it explicitly
+  'vite',
 ];
 
 // 动态查找所有 src/*/index.ts 文件
@@ -32,6 +34,9 @@ export default defineConfig({
     // packages
     ...packageEntries,
     'src/i18n/resources/index.ts',
+    'src/static-css/emit/index.ts',
+    'src/static-css/runtime/index.ts',
+    'src/static-css/vite/index.ts',
   ],
   external,
   format: ['esm'],


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Adds `@lobehub/ui/static-css` — build-time extraction of antd component styles and LobeHub theme token palettes into cacheable static stylesheets, generalized from the implementation running in `lobehub-landing-rr` (its `buildAntdStaticCss` / `buildThemeVarsCss` / `antd-static-css.server` trio).

Four subpath entries:

- `@lobehub/ui/static-css` — core: `buildAntdStaticCss` (probe render → cssinjs `style` rules → hashed payload), `buildThemeVarsCss` (both token palettes + dark component-token diffs + antd v6 cssVar shadow selectors), probe registry (52 probes), zero-dependency antd import scanner.
- `@lobehub/ui/static-css/runtime` — `buildInlineAntdStyle` for SSR: css-var blocks stay inline, style rules ship via the static sheet, uncovered components fall back inline and are reported as data (no console noise).
- `@lobehub/ui/static-css/vite` — plugin serving `virtual:lobehub/antd-static-css` / `virtual:lobehub/theme-vars-css`.
- `@lobehub/ui/static-css/emit` — writes `antd.css` / `theme-vars.css` / manifest for non-Vite consumers, forcing production semantics before React/antd load.

Probe selection is by `included` name list or `included: 'auto'`: scans project source for antd imports (by import source, never by component name — Base UI wrappers pull nothing) and unions `lobeUiAntdBaseline` when `@lobehub/ui` is imported. The baseline is kept honest by `baseline.test.ts`, which scans this repo's own source and fails on drift.

#### 📝 补充信息 | Additional Information

- Precision model: over-approximation is harmless (bytes in one cached file); under-approximation self-heals via runtime inline fallback and surfaces in `uncovered`.
- `vite` added to tsdown `external` — the vite entry's type-only import otherwise makes rolldown-plugin-dts try to bundle postcss's CJS dts.
- Verified: full suite 1211/1211, `tsc --noEmit` clean, end-to-end emit run from built `es/` output (antd.css 33KB, theme-vars.css 64KB, manifest).
- Docs in `src/static-css/README.md`, including the ambient `declare module` snippet for the virtual modules.