### PR TITLE
✨ feat(base-ui): add outdent to text Button and borderless ActionIcon

### DIFF
--- a/src/base-ui/ActionIcon/ActionIcon.tsx
+++ b/src/base-ui/ActionIcon/ActionIcon.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { cx } from 'antd-style';
-import type { MouseEvent, Ref } from 'react';
+import type { CSSProperties, MouseEvent, ReactElement, Ref } from 'react';
 import { memo, useMemo } from 'react';
 
 import type { ButtonProps } from '@/base-ui/Button';
@@ -9,9 +9,9 @@ import Button from '@/base-ui/Button';
 import Tooltip from '@/base-ui/Tooltip';
 import Icon from '@/Icon';
 
-import { variants } from './style';
-import { type ActionIconProps } from './type';
-import { calcSize } from './utils';
+import { styles, variants } from './style';
+import type { ActionIconOutdent, ActionIconProps, ActionIconVariant } from './type';
+import { calcOutdent, calcSize } from './utils';
 
 const resolveButtonType = (variant: ActionIconProps['variant']) => {
   if (variant === 'filled') return 'fill' as const;
@@ -25,7 +25,12 @@ const resolveButtonSize = (size: ActionIconProps['size']) => {
   return 'middle' as const;
 };
 
-const ActionIcon = memo<ActionIconProps>(
+type ActionIconImplProps = Omit<ActionIconProps, 'outdent' | 'variant'> & {
+  outdent?: ActionIconOutdent;
+  variant?: ActionIconVariant;
+};
+
+const ActionIconImpl = memo<ActionIconImplProps>(
   ({
     active,
     className,
@@ -41,12 +46,13 @@ const ActionIcon = memo<ActionIconProps>(
     icon,
     loading,
     onClick,
+    outdent,
     ref,
     shadow,
     size = 'middle',
     spin: iconSpinning,
     style,
-    styles,
+    styles: slotStyles,
     title,
     tooltipProps,
     variant = 'borderless',
@@ -80,15 +86,21 @@ const ActionIcon = memo<ActionIconProps>(
         icon={icon}
         size={size}
         spin={iconSpinning}
-        style={{ pointerEvents: 'none', ...styles?.icon }}
+        style={{ pointerEvents: 'none', ...slotStyles?.icon }}
       />
     ) : undefined;
+
+    const shouldOutdent = variant === 'borderless' && outdent;
+    const outdentCls = shouldOutdent
+      ? outdent === 'end'
+        ? styles.outdentEnd
+        : styles.outdentStart
+      : undefined;
 
     const node = (
       <Button
         {...(rest as unknown as ButtonProps)}
         aria-label={popupTriggerLabel}
-        className={cx(variants({ active, danger, glass, shadow }), classNames?.root, className)}
         danger={danger}
         disabled={disabled}
         htmlType="button"
@@ -98,11 +110,20 @@ const ActionIcon = memo<ActionIconProps>(
         size={resolveButtonSize(size)}
         tabIndex={disabled ? -1 : 0}
         type={resolveButtonType(variant)}
+        className={cx(
+          variants({ active, danger, glass, shadow }),
+          outdentCls,
+          classNames?.root,
+          className,
+        )}
         style={{
+          ...(shouldOutdent
+            ? ({ '--action-icon-outdent': calcOutdent(size) } as CSSProperties)
+            : undefined),
           borderRadius,
           height: blockSize,
           width: blockSize,
-          ...styles?.root,
+          ...slotStyles?.root,
           ...style,
         }}
         onClick={handleClick}
@@ -126,6 +147,10 @@ const ActionIcon = memo<ActionIconProps>(
   },
 );
 
-ActionIcon.displayName = 'BaseActionIcon';
+ActionIconImpl.displayName = 'BaseActionIcon';
+
+const ActionIcon = ActionIconImpl as unknown as <V extends ActionIconVariant = 'borderless'>(
+  props: ActionIconProps<V>,
+) => ReactElement;
 
 export default ActionIcon;

--- a/src/base-ui/ActionIcon/ActionIcon.tsx
+++ b/src/base-ui/ActionIcon/ActionIcon.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { cx } from 'antd-style';
-import type { CSSProperties, MouseEvent, ReactElement, Ref } from 'react';
+import type { MouseEvent, ReactElement, Ref } from 'react';
 import { memo, useMemo } from 'react';
 
 import type { ButtonProps } from '@/base-ui/Button';
@@ -9,7 +9,7 @@ import Button from '@/base-ui/Button';
 import Tooltip from '@/base-ui/Tooltip';
 import Icon from '@/Icon';
 
-import { styles, variants } from './style';
+import { variants } from './style';
 import type { ActionIconOutdent, ActionIconProps, ActionIconVariant } from './type';
 import { calcOutdent, calcSize } from './utils';
 
@@ -90,17 +90,18 @@ const ActionIconImpl = memo<ActionIconImplProps>(
       />
     ) : undefined;
 
-    const shouldOutdent = variant === 'borderless' && outdent;
-    const outdentCls = shouldOutdent
+    const outdentAmount = variant === 'borderless' && outdent ? calcOutdent(size) : undefined;
+    const outdentMargin = outdentAmount
       ? outdent === 'end'
-        ? styles.outdentEnd
-        : styles.outdentStart
+        ? { marginInlineEnd: `-${outdentAmount}` }
+        : { marginInlineStart: `-${outdentAmount}` }
       : undefined;
 
     const node = (
       <Button
         {...(rest as unknown as ButtonProps)}
         aria-label={popupTriggerLabel}
+        className={cx(variants({ active, danger, glass, shadow }), classNames?.root, className)}
         danger={danger}
         disabled={disabled}
         htmlType="button"
@@ -110,16 +111,8 @@ const ActionIconImpl = memo<ActionIconImplProps>(
         size={resolveButtonSize(size)}
         tabIndex={disabled ? -1 : 0}
         type={resolveButtonType(variant)}
-        className={cx(
-          variants({ active, danger, glass, shadow }),
-          outdentCls,
-          classNames?.root,
-          className,
-        )}
         style={{
-          ...(shouldOutdent
-            ? ({ '--action-icon-outdent': calcOutdent(size) } as CSSProperties)
-            : undefined),
+          ...outdentMargin,
           borderRadius,
           height: blockSize,
           width: blockSize,

--- a/src/base-ui/ActionIcon/__tests__/ActionIcon.test.tsx
+++ b/src/base-ui/ActionIcon/__tests__/ActionIcon.test.tsx
@@ -6,7 +6,8 @@ import { type ReactNode } from 'react';
 import ConfigProvider from '@/ConfigProvider';
 
 import ActionIcon from '../ActionIcon';
-import { calcSize } from '../utils';
+import type { ActionIconProps } from '../type';
+import { actionIconOutdent, calcOutdent, calcSize } from '../utils';
 
 const renderActionIcon = (ui: ReactNode) =>
   render(<ConfigProvider motion={motion}>{ui}</ConfigProvider>);
@@ -48,6 +49,15 @@ describe('ActionIcon', () => {
     expect(calcSize(undefined)).toEqual({ blockSize: '1.8em', borderRadius: '0.3em' });
     expect(calcSize('large')).toEqual({ blockSize: 44, borderRadius: 8 });
     expect(calcSize({ blockSize: 40 })).toEqual({ blockSize: 40, borderRadius: 6 });
+  });
+
+  test('calcOutdent is half of block minus glyph', () => {
+    expect(calcOutdent('small')).toBe(`${actionIconOutdent.small}px`);
+    expect(calcOutdent('middle')).toBe(`${actionIconOutdent.middle}px`);
+    expect(calcOutdent('large')).toBe(`${actionIconOutdent.large}px`);
+    expect(calcOutdent(32)).toBe('12.8px');
+    expect(calcOutdent({ blockSize: 48 })).toBe('12px');
+    expect(calcOutdent(undefined)).toBe('0.4em');
   });
 
   test('blocks clicks while disabled and marks the root untabbable', () => {
@@ -121,4 +131,37 @@ describe('ActionIcon', () => {
     expect(container.querySelector('.icon-slot')).not.toBeNull();
     expect(getComputedStyle(root).background).toBe('rgb(255, 0, 0)');
   });
+
+  test.each(['small', 'middle', 'large'] as const)(
+    'outdent on a borderless ActionIcon cancels %s icon inset',
+    (size) => {
+      renderActionIcon(<ActionIcon outdent icon={Settings} size={size} />);
+
+      const style = getComputedStyle(screen.getByRole('button'));
+
+      expect(style.getPropertyValue('--action-icon-outdent').trim()).toBe(
+        `${actionIconOutdent[size]}px`,
+      );
+      expect(style.marginInlineStart.replaceAll(' ', '')).toBe(
+        'calc(var(--action-icon-outdent)*-1)',
+      );
+    },
+  );
+
+  test('outdent="end" cancels inset on the end edge', () => {
+    renderActionIcon(<ActionIcon icon={Settings} outdent={'end'} />);
+
+    const style = getComputedStyle(screen.getByRole('button'));
+
+    expect(style.marginInlineEnd.replaceAll(' ', '')).toBe('calc(var(--action-icon-outdent)*-1)');
+    expect(style.marginInlineStart.replaceAll(' ', '')).not.toContain('--action-icon-outdent');
+  });
 });
+
+{
+  const borderless: ActionIconProps<'borderless'> = { outdent: true, variant: 'borderless' };
+  void borderless;
+  // @ts-expect-error outdent is only on variant="borderless"
+  const filled: ActionIconProps<'filled'> = { outdent: true, variant: 'filled' };
+  void filled;
+}

--- a/src/base-ui/ActionIcon/__tests__/ActionIcon.test.tsx
+++ b/src/base-ui/ActionIcon/__tests__/ActionIcon.test.tsx
@@ -137,13 +137,8 @@ describe('ActionIcon', () => {
     (size) => {
       renderActionIcon(<ActionIcon outdent icon={Settings} size={size} />);
 
-      const style = getComputedStyle(screen.getByRole('button'));
-
-      expect(style.getPropertyValue('--action-icon-outdent').trim()).toBe(
-        `${actionIconOutdent[size]}px`,
-      );
-      expect(style.marginInlineStart.replaceAll(' ', '')).toBe(
-        'calc(var(--action-icon-outdent)*-1)',
+      expect(getComputedStyle(screen.getByRole('button')).marginInlineStart).toBe(
+        `-${actionIconOutdent[size]}px`,
       );
     },
   );
@@ -153,8 +148,8 @@ describe('ActionIcon', () => {
 
     const style = getComputedStyle(screen.getByRole('button'));
 
-    expect(style.marginInlineEnd.replaceAll(' ', '')).toBe('calc(var(--action-icon-outdent)*-1)');
-    expect(style.marginInlineStart.replaceAll(' ', '')).not.toContain('--action-icon-outdent');
+    expect(style.marginInlineEnd).toBe(`-${actionIconOutdent.middle}px`);
+    expect(style.marginInlineStart).not.toBe(`-${actionIconOutdent.middle}px`);
   });
 });
 

--- a/src/base-ui/ActionIcon/demos/outdent.tsx
+++ b/src/base-ui/ActionIcon/demos/outdent.tsx
@@ -1,0 +1,48 @@
+import { Flexbox } from '@lobehub/ui';
+import { ActionIcon, Text } from '@lobehub/ui/base-ui';
+import { Paperclip } from 'lucide-react';
+
+const TaskHeader = ({ outdent }: { outdent?: boolean }) => (
+  <Flexbox
+    gap={8}
+    padding={16}
+    style={{
+      border: '1px solid var(--ant-color-border-secondary, rgba(127,127,127,0.25))',
+      borderRadius: 12,
+      maxWidth: 560,
+    }}
+  >
+    <Text strong>Make the tasks page feel like a workbench</Text>
+    <Text fontSize={13} type={'secondary'}>
+      The task list should read as a workbench: grouped, scannable, and ready to act on.
+    </Text>
+    <ActionIcon
+      icon={Paperclip}
+      outdent={outdent || undefined}
+      size={'small'}
+      title={'Attach file'}
+    />
+    <Flexbox gap={6}>
+      <Text fontSize={13}>Review the current task list layout</Text>
+      <Text fontSize={13}>Propose a grouped workbench structure</Text>
+      <Text fontSize={13}>Ship the workbench grouping on the tasks page</Text>
+    </Flexbox>
+  </Flexbox>
+);
+
+export default () => (
+  <Flexbox gap={20} padding={16}>
+    <Flexbox gap={8}>
+      <Text fontSize={12} type={'secondary'}>
+        default
+      </Text>
+      <TaskHeader />
+    </Flexbox>
+    <Flexbox gap={8}>
+      <Text fontSize={12} type={'secondary'}>
+        outdent
+      </Text>
+      <TaskHeader outdent />
+    </Flexbox>
+  </Flexbox>
+);

--- a/src/base-ui/ActionIcon/index.mdx
+++ b/src/base-ui/ActionIcon/index.mdx
@@ -6,6 +6,7 @@ category: General
 
 import DemoDropdownMenu from './demos/DropdownMenu.tsx?demo';
 import DemoIndex from './demos/index.tsx?demo';
+import DemoOutdent from './demos/outdent.tsx?demo';
 
 ## Playground
 
@@ -14,6 +15,12 @@ import DemoIndex from './demos/index.tsx?demo';
 ## DropdownMenu trigger
 
 <Demo of={DemoDropdownMenu} layout="bare" />
+
+## Outdent borderless
+
+`outdent` is typed onto `variant="borderless"` only (the default). It applies a negative margin equal to this size's icon inset — half of `blockSize − glyph` (`small` 5, `middle` 8, `large` 10) — so a paperclip action lines up with the title and list beside it.
+
+<Demo of={DemoOutdent} layout="bare" />
 
 ## API
 

--- a/src/base-ui/ActionIcon/index.ts
+++ b/src/base-ui/ActionIcon/index.ts
@@ -3,7 +3,9 @@ export { default as ActionIcon } from './ActionIcon';
 export { styles as actionIconStyles } from './style';
 export type {
   ActionIconClassNames,
+  ActionIconOutdent,
   ActionIconProps,
   ActionIconSize,
   ActionIconStyles,
+  ActionIconVariant,
 } from './type';

--- a/src/base-ui/ActionIcon/style.ts
+++ b/src/base-ui/ActionIcon/style.ts
@@ -31,6 +31,12 @@ export const styles = createStaticStyles(({ css, cssVar }) => {
       }
     `,
     shadow: lobeStaticStylish.shadow,
+    outdentStart: css`
+      margin-inline-start: calc(var(--action-icon-outdent) * -1);
+    `,
+    outdentEnd: css`
+      margin-inline-end: calc(var(--action-icon-outdent) * -1);
+    `,
   };
 });
 

--- a/src/base-ui/ActionIcon/style.ts
+++ b/src/base-ui/ActionIcon/style.ts
@@ -31,12 +31,6 @@ export const styles = createStaticStyles(({ css, cssVar }) => {
       }
     `,
     shadow: lobeStaticStylish.shadow,
-    outdentStart: css`
-      margin-inline-start: calc(var(--action-icon-outdent) * -1);
-    `,
-    outdentEnd: css`
-      margin-inline-end: calc(var(--action-icon-outdent) * -1);
-    `,
   };
 });
 

--- a/src/base-ui/ActionIcon/type.ts
+++ b/src/base-ui/ActionIcon/type.ts
@@ -10,6 +10,8 @@ interface ActionIconSizeConfig extends IconSizeConfig {
 }
 
 export type ActionIconSize = number | IconSizeType | ActionIconSizeConfig;
+export type ActionIconVariant = 'borderless' | 'filled' | 'outlined';
+export type ActionIconOutdent = boolean | 'start' | 'end';
 
 export interface ActionIconClassNames {
   icon?: string;
@@ -21,7 +23,7 @@ export interface ActionIconStyles {
   root?: CSSProperties;
 }
 
-export interface ActionIconProps
+interface BaseActionIconOwnProps
   extends Partial<LucideIconProps>, Omit<CenterProps, 'title' | 'children'> {
   active?: boolean;
   classNames?: ActionIconClassNames;
@@ -37,5 +39,19 @@ export interface ActionIconProps
   styles?: ActionIconStyles;
   title?: TooltipProps['title'];
   tooltipProps?: Omit<TooltipProps, 'children' | 'title'>;
-  variant?: 'borderless' | 'filled' | 'outlined';
 }
+
+type BorderlessOutdentProps<V extends ActionIconVariant> = [V] extends ['borderless']
+  ? {
+      /**
+       * Cancels this size's icon inset (half of block − glyph) with a negative
+       * margin so a borderless ActionIcon lines up with adjacent copy. `true` /
+       * `'start'` outdent the start edge; `'end'` outdents the end edge.
+       */
+      outdent?: ActionIconOutdent;
+      variant?: V;
+    }
+  : { outdent?: never; variant?: V };
+
+export type ActionIconProps<V extends ActionIconVariant = ActionIconVariant> =
+  BaseActionIconOwnProps & BorderlessOutdentProps<V>;

--- a/src/base-ui/ActionIcon/utils.ts
+++ b/src/base-ui/ActionIcon/utils.ts
@@ -2,6 +2,14 @@ import { isNumber } from 'es-toolkit/compat';
 
 import type { ActionIconSize } from './type';
 
+export const actionIconOutdent = {
+  large: 10,
+  middle: 8,
+  small: 5,
+} as const;
+
+const toCss = (value: number | string) => (isNumber(value) ? `${value}px` : value);
+
 export const calcSize = (iconSize?: ActionIconSize) => {
   let blockSize: number | string;
   let borderRadius: number | string;
@@ -47,4 +55,33 @@ export const calcSize = (iconSize?: ActionIconSize) => {
     blockSize,
     borderRadius,
   };
+};
+
+export const calcOutdent = (iconSize?: ActionIconSize) => {
+  if (isNumber(iconSize)) {
+    return `${iconSize * 0.4}px`;
+  }
+
+  switch (iconSize) {
+    case 'large': {
+      return `${actionIconOutdent.large}px`;
+    }
+    case 'middle': {
+      return `${actionIconOutdent.middle}px`;
+    }
+    case 'small': {
+      return `${actionIconOutdent.small}px`;
+    }
+    default: {
+      if (iconSize) {
+        const { blockSize } = calcSize(iconSize);
+        const glyph = iconSize.size ?? 24;
+        if (isNumber(blockSize) && isNumber(glyph)) {
+          return `${Math.max(0, (blockSize - glyph) / 2)}px`;
+        }
+        return `calc((${toCss(blockSize)} - ${toCss(glyph)}) / 2)`;
+      }
+      return '0.4em';
+    }
+  }
 };

--- a/src/base-ui/Button/Button.tsx
+++ b/src/base-ui/Button/Button.tsx
@@ -1,13 +1,19 @@
 'use client';
 
 import { cx } from 'antd-style';
-import { isValidElement, type MouseEvent, type ReactNode, type Ref } from 'react';
+import {
+  isValidElement,
+  type MouseEvent,
+  type ReactElement,
+  type ReactNode,
+  type Ref,
+} from 'react';
 
 import Icon, { type IconProps } from '@/Icon';
 import { useMotionComponent } from '@/MotionProvider';
 
 import { styles } from './style';
-import type { ButtonProps } from './type';
+import type { ButtonOutdent, ButtonProps, ButtonType } from './type';
 
 const resolveIconNode = (node: ReactNode | IconProps['icon'] | undefined | null) => {
   if (node === undefined || node === null) return null;
@@ -76,13 +82,19 @@ const motionTransition = {
   type: 'spring' as const,
 };
 
-const Button = ({
+type ButtonImplProps = Omit<ButtonProps, 'outdent' | 'type'> & {
+  outdent?: ButtonOutdent;
+  type?: ButtonType;
+};
+
+const ButtonImpl = ({
   block,
   children,
   className,
   classNames,
   danger = false,
   disabled,
+  outdent,
   ghost = false,
   href,
   htmlType = 'button',
@@ -97,7 +109,7 @@ const Button = ({
   target,
   type = 'default',
   ...rest
-}: ButtonProps) => {
+}: ButtonImplProps) => {
   const Motion = useMotionComponent();
   const isInteractionDisabled = disabled || loading;
   const sizeCls = resolveSizeCls(size);
@@ -111,6 +123,13 @@ const Button = ({
   const iconOnly = !hasChildren && !!renderIcon;
   const iconOnlySizeCls = iconOnly ? resolveIconOnlySizeCls(size) : undefined;
 
+  const outdentCls =
+    type === 'text' && outdent
+      ? outdent === 'end'
+        ? styles.outdentEnd
+        : styles.outdentStart
+      : undefined;
+
   const composedClassName = cx(
     styles.base,
     sizeCls,
@@ -119,6 +138,7 @@ const Button = ({
     block && styles.block,
     iconPosition === 'end' && styles.iconEnd,
     iconOnlySizeCls,
+    outdentCls,
     className,
   );
 
@@ -208,6 +228,10 @@ const Button = ({
   );
 };
 
-Button.displayName = 'BaseButton';
+ButtonImpl.displayName = 'BaseButton';
+
+const Button = ButtonImpl as <T extends ButtonType = 'default'>(
+  props: ButtonProps<T>,
+) => ReactElement;
 
 export default Button;

--- a/src/base-ui/Button/__tests__/Button.test.tsx
+++ b/src/base-ui/Button/__tests__/Button.test.tsx
@@ -5,6 +5,7 @@ import { type ReactNode, useState } from 'react';
 import ConfigProvider from '@/ConfigProvider';
 
 import Button from '../Button';
+import { buttonPaddingInline } from '../style';
 import type { ButtonProps } from '../type';
 
 const renderButton = (children: ReactNode) =>
@@ -151,4 +152,45 @@ describe('Button', () => {
       '0px',
     );
   });
+
+  test.each(['small', 'middle', 'large'] as const)(
+    'outdent on a text button cancels %s padding-inline',
+    (size) => {
+      renderButton(
+        <Button outdent size={size} type={'text'}>
+          Attach
+        </Button>,
+      );
+
+      const style = getComputedStyle(screen.getByRole('button', { name: 'Attach' }));
+
+      expect(style.getPropertyValue('--button-padding-inline').trim()).toBe(
+        `${buttonPaddingInline[size]}px`,
+      );
+      expect(style.marginInlineStart.replaceAll(' ', '')).toBe(
+        'calc(var(--button-padding-inline)*-1)',
+      );
+    },
+  );
+
+  test('outdent="end" cancels padding on the end edge', () => {
+    renderButton(
+      <Button outdent={'end'} type={'text'}>
+        Next
+      </Button>,
+    );
+
+    const style = getComputedStyle(screen.getByRole('button', { name: 'Next' }));
+
+    expect(style.marginInlineEnd.replaceAll(' ', '')).toBe('calc(var(--button-padding-inline)*-1)');
+    expect(style.marginInlineStart.replaceAll(' ', '')).not.toContain('--button-padding-inline');
+  });
 });
+
+{
+  const text: ButtonProps<'text'> = { outdent: true, type: 'text' };
+  void text;
+  // @ts-expect-error outdent is only on type="text"
+  const primary: ButtonProps<'primary'> = { outdent: true, type: 'primary' };
+  void primary;
+}

--- a/src/base-ui/Button/demos/outdent.tsx
+++ b/src/base-ui/Button/demos/outdent.tsx
@@ -1,0 +1,56 @@
+import { Flexbox } from '@lobehub/ui';
+import { Button, Text, TextArea } from '@lobehub/ui/base-ui';
+import { ImagePlus } from 'lucide-react';
+
+const RejectFooter = ({ outdent }: { outdent?: boolean }) => (
+  <Flexbox
+    gap={10}
+    padding={16}
+    style={{
+      border: '1px solid var(--ant-color-border-secondary, rgba(127,127,127,0.25))',
+      borderRadius: 12,
+      maxWidth: 560,
+    }}
+  >
+    <Text fontSize={12} type={'secondary'}>
+      Additional notes (optional)
+    </Text>
+    <TextArea
+      autoSize={{ maxRows: 5, minRows: 2 }}
+      placeholder={'What is wrong, and what do you expect instead…'}
+    />
+    <Flexbox horizontal align={'flex-start'} gap={8}>
+      <Flexbox horizontal flex={1}>
+        <Button
+          icon={<ImagePlus size={14} />}
+          outdent={outdent || undefined}
+          size={'small'}
+          type={'text'}
+        >
+          Attach screenshot
+        </Button>
+      </Flexbox>
+      <Button size={'small'}>Cancel</Button>
+      <Button size={'small'} type={'primary'}>
+        Submit feedback
+      </Button>
+    </Flexbox>
+  </Flexbox>
+);
+
+export default () => (
+  <Flexbox gap={20} padding={16}>
+    <Flexbox gap={8}>
+      <Text fontSize={12} type={'secondary'}>
+        default
+      </Text>
+      <RejectFooter />
+    </Flexbox>
+    <Flexbox gap={8}>
+      <Text fontSize={12} type={'secondary'}>
+        outdent
+      </Text>
+      <RejectFooter outdent />
+    </Flexbox>
+  </Flexbox>
+);

--- a/src/base-ui/Button/index.mdx
+++ b/src/base-ui/Button/index.mdx
@@ -7,6 +7,7 @@ category: General
 import DemoIndex from './demos/index.tsx?demo';
 import DemoSizes from './demos/sizes.tsx?demo';
 import DemoIcons from './demos/icons.tsx?demo';
+import DemoOutdent from './demos/outdent.tsx?demo';
 import DemoSplit from './demos/split.tsx?demo';
 
 ## Type, danger & ghost
@@ -20,6 +21,12 @@ import DemoSplit from './demos/split.tsx?demo';
 ## Icons, loading & link
 
 <Demo of={DemoIcons} layout="bare" />
+
+## Outdent text
+
+`outdent` is typed onto `type="text"` only. It applies a negative margin equal to that size's `padding-inline` (`small` 8, `middle` 14, `large` 16), so a text action such as **Attach screenshot** lines up with the field above it.
+
+<Demo of={DemoOutdent} layout="bare" />
 
 ## Split button
 

--- a/src/base-ui/Button/index.ts
+++ b/src/base-ui/Button/index.ts
@@ -5,5 +5,12 @@ export {
   type SplitButtonMenuProps,
   type SplitButtonProps,
 } from './SplitButton';
-export { styles as buttonStyles } from './style';
-export type { ButtonIconPosition, ButtonProps, ButtonShape, ButtonSize, ButtonType } from './type';
+export { buttonPaddingInline, styles as buttonStyles } from './style';
+export type {
+  ButtonIconPosition,
+  ButtonOutdent,
+  ButtonProps,
+  ButtonShape,
+  ButtonSize,
+  ButtonType,
+} from './type';

--- a/src/base-ui/Button/style.ts
+++ b/src/base-ui/Button/style.ts
@@ -2,6 +2,12 @@ import { createStaticStyles } from 'antd-style';
 
 import { controlHeight } from '@/base-ui/controlSize';
 
+export const buttonPaddingInline = {
+  large: 16,
+  middle: 14,
+  small: 8,
+} as const;
+
 export const styles = createStaticStyles(({ css, cssVar }) => ({
   base: css`
     cursor: pointer;
@@ -41,24 +47,38 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 
   sizeSmall: css`
+    --button-padding-inline: ${buttonPaddingInline.small}px;
+
     height: ${controlHeight.small}px;
-    padding-inline: 8px;
+    padding-inline: var(--button-padding-inline);
     border-radius: ${cssVar.borderRadiusSM};
     font-size: 12px;
   `,
 
   sizeMiddle: css`
+    --button-padding-inline: ${buttonPaddingInline.middle}px;
+
     height: ${controlHeight.middle}px;
-    padding-inline: 14px;
+    padding-inline: var(--button-padding-inline);
     border-radius: ${cssVar.borderRadiusSM};
     font-size: 13px;
   `,
 
   sizeLarge: css`
+    --button-padding-inline: ${buttonPaddingInline.large}px;
+
     height: ${controlHeight.large}px;
-    padding-inline: 16px;
+    padding-inline: var(--button-padding-inline);
     border-radius: ${cssVar.borderRadius};
     font-size: 14px;
+  `,
+
+  outdentStart: css`
+    margin-inline-start: calc(var(--button-padding-inline) * -1);
+  `,
+
+  outdentEnd: css`
+    margin-inline-end: calc(var(--button-padding-inline) * -1);
   `,
 
   shapeCircle: css`
@@ -79,16 +99,22 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 
   iconOnlySmall: css`
+    --button-padding-inline: 0px;
+
     width: 24px;
     padding-inline: 0;
   `,
 
   iconOnlyMiddle: css`
+    --button-padding-inline: 0px;
+
     width: 32px;
     padding-inline: 0;
   `,
 
   iconOnlyLarge: css`
+    --button-padding-inline: 0px;
+
     width: 40px;
     padding-inline: 0;
   `,

--- a/src/base-ui/Button/type.ts
+++ b/src/base-ui/Button/type.ts
@@ -12,6 +12,7 @@ export type ButtonType = 'default' | 'primary' | 'dashed' | 'fill' | 'link' | 't
 export type ButtonShape = 'default' | 'circle' | 'round';
 export type ButtonSize = 'small' | 'middle' | 'large';
 export type ButtonIconPosition = 'start' | 'end';
+export type ButtonOutdent = boolean | 'start' | 'end';
 
 interface BaseButtonOwnProps {
   block?: boolean;
@@ -35,17 +36,31 @@ interface BaseButtonOwnProps {
   size?: ButtonSize;
   styles?: { icon?: CSSProperties };
   target?: string;
-  type?: ButtonType;
 }
+
+type TextOutdentProps<T extends ButtonType> = [T] extends ['text']
+  ? {
+      /**
+       * Cancels this size's `padding-inline` with a negative margin so a `text`
+       * button lines up with adjacent copy. `true` / `'start'` outdent the start
+       * edge; `'end'` outdents the end edge.
+       */
+      outdent?: ButtonOutdent;
+      type?: T;
+    }
+  : { outdent?: never; type?: T };
 
 type NativeButtonProps = Omit<
   ButtonHTMLAttributes<HTMLButtonElement>,
-  keyof BaseButtonOwnProps | 'type'
+  keyof BaseButtonOwnProps | 'type' | 'outdent'
 >;
 
 type NativeAnchorProps = Omit<
   AnchorHTMLAttributes<HTMLAnchorElement>,
-  keyof BaseButtonOwnProps | 'type'
+  keyof BaseButtonOwnProps | 'type' | 'outdent'
 >;
 
-export type ButtonProps = BaseButtonOwnProps & NativeButtonProps & Partial<NativeAnchorProps>;
+export type ButtonProps<T extends ButtonType = ButtonType> = BaseButtonOwnProps &
+  NativeButtonProps &
+  Partial<NativeAnchorProps> &
+  TextOutdentProps<T>;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Add `outdent` so a borderless text control can cancel its own hit-area inset and line up with adjacent copy.

- **Button**: `outdent?: boolean | 'start' | 'end'` is typed onto `type="text"` only (generic `ButtonProps<T>`). Negative margin equals that size's `padding-inline` (`small` 8, `middle` 14, `large` 16).
- **ActionIcon**: the same prop, typed onto `variant="borderless"` only. Icon-only buttons zero `--button-padding-inline`, so ActionIcon owns its own token — half of `blockSize − glyph` (`small` 5, `middle` 8, `large` 10).

Demos use the real call sites: reject-modal **Attach screenshot**, and a task header paperclip next to the title/list.

#### 📝 补充信息 | Additional Information

```tsx
<Button outdent size="small" type="text">Attach screenshot</Button>
<ActionIcon icon={Paperclip} outdent size="small" />
```

Docs: `/components/base-ui/button` (Outdent text) and `/components/base-ui/action-icon` (Outdent borderless).