### PR TITLE
⬆️ chore(deps): upgrade @base-ui/react to 1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
   },
   "dependencies": {
     "@ant-design/cssinjs": "^2.1.2",
-    "@base-ui/react": "1.6.0",
+    "@base-ui/react": "1.8.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",

--- a/src/base-ui/Popover/PopoverGroup.tsx
+++ b/src/base-ui/Popover/PopoverGroup.tsx
@@ -6,6 +6,7 @@ import { type FC, type ReactNode, useCallback, useMemo, useRef, useState } from 
 import {
   useDestroyOnInvalidActiveTriggerElement,
   useHidePopupWhenPositionerAtOrigin,
+  usePopupHandleStore,
 } from '@/utils/destroyOnInvalidActiveTriggerElement';
 import { parseTrigger } from '@/utils/parseTrigger';
 import { placementMap } from '@/utils/placement';
@@ -82,10 +83,11 @@ const PopoverGroup: FC<PopoverGroupProps> = ({
     [],
   );
 
-  useDestroyOnInvalidActiveTriggerElement(handle.store, destroy, {
+  const store = usePopupHandleStore(handle);
+  useDestroyOnInvalidActiveTriggerElement(store, destroy, {
     enabled: !disableDestroyOnInvalidTrigger,
   });
-  useHidePopupWhenPositionerAtOrigin(handle.store, { enabled: !disableZeroOriginGuard });
+  useHidePopupWhenPositionerAtOrigin(store, { enabled: !disableZeroOriginGuard });
 
   const portalContainer = usePopoverPortalContainer();
 

--- a/src/base-ui/Tooltip/TooltipGroup.tsx
+++ b/src/base-ui/Tooltip/TooltipGroup.tsx
@@ -9,6 +9,7 @@ import { useAppElement } from '@/ThemeProvider';
 import {
   useDestroyOnInvalidActiveTriggerElement,
   useHidePopupWhenPositionerAtOrigin,
+  usePopupHandleStore,
 } from '@/utils/destroyOnInvalidActiveTriggerElement';
 import { placementMap } from '@/utils/placement';
 
@@ -52,10 +53,11 @@ const TooltipGroup: FC<TooltipGroupProps> = ({
   const floatingLayerContainer = useFloatingLayer();
   const portalContainer = floatingLayerContainer ?? appElement;
 
-  useDestroyOnInvalidActiveTriggerElement(handle.store, destroy, {
+  const store = usePopupHandleStore(handle);
+  useDestroyOnInvalidActiveTriggerElement(store, destroy, {
     enabled: !disableDestroyOnInvalidTrigger,
   });
-  useHidePopupWhenPositionerAtOrigin(handle.store, { enabled: !disableZeroOriginGuard });
+  useHidePopupWhenPositionerAtOrigin(store, { enabled: !disableZeroOriginGuard });
 
   return (
     <TooltipGroupHandleContext value={handle}>

--- a/src/utils/destroyOnInvalidActiveTriggerElement.ts
+++ b/src/utils/destroyOnInvalidActiveTriggerElement.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect } from 'react';
+import { useCallback, useLayoutEffect, useSyncExternalStore } from 'react';
 
 type PopupStoreLike = {
   // Base UI store's `useState` has a strongly-typed key union; we keep it loose here on purpose.
@@ -8,6 +8,24 @@ type PopupStoreLike = {
     positionerElement?: HTMLElement | null;
   };
   useState?: (...args: any[]) => unknown;
+};
+
+// Base UI 1.7+ strips `store`/`subscribeStore` from the handle's public typings, but detached
+// triggers still rely on them at runtime: the handle points at an inert fallback store until a
+// Root attaches in an effect, so the store must be read through a subscription, not captured once.
+type PopupHandleLike = {
+  store: PopupStoreLike;
+  subscribeStore: (listener: () => void) => () => void;
+};
+
+export const usePopupHandleStore = (handle: object): PopupStoreLike => {
+  const typedHandle = handle as PopupHandleLike;
+  const subscribe = useCallback(
+    (listener: () => void) => typedHandle.subscribeStore(listener),
+    [typedHandle],
+  );
+  const getSnapshot = useCallback(() => typedHandle.store, [typedHandle]);
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 };
 
 const isInvalidTriggerElement = (el: Element | null): boolean => {


### PR DESCRIPTION
## Why

`@base-ui/react` has been pinned to 1.6.0 since a78cdf66. Two things blocked the bump:

1. **1.7.0 removed `store` from the public `PopoverHandle` / `TooltipHandle` typings** (moved into `BasePopupHandle`, still present at runtime). `PopoverGroup` and `TooltipGroup` read `handle.store` directly, which is what broke type-check on the renovate PR #601.
2. **1.7.0 regressed hover handoff between detached triggers wrapping antd Buttons** (mui/base-ui#5416). Fixed upstream in mui/base-ui#5442, first shipped in 1.8.0.

## What

- Bump `@base-ui/react` 1.6.0 → 1.8.0.
- Add `usePopupHandleStore(handle)` in `src/utils/destroyOnInvalidActiveTriggerElement.ts`: subscribes to the handle's `subscribeStore` via `useSyncExternalStore` and returns the current store. This is not just a typing workaround: since 1.7 a `Root` attaches its store in an effect, so `handle.store` at render time is an inert fallback. Capturing it once would leave `open` permanently `false` and silently disable the destroy-on-invalid-trigger and zero-origin guards. This mirrors base-ui's own internal `usePopupHandleStore` used by detached triggers.
- `PopoverGroup` / `TooltipGroup` consume the hook instead of `handle.store`.

## Verification

- `pnpm type-check`: baseline on 1.6.0 had 0 errors; after the bump only the 4 `handle.store` TS2339 errors appeared; 0 after the fix.
- `pnpm vitest run`: 173 files / 1353 tests pass.
- Browser (docs dev server):
  - Tooltip group `group-remove-trigger` demo: tooltip destroyed on trigger unmount and on `display:none`.
  - Popover group hover handoff, re-run with the issue's original conditions (antd Button triggers, 8-step pointer glide, assert after 2s), against 1.7.0 as a control:

    | pair | 1.7.0 | 1.8.0 |
    |---|---|---|
    | Dashboard → Analytics | fail | ok |
    | Dashboard → Automation | ok | ok |
    | Analytics → Dashboard | fail | ok |
    | Analytics → Automation | fail | ok |
    | Automation → Dashboard | ok | ok |
    | Automation → Analytics | fail | ok |

    The 1.7.0 column matches the matrix in mui/base-ui#5416 exactly.

Supersedes #601.

https://claude.ai/code/session_01M6WjoVy32S48WjQnMsFDuB
