### PR TITLE
✨ feat(text): add shinyGroup so one row sweeps as a single wave

### DIFF
--- a/src/base-ui/Text/demos/shiny.tsx
+++ b/src/base-ui/Text/demos/shiny.tsx
@@ -1,6 +1,6 @@
 import { Flexbox } from '@lobehub/ui';
-import { Text } from '@lobehub/ui/base-ui';
-import { createStaticStyles, cssVar } from 'antd-style';
+import { Text, textGroupStyles, textStyles } from '@lobehub/ui/base-ui';
+import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { Check, SquareChevronRight } from 'lucide-react';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
@@ -37,5 +37,15 @@ export default () => (
       </span>
       <Check color={cssVar.colorSuccess} size={14} />
     </Text>
+
+    <div className={cx(styles.row, textGroupStyles.shinyGroup)}>
+      <span className={textStyles.shiny}>Bash:</span>
+      <span className={styles.chip}>
+        <SquareChevronRight size={14} />
+        Read round-3 actionable review feedback
+      </span>
+      <span className={textStyles.shiny}>waiting for the shell</span>
+      <Check color={cssVar.colorSuccess} size={14} />
+    </div>
   </Flexbox>
 );

--- a/src/base-ui/Text/index.mdx
+++ b/src/base-ui/Text/index.mdx
@@ -20,7 +20,7 @@ Types, colors, headings, formatting combinations, and ellipsis modes:
 
 ## Shiny
 
-The shimmer sweeps the text only — icons, chips, and other non-text children keep their own paint:
+The shimmer sweeps the text only — icons, chips, and other non-text children keep their own paint. A row that shimmers several separate spans adds `textGroupStyles.shinyGroup`, which hands every span the same row-wide sweep so they read as one continuous wave rather than one sweep per span:
 
 <Demo of={DemoShiny} layout="bare" />
 
@@ -48,6 +48,12 @@ The shimmer sweeps the text only — icons, chips, and other non-text children k
 | ref | `Ref<HTMLDivElement>` | - | Forwarded to the root element. |
 | shiny | `boolean` | - | Looping shimmer sweep for loading or streaming text. Falls back to a static color when `prefers-reduced-motion` is set. |
 | shinyDuration | `CSSProperties['animationDuration']` | `'1.5s'` | Sweep cycle length. Only accepted when `shiny` is set. |
+
+### textGroupStyles
+
+| Class | Description |
+| --- | --- | --- | --- |
+| shinyGroup | Put it on a row that contains several `textStyles.shiny` spans: the row becomes the sweep's coordinate space, so every span shares one continuous wave. |
 | strong | `boolean` | - | Bold text. |
 | textDecoration | `CSSProperties['textDecoration']` | - | Text decoration. |
 | textTransform | `CSSProperties['textTransform']` | - | Text transform. |

--- a/src/base-ui/Text/index.ts
+++ b/src/base-ui/Text/index.ts
@@ -1,4 +1,8 @@
-export { styles as textStyles, variants as textVariants } from './style';
+export {
+  groupStyles as textGroupStyles,
+  styles as textStyles,
+  variants as textVariants,
+} from './style';
 export { default } from './Text';
 export { default as Text } from './Text';
 export type { TextClassNames, TextProps, TextStyles } from './type';

--- a/src/base-ui/Text/style.ts
+++ b/src/base-ui/Text/style.ts
@@ -116,7 +116,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
      * background-clip path — masking would erase that non-text paint. */
     @supports (-webkit-mask-clip: text) {
       &:not(:has(*)) {
-        position: relative;
+        position: var(--shiny-origin, relative);
 
         background: none;
 
@@ -169,6 +169,24 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   warning: css`
     color: ${cssVar.colorWarning};
+  `,
+}));
+
+/**
+ * Coordinate layer for a row that shimmers several separate text spans. Each
+ * span's sweep overlay resolves against the nearest positioned ancestor, so
+ * dropping `position` on the spans and holding it here gives every span the
+ * same row-wide overlay — one continuous wave instead of one sweep per span.
+ */
+export const groupStyles = createStaticStyles(({ css }) => ({
+  shinyGroup: css`
+    @supports (-webkit-mask-clip: text) {
+      & {
+        --shiny-origin: static;
+
+        position: relative;
+      }
+    }
   `,
 }));
 


### PR DESCRIPTION
## 💡 Motivation

接 #635。#635 让带 icon 的行退回 `background-clip` 重绘路径，下游（lobe-chat）于是把 shiny 从整行挪到纯文本 span 上以回到合成器路径。但一行里如果有**多个** shiny span（label + icon + 尾部文字），每个 span 各自定位自己的扫光 overlay，就会各扫各的、相位对不上。

`shinyGroup` 让行持有定位、span 交出定位，于是每个 overlay 都以行盒为参照 —— 几何一致、动画一致，整行只有一条连续的波。

## 🔍 Changes

- `styles.shiny` 的快路径改用 `position: var(--shiny-origin, relative)`
- 新增 `groupStyles.shinyGroup`（导出为 `textGroupStyles`）：行上 `position: relative` + `--shiny-origin: static`
- demo 增加第三行：`shinyGroup` + 两个被 icon / chip 隔开的 shiny span
- 文档补 `textGroupStyles` 说明

单独使用 `<Text shiny>` 行为不变（拿到 `--shiny-origin` 的默认值 `relative`）。

实现上没有用 `.group .${styles.shiny}` 这种跨类选择器 —— emotion 会把 `styles.shiny` **内联展开成声明**而不是给出类名，规则不会生效；改用继承的 CSS 变量传递。

## ✅ Verification

浏览器实测（dumi demo，Chrome）：

1. **相位**：同一行两个 shiny span 的 overlay 读数为 `width: 1120px`（=行宽）、`translate: 86.6667%`，完全一致 → 同一条波。不加 group 的对照组是三处同时发亮、各扫各的。
2. **仍在合成器上**：1500 行 / 3000 个 shiny span，测 3 秒内主线程能完成的计算块数 —— 无动画基线 650；mask + overlay 路径 641 / 633（≈2% 占用）；`background-position` 重绘路径 101 / 92（≈85% 占用）。
3. `src/base-ui/Text` 12 tests passed。