### PR TITLE
🐛 fix(mermaid): give the diagram preview an opaque background

### DIFF
--- a/src/Mermaid/SyntaxMermaid/MermaidSvg.test.tsx
+++ b/src/Mermaid/SyntaxMermaid/MermaidSvg.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render } from '@testing-library/react';
+
+import MermaidSvg from './MermaidSvg';
+
+const openPreview = vi.hoisted(() => vi.fn());
+
+vi.mock('@/Image/viewer/registry', () => ({ openPreview, usePreviewSession: () => null }));
+
+const SVG = '<svg id="scope-1" viewBox="0 0 10 10" style="--bg: rgb(1, 2, 3)"></svg>';
+
+beforeEach(() => {
+  openPreview.mockClear();
+  vi.stubGlobal('URL', { ...URL, createObjectURL: () => 'blob:mermaid', revokeObjectURL: vi.fn() });
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('MermaidSvg', () => {
+  it('opens the in-house viewer anchored on the diagram box', () => {
+    const { container } = render(<MermaidSvg svg={SVG} />);
+
+    fireEvent.click(container.querySelector('svg')!.parentElement!);
+
+    expect(openPreview).toHaveBeenCalledTimes(1);
+    const entry = openPreview.mock.calls[0][0];
+    expect(entry.src).toBe('blob:mermaid');
+    expect(entry.element).toBe(container.querySelector('img'));
+  });
+});

--- a/src/Mermaid/SyntaxMermaid/MermaidSvg.tsx
+++ b/src/Mermaid/SyntaxMermaid/MermaidSvg.tsx
@@ -1,7 +1,10 @@
 'use client';
 
-import { Image as AntImage } from 'antd';
 import { memo, type Ref, useCallback, useEffect, useRef, useState } from 'react';
+
+import { DEFAULT_AUTO_ZOOM_THRESHOLD, DEFAULT_MAX_SCALE } from '@/Image/viewer/geometry';
+import PreviewOutlet from '@/Image/viewer/PreviewOutlet';
+import { openPreview } from '@/Image/viewer/registry';
 
 import { toStandaloneSvgString } from './prepareInlineSvg';
 import { prepareMermaidSvgString } from './prepareMermaidSvg';
@@ -13,10 +16,23 @@ interface MermaidSvgProps {
   svg: string;
 }
 
+// The viewer flies the image out of the element it was opened from, so the
+// diagram needs a real <img> to measure — hence a hidden anchor tracking the
+// diagram box rather than a display:none preview image.
+const anchorStyle: React.CSSProperties = {
+  height: '100%',
+  insetBlockStart: 0,
+  insetInlineStart: 0,
+  pointerEvents: 'none',
+  position: 'absolute',
+  visibility: 'hidden',
+  width: '100%',
+};
+
 const MermaidSvg = memo<MermaidSvgProps>(({ className, ref, style, svg }) => {
   const containerRef = useRef<HTMLDivElement>(null);
+  const anchorRef = useRef<HTMLImageElement>(null);
   const [previewUrl, setPreviewUrl] = useState<string>();
-  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     return () => {
@@ -28,32 +44,37 @@ const MermaidSvg = memo<MermaidSvgProps>(({ className, ref, style, svg }) => {
   // CSS variables and be XML-well-formed, neither of which the inline copy needs.
   const handleOpen = useCallback(() => {
     const element = containerRef.current?.querySelector('svg');
-    if (!element) return;
+    const anchor = anchorRef.current;
+    if (!element || !anchor) return;
 
     const standalone = prepareMermaidSvgString(toStandaloneSvgString(element));
+    const url = URL.createObjectURL(new Blob([standalone], { type: 'image/svg+xml' }));
     setPreviewUrl((previous) => {
       if (previous) URL.revokeObjectURL(previous);
-      return URL.createObjectURL(new Blob([standalone], { type: 'image/svg+xml' }));
+      return url;
     });
-    setOpen(true);
+
+    openPreview({
+      element: anchor,
+      options: {
+        autoZoomThreshold: DEFAULT_AUTO_ZOOM_THRESHOLD,
+        defaultZoom: 'auto',
+        maxScale: DEFAULT_MAX_SCALE,
+      },
+      src: url,
+    });
   }, []);
 
   return (
-    <div className={className} ref={ref} style={style}>
+    <div className={className} ref={ref} style={{ position: 'relative', ...style }}>
       <div
         dangerouslySetInnerHTML={{ __html: svg }}
         ref={containerRef}
         style={{ cursor: 'zoom-in' }}
         onClick={handleOpen}
       />
-      {previewUrl && (
-        <AntImage
-          preview={{ onVisibleChange: setOpen, src: previewUrl, visible: open }}
-          src={previewUrl}
-          style={{ display: 'none' }}
-          wrapperStyle={{ display: 'none' }}
-        />
-      )}
+      <img aria-hidden alt="" ref={anchorRef} src={previewUrl} style={anchorStyle} />
+      <PreviewOutlet elementRef={anchorRef} />
     </div>
   );
 });

--- a/src/Mermaid/SyntaxMermaid/prepareInlineSvg.test.ts
+++ b/src/Mermaid/SyntaxMermaid/prepareInlineSvg.test.ts
@@ -73,4 +73,18 @@ describe('toStandaloneSvgString', () => {
     expect(standalone).toContain('--bg: #0d0d0d');
     expect(standalone).toContain('--fg: #ffffff');
   });
+
+  it('paints the background so the copy is not transparent', () => {
+    const host = document.createElement('div');
+    host.innerHTML = prepareInlineMermaidSvg(render(), 'scope-1');
+    document.body.append(host);
+
+    const svg = host.querySelector('svg')!;
+    svg.style.setProperty('--bg', 'rgb(13, 13, 13)');
+
+    const standalone = toStandaloneSvgString(svg);
+    host.remove();
+
+    expect(standalone).toContain('background: rgb(13, 13, 13)');
+  });
 });

--- a/src/Mermaid/SyntaxMermaid/prepareInlineSvg.ts
+++ b/src/Mermaid/SyntaxMermaid/prepareInlineSvg.ts
@@ -61,6 +61,12 @@ export const toStandaloneSvgString = (element: SVGElement): string => {
     if (value) clone.style.setProperty(name, value);
   }
 
+  // The diagram is rendered transparent so it inherits the page surface, but a
+  // standalone copy has nothing behind it: without an explicit fill the viewer
+  // scrim (and whatever it lets through) shows straight through the diagram.
+  const background = computed.getPropertyValue('--bg').trim();
+  if (background) clone.style.setProperty('background', background);
+
   const fontFamily = computed.fontFamily;
   if (fontFamily) clone.style.setProperty('font-family', fontFamily);
 

--- a/src/static-css/baseline.ts
+++ b/src/static-css/baseline.ts
@@ -17,7 +17,6 @@ export const lobeUiAntdBaseline: AntdProbeName[] = [
   'dropdown',
   'empty',
   'form',
-  'image',
   'input',
   'input-number',
   'input-textarea',


### PR DESCRIPTION
## What

Mermaid 图的预览灯箱没有背景：图是透明的，直接透过遮罩看到底下的页面内容。

## Why

1. `useMermaid` 的 `LOBE_THEME_OPTIONS` 用 `transparent: true`，beautiful-mermaid 因此不输出 `background:var(--bg)` —— 内嵌在页面里没问题（继承页面底色），但 Blob 独立文档背后什么都没有。
2. `toStandaloneSvgString()` 只把 `--bg/--fg/...` 烘成字面值，没有真的刷背景。
3. `MermaidSvg` 用的是 `antd` 的 `Image`（`.ant-image-preview-mask`，45% 黑遮罩），Image 迁到自研 viewer 时漏掉了这里。

## How

- `toStandaloneSvgString()` 把解析后的 `--bg` 刷成 SVG 背景，独立副本不再透明。
- `MermaidSvg` 改用自研 viewer（`openPreview` + `PreviewOutlet`），去掉 antd `Image` 依赖。viewer 需要一个真实元素做 FLIP 起点，所以用一个覆盖在图上的隐藏 `<img>` 当锚点。

## Test

- `prepareInlineSvg.test.ts`：新增背景断言，改动前红、改动后绿。
- `MermaidSvg.test.tsx`：新增，断言点击走自研 viewer 且锚在图的盒子上。
- `src/Mermaid` + `src/Image` 全绿（277 tests），`tsc --noEmit` 通过。