### PR TITLE
🐛 fix(alert): anchor icon and controls to the title line box

### DIFF
--- a/src/Alert/Alert.test.tsx
+++ b/src/Alert/Alert.test.tsx
@@ -5,7 +5,7 @@ import Button from '@/Button';
 import Alert from './Alert';
 
 describe('Alert', () => {
-  test('centers single-line content with its action and close control', () => {
+  test('anchors the action and close control to the title line box', () => {
     render(
       <Alert
         closable
@@ -14,7 +14,34 @@ describe('Alert', () => {
       />,
     );
 
-    expect(getComputedStyle(screen.getByRole('alert')).alignItems).toBe('center');
+    const alert = screen.getByRole('alert');
+    const actions = getComputedStyle(alert.querySelector('.ant-alert-actions')!);
+    expect(actions.alignSelf).toBe('flex-start');
+    expect(actions.height).toBe('24px');
+    expect(actions.alignItems).toBe('center');
+    const close = getComputedStyle(alert.querySelector('.ant-alert-close-icon')!);
+    expect(close.alignSelf).toBe('flex-start');
+    expect(close.height).toBe('24px');
+  });
+
+  test('keeps the icon on the first line of a wrapping message-only alert', () => {
+    render(
+      <Alert
+        title={
+          <div>
+            <p>The workspace will be permanently deleted, along with:</p>
+            <ul>
+              <li>All agents, skills, and their configurations</li>
+              <li>All messages, topics, and tasks</li>
+            </ul>
+          </div>
+        }
+      />,
+    );
+
+    const icon = getComputedStyle(screen.getByRole('alert').querySelector('.ant-alert-icon')!);
+    expect(icon.alignSelf).toBe('flex-start');
+    expect(icon.height).toBe('24px');
   });
 
   test('keeps multi-line content top-aligned', () => {

--- a/src/Alert/style.ts
+++ b/src/Alert/style.ts
@@ -72,21 +72,34 @@ export const styles = createStaticStyles(({ css, cssVar }) => {
 
       max-width: 100%;
 
+      /* Every control anchors itself to the title's FIRST 24px line box via
+         align-self. Root-level align-items cannot be relied on: antd v6's own
+         base style centers the row, and whether it or these static styles win
+         depends on stylesheet injection order, which differs between
+         environments. Centering the row is also wrong for message-only alerts
+         whose content wraps - the icon drifts to the middle of the block. */
       .${prefixCls}-alert-icon {
         display: flex;
         align-items: center;
+        align-self: flex-start;
+
         height: 24px;
         margin: 0;
       }
       .${prefixCls}-alert-close-icon {
         display: flex;
         align-items: center;
+        align-self: flex-start;
+
         height: 24px;
         margin: 0;
       }
-    `,
-    rootSingleLine: css`
-      align-items: center;
+      .${prefixCls}-alert-actions {
+        display: flex;
+        align-items: center;
+        align-self: flex-start;
+        height: 24px;
+      }
     `,
     rootNoTitleNoIconNoClosable: css`
       gap: 8px;
@@ -299,7 +312,7 @@ export const rootVariants = cva(styles.rootBase, {
       true: styles.glass,
     },
     hasTitle: {
-      false: styles.rootSingleLine,
+      false: null,
       true: null,
     },
     showIcon: {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

A message-only Alert whose title wraps to multiple lines (e.g. a confirm-modal warning carrying a paragraph plus a bullet list) rendered its icon vertically centered against the whole block instead of sitting on the first line.

Two stacked causes:

- `rootSingleLine` (from #613) applies `align-items: center` to the root whenever `description` is absent — but "no description" does not mean "one line", so wrapped message-only content centered the icon against the whole block.
- Root-level `align-items` on this component is an injection-order lottery anyway: antd v6's own base style centers `.ant-alert`, and whether antd's cssinjs or these static styles win differs between environments (verified: jsdom resolves `center` while the browser resolves `flex-start` for the same markup).

Fix: stop expressing alignment on the root and anchor each control to the title's first 24px line box via `align-self: flex-start` — which beats any root `align-items` regardless of stylesheet order. The icon and close control already used the 24px line-box pattern; the actions slot (`.ant-alert-actions`) now gets the same box, so #613's goal — action/close visually centered with a single-line title — still holds, now aligned to the first line in the multi-line case too.

#### 📝 补充信息 | Additional Information

- Verified in a real browser on the downstream delete-workspace confirm modal: icon box `align-self: flex-start`, 24px, top offset 9px inside a 258px alert (previously centered at ~117px).
- Single-line composition from #613 (title + small action + closable) keeps all controls on the title's line axis.
- `vitest run src/Alert` 3/3, scoped eslint clean, `pnpm type-check` clean.