### PR TITLE
🐛 fix(text): keep icons visible inside shiny text and boost light-mode contrast

### DIFF
--- a/src/base-ui/Text/demos/shiny.tsx
+++ b/src/base-ui/Text/demos/shiny.tsx
@@ -1,0 +1,41 @@
+import { Flexbox } from '@lobehub/ui';
+import { Text } from '@lobehub/ui/base-ui';
+import { createStaticStyles, cssVar } from 'antd-style';
+import { Check, SquareChevronRight } from 'lucide-react';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  chip: css`
+    display: inline-flex;
+    gap: 6px;
+    align-items: center;
+
+    padding-block: 2px;
+    padding-inline: 10px;
+    border-radius: 999px;
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+
+    background: ${cssVar.colorFillTertiary};
+  `,
+  row: css`
+    display: flex;
+    gap: 6px;
+    align-items: center;
+  `,
+}));
+
+export default () => (
+  <Flexbox gap={12} padding={16}>
+    <Text shiny>Plain shiny text</Text>
+
+    <Text shiny className={styles.row}>
+      <span>Bash:</span>
+      <span className={styles.chip}>
+        <SquareChevronRight size={14} />
+        Read round-3 actionable review feedback
+      </span>
+      <Check color={cssVar.colorSuccess} size={14} />
+    </Text>
+  </Flexbox>
+);

--- a/src/base-ui/Text/index.mdx
+++ b/src/base-ui/Text/index.mdx
@@ -10,12 +10,19 @@ apiHeader:
 ---
 
 import DemoBasic from './demos/index.tsx?demo';
+import DemoShiny from './demos/shiny.tsx?demo';
 
 ## Basic
 
 Types, colors, headings, formatting combinations, and ellipsis modes:
 
 <Demo of={DemoBasic} layout="bare" />
+
+## Shiny
+
+The shimmer sweeps the text only — icons, chips, and other non-text children keep their own paint:
+
+<Demo of={DemoShiny} layout="bare" />
 
 ## APIs
 

--- a/src/base-ui/Text/style.ts
+++ b/src/base-ui/Text/style.ts
@@ -101,14 +101,9 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
 
     user-select: none;
 
-    color: color-mix(in srgb, ${cssVar.colorText} 45%, transparent);
+    color: color-mix(in srgb, ${cssVar.colorText} 28%, transparent);
 
-    background: linear-gradient(
-      120deg,
-      transparent 25%,
-      ${cssVar.colorTextSecondary} 50%,
-      transparent 75%
-    );
+    background: linear-gradient(120deg, transparent 25%, ${cssVar.colorText} 50%, transparent 75%);
     background-clip: text;
     background-size: 200% 100%;
 
@@ -116,34 +111,38 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
 
     /* Animating background-position repaints every glyph each frame. Where
      * mask-clip: text is supported, clip a transform-animated overlay to the
-     * glyphs instead so the sweep stays on the compositor. */
+     * glyphs instead so the sweep stays on the compositor. The mask clips every
+     * descendant too, so rows that also render icons or chips keep the
+     * background-clip path — masking would erase that non-text paint. */
     @supports (-webkit-mask-clip: text) {
-      position: relative;
+      &:not(:has(*)) {
+        position: relative;
 
-      background: none;
+        background: none;
 
-      animation: none;
+        animation: none;
 
-      /* stylelint-disable-next-line declaration-property-value-no-unknown */
-      mask-clip: text;
-      mask-image: linear-gradient(#fff, #fff);
+        /* stylelint-disable-next-line declaration-property-value-no-unknown */
+        mask-clip: text;
+        mask-image: linear-gradient(#fff, #fff);
 
-      &::after {
-        pointer-events: none;
-        will-change: transform;
-        content: '';
+        &::after {
+          pointer-events: none;
+          will-change: transform;
+          content: '';
 
-        position: absolute;
-        inset: 0;
+          position: absolute;
+          inset: 0;
 
-        background: linear-gradient(
-          90deg,
-          transparent 25%,
-          ${cssVar.colorTextSecondary} 50%,
-          transparent 75%
-        );
+          background: linear-gradient(
+            90deg,
+            transparent 25%,
+            ${cssVar.colorText} 50%,
+            transparent 75%
+          );
 
-        animation: ${sweep} var(--shiny-duration) linear infinite;
+          animation: ${sweep} var(--shiny-duration) linear infinite;
+        }
       }
     }
 


### PR DESCRIPTION
## 💡 Motivation

`textStyles.shiny` 的 `mask-clip: text` 快路径会把**整个元素及其所有子节点**裁到文字字形上。任何在 shiny 行里渲染的非文字内容 —— lucide icon、命令 chip 的胶囊底色、状态 ✓ —— 都会被整块抹掉。在 lobe-chat 的 `RunCommand` inspector 上表现为：`Bash:` 后面的终端 icon 和 chip 背景消失，只剩裸文字。

另外扫光在 light 下几乎看不出来：底色 `colorText 45%` 与扫光 `colorTextSecondary`（黑 65%）只差 20%。

## 🔍 Changes

- mask 快路径加 `&:not(:has(*))` 守卫：纯文本行继续走合成器动画（不掉帧的那条路径），带 element 子节点的行退回 `background-clip: text`，只裁自身背景，不影响子节点。
- 提高对比：底色 `color-mix(colorText 28%)`，扫光改为 `colorText`（原 `colorTextSecondary`），light / dark 都更清晰。
- 新增 `## Shiny` demo：`Bash:` + 终端 icon + 命令 chip + 成功 ✓，直接暴露这个回归。

## ✅ Verification

- `src/base-ui/Text` 12 tests passed
- dumi 里 light / dark 双主题实测：icon、chip 底色、✓ 全部正常显示，扫光在白底可见