### PR TITLE
🐛 fix(code-editor): align highlight layer with textarea layout

### DIFF
--- a/src/CodeEditor/style.ts
+++ b/src/CodeEditor/style.ts
@@ -19,6 +19,28 @@ export const styles = createStaticStyles(({ css, cssVar }) => {
     filled: lobeStaticStylish.variantFilledWithoutHover,
     highlight: css`
       pointer-events: none;
+
+      /* Mirror the textarea's text flow instead of the highlighter's flex rows. */
+      pre code {
+        display: block;
+
+        /* Keep the final empty line measurable after a trailing newline. */
+        &::after {
+          content: '\\200b';
+        }
+
+        .line {
+          display: inline;
+          margin: 0;
+          padding: 0;
+        }
+
+        /* Token emphasis must not change glyph metrics relative to the textarea. */
+        span {
+          font-weight: inherit !important;
+          font-style: normal !important;
+        }
+      }
     `,
     outlined: lobeStaticStylish.variantOutlinedWithoutHover,
     root: css`

--- a/src/CodeEditor/style.ts
+++ b/src/CodeEditor/style.ts
@@ -38,7 +38,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => {
         /* Token emphasis must not change glyph metrics relative to the textarea. */
         span {
           font-weight: inherit !important;
-          font-style: normal !important;
+          font-style: inherit !important;
         }
       }
     `,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🐛 fix

#### 🔀 变更说明 | Description of Change

修复 CodeEditor 多行编辑时光标、选区与高亮文本错位的问题。

高亮镜像层原有的 flex 行布局会引入额外间距并折叠空行，导致其与 textarea 的文本位置不一致。本次仅调整 CodeEditor 内部样式：

- 使用与 textarea 一致的文本流，保留空行及末尾换行高度。
- 统一 token 字形，避免粗体、斜体改变文本度量。

保留语法高亮颜色，不影响 SyntaxHighlighter 的公共展示样式。

#### 📝 补充信息 | Additional Information

关联 Issue：#534

已验证多行及空行、Enter 换行、鼠标拖选、Shift + 方向键选择和长文本自动换行。

**Before**

<img width="1375" alt="修复前：选区与高亮文本错位" src="https://github.com/user-attachments/assets/d4fbcef7-70d4-4b35-9b90-166c8c8c9f30" />

**After**

<img width="1260" alt="修复后：选区与高亮文本对齐" src="https://github.com/user-attachments/assets/657e101a-7b13-49cb-aaa4-2823847b097c" />