### PR TITLE
🐛 fix(docs): render the base-ui Text demo

### DIFF
--- a/src/base-ui/Text/index.mdx
+++ b/src/base-ui/Text/index.mdx
@@ -15,7 +15,7 @@ import DemoBasic from './demos/index.tsx?demo';
 
 Types, colors, headings, formatting combinations, and ellipsis modes:
 
-<code src="./demos/index.tsx" nopadding></code>
+<Demo of={DemoBasic} layout="bare" />
 
 ## APIs
 


### PR DESCRIPTION
The base-ui Text page renders an empty box where its only demo should be: `index.mdx` still uses the dumi-era `<code src>` syntax, which docs-kit leaves in the DOM as an inert `<code src="./demos/index.tsx"></code>` element.

It is the only file in the repo still on that syntax — every other page uses `<Demo of={...} />`, and the `DemoBasic` import was already present but unused.

Verified in the docs dev server: the Basic demo now renders (types, colors, headings, ellipsis modes).