### PR TITLE
💄 style(base-ui): rebalance Modal header and body spacing

### DIFF
--- a/packages/docs-kit/site/components/DocsLayout/DocsLayout.test.tsx
+++ b/packages/docs-kit/site/components/DocsLayout/DocsLayout.test.tsx
@@ -165,7 +165,7 @@ it('does not override component typography inside an embedded demo', () => {
   const demoHeading = screen.getByRole('heading', { name: 'Demo modal title' });
 
   expect(getComputedStyle(documentationHeading).fontSize).toBe('1.625rem');
-  expect(getComputedStyle(demoHeading).fontSize).toBe('17px');
+  expect(getComputedStyle(demoHeading).fontSize).toBe('14px');
   expect(getComputedStyle(demoHeading).fontWeight).toBe('600');
   expect(getComputedStyle(demoHeading).marginBlockStart).toBe('0');
 });

--- a/src/base-ui/Modal/Modal.tsx
+++ b/src/base-ui/Modal/Modal.tsx
@@ -301,7 +301,7 @@ const Modal = memo<ModalComponentProps>(
               </ModalHeader>
             )}
             <ModalContent
-              className={classNames?.body}
+              className={cx(!showHeader && styles.contentNoHeader, classNames?.body)}
               style={{
                 ...(hasHeight || isFullscreen ? { flex: 1 } : {}),
                 ...semanticStyles?.body,

--- a/src/base-ui/Modal/imperative.tsx
+++ b/src/base-ui/Modal/imperative.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { cx } from 'antd-style';
 import type { ReactNode } from 'react';
 import { memo, useCallback, useEffect, useState, useSyncExternalStore } from 'react';
 import { createPortal } from 'react-dom';
@@ -21,6 +22,7 @@ import {
   ModalTitle,
 } from './atoms';
 import { ModalContext, useModalContext } from './context';
+import { styles } from './style';
 import type { ImperativeModalProps, ModalConfirmConfig, ModalInstance } from './type';
 
 // --- Shared types ---
@@ -205,7 +207,10 @@ export function createModalSystem(): ModalSystem {
                   <ModalClose className={classNames?.close} style={semanticStyles?.close} />
                 </ModalHeader>
               )}
-              <ModalContent className={classNames?.content} style={semanticStyles?.content}>
+              <ModalContent
+                className={cx(!showTitle && styles.contentNoHeader, classNames?.content)}
+                style={semanticStyles?.content}
+              >
                 {content ?? children}
               </ModalContent>
               {footer}

--- a/src/base-ui/Modal/style.ts
+++ b/src/base-ui/Modal/style.ts
@@ -20,7 +20,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     cursor: pointer;
 
     position: absolute;
-    inset-block-start: 12px;
+    inset-block-start: 8px;
     inset-inline-end: 12px;
 
     display: flex;
@@ -84,8 +84,12 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
 
   content: css`
     overflow: hidden auto;
-    padding-block: 12px;
+    padding-block: 0 16px;
     padding-inline: 16px;
+  `,
+
+  contentNoHeader: css`
+    padding-block-start: 16px;
   `,
 
   footer: css`
@@ -103,8 +107,8 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     align-items: center;
     justify-content: space-between;
 
-    min-height: 56px;
-    padding-block: 12px;
+    min-height: 48px;
+    padding-block: 8px;
     padding-inline: 16px;
   `,
 
@@ -164,11 +168,10 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   title: css`
     margin: 0;
 
-    font-size: 17px;
+    font-size: 14px;
     font-weight: 600;
     line-height: 1.4;
     color: ${cssVar.colorText};
-    letter-spacing: -0.005em;
   `,
 
   loadingSpinner: css`


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Modals read top-heavy: a lot of chrome above the title, almost nothing below the last control.

Two causes:

1. **Stacked padding.** `header`'s `padding-block: 12px` and `content`'s `padding-block: 12px` add up to a 24px gap between the title and the first field.
2. **No footer to balance it.** `footer: null` is the common case, so the body's 12px `padding-bottom` is the only thing under the last control — 56px of header against 12px of tail.

Changes:

| | before | after |
|---|---|---|
| `header` | `min-height: 56px` / `padding-block: 12px` | `min-height: 48px` / `padding-block: 8px` |
| `content` | `padding-block: 12px` | `padding-block: 0 16px` |
| `close` | `inset-block-start: 12px` | `inset-block-start: 8px` |
| `title` | `17px`, `letter-spacing: -0.005em` | `14px`, no letter-spacing |

The `close` inset moves with the header so the 32px button stays vertically centred (8px above and below). Its hit area is unchanged.

`contentNoHeader` is new: with the top inset removed from `content`, a modal that renders no header would have its body flush against the panel edge, so that case gets its own 16px top inset back.

**`createModal` does not render `<Modal>`.** `imperative.tsx`'s `StackItem` is a separate renderer — it decides the header from `title` alone and uses the absolutely-positioned `ModalClose` rather than `Modal.tsx`'s inline close button. The `contentNoHeader` branch therefore lands in both paths; a fix in `Modal.tsx` alone is a no-op for every imperative modal.

`confirmModal` is unaffected — it already passes `styles: { content: { padding: 0 } }` and supplies its own body padding and footer.

#### 📝 补充信息 | Additional Information

Measured with the built package linked into lobe-chat, on real `createModal` call sites:

| | header | title | body padding | title → first field | last control → panel bottom |
|---|---|---|---|---|---|
| before | 56 | 17px/600 | 12 · 12 | 28 | 13 |
| after | 48 | 14px/600 | 0 · 16 | 14 | 17 |

Sampled 15 modals in lobe-chat across three shapes — header + default padding, header + `content padding: 0`, and no header. No regressions: the `padding: 0` call sites are untouched by definition, and the header-less ones pick up the new 16 · 16 body inset.