### PR TITLE
🔧 chore(eslint): ban the migrated ActionIcon, Avatar, Tag and Text wrappers

### DIFF
--- a/src/eslint/index.test.ts
+++ b/src/eslint/index.test.ts
@@ -38,6 +38,12 @@ describe('restrictedImports', () => {
     ]);
   });
 
+  it.each(['ActionIcon', 'Avatar', 'Tag', 'Text'])('rejects the migrated %s wrapper', (name) => {
+    expect(lint(`import { ${name} } from '@lobehub/ui';`)).toEqual([
+      expect.objectContaining({ ruleId: 'no-restricted-imports', severity: 2 }),
+    ]);
+  });
+
   it('allows Alert from the Base UI entrypoint', () => {
     expect(lint("import { Alert } from '@lobehub/ui/base-ui';")).toEqual([]);
   });

--- a/src/eslint/index.ts
+++ b/src/eslint/index.ts
@@ -1,6 +1,8 @@
 const DEPRECATED_UI_COMPONENTS = [
+  'ActionIcon',
   'Alert',
   'AutoComplete',
+  'Avatar',
   'Button',
   'Checkbox',
   'CheckboxGroup',
@@ -13,6 +15,8 @@ const DEPRECATED_UI_COMPONENTS = [
   'Slider',
   'SliderWithInput',
   'Tabs',
+  'Tag',
+  'Text',
 ];
 
 const DEPRECATED_ANTD_COMPONENT_PATHS = [


### PR DESCRIPTION
`ActionIcon`, `Avatar`, `Tag` and `Text` all have Base UI implementations now, so the antd-based wrappers belong in `DEPRECATED_UI_COMPONENTS` alongside the rest.

Adds a test asserting each of the four is rejected from the `@lobehub/ui` root.

Note for consumers: the list is shared between the `@lobehub/ui` and `antd` entries, so this also flags `Avatar` / `Tag` imported straight from `antd`.