### PR TITLE
🐛 fix(docs-kit): sync navigation section count with base-ui doc pages

### DIFF
--- a/packages/docs-kit/site/content/navigation.test.ts
+++ b/packages/docs-kit/site/content/navigation.test.ts
@@ -167,8 +167,8 @@ describe('reviewed documentation navigation', () => {
       compactEntries.map(([source, section]) => [sourceIdentity(source), section]),
     );
 
-    expect(compactEntries).toHaveLength(164);
-    expect(compactBySource.size).toBe(164);
+    expect(compactEntries).toHaveLength(168);
+    expect(compactBySource.size).toBe(168);
     for (const frozenDocument of compatibility.documents) {
       expect(compactBySource.get(sourceIdentity(frozenDocument.source))).toBe(
         frozenDocument.section,


### PR DESCRIPTION
PR #621 added 4 base-ui doc pages to `navigationSections.json` (164 → 168) but the hardcoded count in `navigation.test.ts` was not updated, so Release CI on master fails and blocks the release.

- `packages/docs-kit/site/content/navigation.test.ts`: 164 → 168

`pnpm vitest run packages/docs-kit/site/content/navigation.test.ts` → 8 passed.