### PR TITLE
💄 style(text): make shiny text color overridable via --shiny-color

### DIFF
--- a/src/base-ui/Text/style.ts
+++ b/src/base-ui/Text/style.ts
@@ -99,11 +99,16 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   shiny: css`
     --shiny-duration: 1.5s;
 
+    /* The sweep peaks at this color. Override it to match the static text the
+     * shimmering label sits next to. currentColor cannot serve here: the
+     * dimmed color declared below would feed back into the sweep overlay. */
+    --shiny-color: ${cssVar.colorText};
+
     user-select: none;
 
-    color: color-mix(in srgb, ${cssVar.colorText} 28%, transparent);
+    color: color-mix(in srgb, var(--shiny-color) 28%, transparent);
 
-    background: linear-gradient(120deg, transparent 25%, ${cssVar.colorText} 50%, transparent 75%);
+    background: linear-gradient(120deg, transparent 25%, var(--shiny-color) 50%, transparent 75%);
     background-clip: text;
     background-size: 200% 100%;
 
@@ -137,7 +142,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
           background: linear-gradient(
             90deg,
             transparent 25%,
-            ${cssVar.colorText} 50%,
+            var(--shiny-color) 50%,
             transparent 75%
           );
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

`textStyles.shiny` hardcoded `colorText` in all three color slots — the dimmed base color, the `background-clip: text` gradient, and the `mask-clip` sweep overlay. A shimmering label therefore always peaked at full-strength text, even when it lived in a row colored `colorTextSecondary` / `colorTextTertiary`, so it never matched the static text next to it (e.g. `Thinking… 00:46`, where the timer is tertiary but the shimmer peaks near white).

This exposes the color as a `--shiny-color` custom property, defaulting to `colorText`, and reads it from all three places. Existing usage renders identically; consumers can now tone the shimmer to its surroundings with a single variable.

`currentColor` cannot serve this purpose: the element overrides its own `color` with the dimmed mix, so `currentColor` inside the `::after` overlay would resolve to that dimmed value instead of the intended peak.

#### 📝 补充信息 | Additional Information

Consumer side (lobe-chat) sets `--shiny-color: var(--colorTextSecondary)` on its shared shiny class.

https://claude.ai/code/session_01D9PKpto1qV5sq1fubWz4uu