### PR TITLE
🐛 fix(context-menu): fix submenu z-index stacking (#608)

### DIFF
--- a/src/base-ui/ContextMenu/__tests__/submenuZIndex.test.tsx
+++ b/src/base-ui/ContextMenu/__tests__/submenuZIndex.test.tsx
@@ -1,0 +1,91 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+
+import AppElementContext from '@/ThemeProvider/AppElementContext';
+
+import { Z_INDEX_LAYER } from '../../zIndex/constants';
+import { __resetLayerZIndexForTests, __seedMainTopForTests } from '../../zIndex/manager';
+import { ContextMenuHost } from '../ContextMenuHost';
+import { closeContextMenu, showContextMenu } from '../store';
+import type { ContextMenuItem } from '../type';
+
+if (!globalThis.ResizeObserver) {
+  globalThis.ResizeObserver = class {
+    disconnect() {}
+    observe() {}
+    unobserve() {}
+  } as any;
+}
+
+vi.mock('antd-style', async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return {
+    ...actual,
+    createStaticStyles: vi.fn((fn: any) => () => {
+      const result = fn({ css: () => '', cssVar: {} });
+      return new Proxy(result, { get: (target, key) => target[key] || '' });
+    }),
+  };
+});
+
+const submenuItems: ContextMenuItem[] = [
+  {
+    children: [{ key: 'email', label: 'Email' }],
+    defaultOpen: true,
+    key: 'share',
+    label: 'Share',
+  },
+];
+
+const renderHost = () =>
+  render(
+    <AppElementContext value={document.body as unknown as HTMLDivElement}>
+      <ContextMenuHost />
+    </AppElementContext>,
+  );
+
+const getRootPositioner = () => {
+  const share = screen.getByRole('menuitem', { name: 'Share' });
+  const rootMenu = share.closest('[role="menu"]');
+  expect(rootMenu).not.toBeNull();
+  return rootMenu!.parentElement as HTMLElement;
+};
+
+const getSubmenuPositioner = () => {
+  const email = screen.getByRole('menuitem', { name: 'Email' });
+  const submenu = email.closest('[role="menu"]');
+  expect(submenu).not.toBeNull();
+  return submenu!.parentElement as HTMLElement;
+};
+
+describe('ContextMenu submenu z-index stacking (#608)', () => {
+  beforeEach(() => {
+    __resetLayerZIndexForTests();
+  });
+
+  afterEach(() => {
+    act(() => closeContextMenu());
+    __resetLayerZIndexForTests();
+  });
+
+  test('nested submenu stays above root when root z-index exceeds the CSS submenu fallback', async () => {
+    // Simulate ~10 prior floating layer acquisitions so the next root open
+    // lands at/above 1200, past the hard-coded submenu CSS z-index (1199).
+    __seedMainTopForTests(Z_INDEX_LAYER.floating + Z_INDEX_LAYER.step * 9);
+
+    renderHost();
+
+    act(() => {
+      showContextMenu(submenuItems);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('menuitem', { name: 'Email' })).toBeDefined();
+    });
+
+    const rootZ = Number(getRootPositioner().style.zIndex);
+    const submenuZ = Number(getSubmenuPositioner().style.zIndex);
+
+    expect(rootZ).toBeGreaterThanOrEqual(1200);
+    expect(submenuZ).toBeGreaterThan(rootZ);
+  });
+});

--- a/src/base-ui/ContextMenu/renderItems.tsx
+++ b/src/base-ui/ContextMenu/renderItems.tsx
@@ -3,6 +3,7 @@ import { cx } from 'antd-style';
 import { Check } from 'lucide-react';
 import { type MenuInfo } from 'rc-menu/es/interface';
 import {
+  type ComponentProps,
   type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type ReactNode,
@@ -30,11 +31,36 @@ import {
 } from '@/Menu';
 import { preventDefaultAndStopPropagation } from '@/utils/dom';
 
+import { useLayerZIndex } from '../zIndex';
 import {
   type ContextMenuCheckboxItem,
   type ContextMenuItem,
   type ContextMenuSwitchItem,
 } from './type';
+
+type ContextMenuPositionerProps = ComponentProps<typeof ContextMenu.Positioner>;
+
+/**
+ * Submenu positioners are portaled outside the root menu, so they must allocate
+ * their own layer z-index (same pattern as DropdownMenu) rather than relying on
+ * the fixed CSS fallback that can fall behind after repeated root openings (#608).
+ */
+const ContextMenuSubmenuPositioner = memo(({ style, ...rest }: ContextMenuPositionerProps) => {
+  const explicitZIndex =
+    typeof style !== 'function' && style?.zIndex != null && typeof style.zIndex === 'number'
+      ? style.zIndex
+      : undefined;
+  const { zIndex, ref: zRef } = useLayerZIndex<HTMLDivElement>('floating', explicitZIndex);
+
+  const resolvedStyle =
+    typeof style === 'function'
+      ? (state: any) => ({ zIndex, ...style(state) })
+      : { zIndex, ...style };
+
+  return <ContextMenu.Positioner {...rest} ref={zRef as any} style={resolvedStyle} />;
+});
+
+ContextMenuSubmenuPositioner.displayName = 'ContextMenuSubmenuPositioner';
 
 export type { IconAlign, IconSpaceMode } from '@/Menu';
 
@@ -326,7 +352,7 @@ export const renderContextMenuItems = (
             })}
           </ContextMenu.SubmenuTrigger>
           <ContextMenu.Portal>
-            <ContextMenu.Positioner
+            <ContextMenuSubmenuPositioner
               alignOffset={-4}
               className={styles.positioner}
               data-submenu=""
@@ -348,7 +374,7 @@ export const renderContextMenuItems = (
                   <div className={styles.footer}>{submenu.footer}</div>
                 )}
               </ContextMenu.Popup>
-            </ContextMenu.Positioner>
+            </ContextMenuSubmenuPositioner>
           </ContextMenu.Portal>
         </ContextMenu.SubmenuRoot>
       );


### PR DESCRIPTION
## Summary

Fixes #608.

The ContextMenu root layer can receive a dynamically increasing z-index after
repeated open/close cycles, while the nested submenu previously used a fixed
z-index. This could cause the root menu to render above the submenu and
intercept interaction.

This change ensures the nested submenu maintains the correct stacking order.

## Changes

- Fix ContextMenu submenu z-index stacking.
- Add regression coverage for the z-index stacking issue.
- Preserve existing submenu behavior.

## Testing

- [x] Added regression test for #608
- [x] Type-check passed
- [x] Circular dependency check passed
- [x] Prettier passed
- [x] Stylelint passed
- [x] ESLint passed