### PR TITLE
🐛 fix(base-ui): resolve nativeButton for the base-ui ActionIcon trigger

### DIFF
--- a/src/base-ui/ActionIcon/ActionIcon.tsx
+++ b/src/base-ui/ActionIcon/ActionIcon.tsx
@@ -126,6 +126,6 @@ const ActionIcon = memo<ActionIconProps>(
   },
 );
 
-ActionIcon.displayName = 'ActionIcon';
+ActionIcon.displayName = 'BaseActionIcon';
 
 export default ActionIcon;

--- a/src/hooks/useNativeButton.test.tsx
+++ b/src/hooks/useNativeButton.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react';
 
+import ActionIcon from '@/base-ui/ActionIcon';
 import Button from '@/base-ui/Button';
 
 import { useNativeButton } from './useNativeButton';
@@ -7,6 +8,12 @@ import { useNativeButton } from './useNativeButton';
 describe('useNativeButton', () => {
   test('recognizes the base-ui Button as a native button trigger', () => {
     const { result } = renderHook(() => useNativeButton({ children: <Button>Open menu</Button> }));
+
+    expect(result.current.resolvedNativeButton).toBe(true);
+  });
+
+  test('recognizes the base-ui ActionIcon as a native button trigger', () => {
+    const { result } = renderHook(() => useNativeButton({ children: <ActionIcon /> }));
 
     expect(result.current.resolvedNativeButton).toBe(true);
   });

--- a/src/hooks/useNativeButton.ts
+++ b/src/hooks/useNativeButton.ts
@@ -38,6 +38,7 @@ const NATIVE_BUTTON_MAP: Record<string, boolean> = {
   Alert: false,
   Avatar: false,
   AvatarGroup: false,
+  BaseActionIcon: true,
   BaseButton: true,
   Block: false,
   BottomGradientButton: true,


### PR DESCRIPTION
The base-ui `ActionIcon` renders a native `<button>` (it composes base-ui `Button`), but it shipped with the same `displayName` as the antd-based one, which renders a `div`. `NATIVE_BUTTON_MAP` is keyed by `displayName`, so every DropdownMenu / Tooltip / Popover trigger built on the base-ui ActionIcon resolved `nativeButton` to `false`:

```
Base UI: A component that acts as a button expected a non-<button> because the
`nativeButton` prop is false. … can add unintended extra attributes (such as
`role` or `aria-disabled`).
    at DropdownMenuTrigger
```

It is not only console noise — Base UI then applies non-native `role` / `aria-disabled` to a real button, and call sites cannot work around it (an explicit `nativeButton` on the consumer side is overridden by the map lookup).

## Changes

- `src/base-ui/ActionIcon`: `displayName` `'ActionIcon'` -> `'BaseActionIcon'`, following the existing `'BaseButton'` precedent
- `src/hooks/useNativeButton.ts`: map `BaseActionIcon: true`
- one assertion added to `useNativeButton.test.tsx`

## Verification

Patched build dropped into lobehub-cloud (which uses base-ui ActionIcon as a DropdownMenu trigger in the sidebar, agent actions and chat input):

```
before: 5+ Base UI nativeButton warnings on first render
after:  0
```

45 tests pass across `src/hooks`, `src/base-ui/ActionIcon`, `src/base-ui/DropdownMenu`; `tsc --noEmit` clean.