### PR TITLE
🐛 fix(base-ui): keep floating popups inside the viewport and let apps reserve edges

### DIFF
--- a/compatibility.json
+++ b/compatibility.json
@@ -4358,6 +4358,18 @@
     },
     {
       "document": "src/base-ui/Select/index.mdx",
+      "legacyId": "src-base-ui-select-demo-viewportbounds",
+      "legacyRouteId": "components/base-ui/Select/index",
+      "options": {
+        "inline": false,
+        "isolated": true,
+        "layout": "bare"
+      },
+      "pathname": "/components/base-ui/select",
+      "source": "src/base-ui/Select/demos/viewportBounds.tsx"
+    },
+    {
+      "document": "src/base-ui/Select/index.mdx",
       "legacyId": "src-base-ui-select-demo-virtual",
       "legacyRouteId": "components/base-ui/Select/index",
       "options": {
@@ -6853,7 +6865,7 @@
     },
     {
       "category": "Data Display",
-      "description": "HtmlPreview renders LLM-generated HTML inline using a hardened iframe sandbox. It mirrors how Mermaid is embedded in Markdown, but treats the content as code rather than data \u2014 scripts execute inside an isolated frame that cannot reach the host page.",
+      "description": "HtmlPreview renders LLM-generated HTML inline using a hardened iframe sandbox. It mirrors how Mermaid is embedded in Markdown, but treats the content as code rather than data — scripts execute inside an isolated frame that cannot reach the host page.",
       "legacyRouteId": "components/HtmlPreview/index",
       "pathname": "/components/html-preview",
       "section": "Components",
@@ -6978,7 +6990,7 @@
     },
     {
       "category": "Feedback",
-      "description": "An animated SVG loading indicator depicting a neural network \u2014 pulsing nodes connected across layers, particles flowing through the connections, and a slowly rotating outer ring. Suitable for \"AI is thinking / preparing\" empty states.",
+      "description": "An animated SVG loading indicator depicting a neural network — pulsing nodes connected across layers, particles flowing through the connections, and a slowly rotating outer ring. Suitable for \"AI is thinking / preparing\" empty states.",
       "legacyRouteId": "components/NeuralNetworkLoading/index",
       "pathname": "/components/neural-network-loading",
       "section": "Components",
@@ -7165,7 +7177,7 @@
     },
     {
       "category": "Feedback",
-      "description": "A wrapper component for giscus \ud83d\udc8e, a comments system powered by GitHub Discussions.",
+      "description": "A wrapper component for giscus 💎, a comments system powered by GitHub Discussions.",
       "legacyRouteId": "components/awesome/Giscus/index",
       "pathname": "/components/awesome/giscus",
       "section": "Awesome",
@@ -7309,7 +7321,7 @@
     },
     {
       "category": "Data Entry",
-      "description": "Base UI-powered Segmented control \u2014 toggle-group semantics with a sliding active indicator. Drops antd dependency in favor of @base-ui/react/toggle-group.",
+      "description": "Base UI-powered Segmented control — toggle-group semantics with a sliding active indicator. Drops antd dependency in favor of @base-ui/react/toggle-group.",
       "legacyRouteId": "components/base-ui/Segmented/index",
       "pathname": "/components/base-ui/segmented",
       "section": "Base UI",
@@ -7345,7 +7357,7 @@
     },
     {
       "category": "Navigation",
-      "description": "Base UI-powered Tabs with iOS-flavored interactions \u2014 no hover background, tap-scale feedback, and a sliding active indicator across rounded / square / point variants.",
+      "description": "Base UI-powered Tabs with iOS-flavored interactions — no hover background, tap-scale feedback, and a sliding active indicator across rounded / square / point variants.",
       "legacyRouteId": "components/base-ui/Tabs/index",
       "pathname": "/components/base-ui/tabs",
       "section": "Base UI",

--- a/src/base-ui/AutoComplete/AutoComplete.tsx
+++ b/src/base-ui/AutoComplete/AutoComplete.tsx
@@ -5,6 +5,7 @@ import { cx, useThemeMode } from 'antd-style';
 import { XIcon } from 'lucide-react';
 import { memo, useMemo, useRef } from 'react';
 
+import { getFloatingCollisionPadding } from '@/base-ui/floating';
 import { inputStyles, inputVariants } from '@/base-ui/Input';
 import { useLayerZIndex } from '@/base-ui/zIndex';
 import Icon from '@/Icon';
@@ -79,6 +80,7 @@ const AutoComplete = memo<AutoCompleteProps>(
           <Autocomplete.Positioner
             anchor={anchorRef}
             className={styles.positioner}
+            collisionPadding={getFloatingCollisionPadding()}
             ref={positionerRef}
             sideOffset={4}
             style={zIndex === undefined ? undefined : { zIndex }}

--- a/src/base-ui/ContextMenu/ContextMenuHost.tsx
+++ b/src/base-ui/ContextMenu/ContextMenuHost.tsx
@@ -4,6 +4,7 @@ import { ContextMenu } from '@base-ui/react/context-menu';
 import { cx } from 'antd-style';
 import { memo, useEffect, useMemo, useSyncExternalStore } from 'react';
 
+import { getFloatingCollisionPadding } from '@/base-ui/floating';
 import { useIsClient } from '@/hooks/useIsClient';
 import { useAppElement } from '@/ThemeProvider';
 import { registerDevSingleton } from '@/utils/devSingleton';
@@ -72,6 +73,7 @@ export const ContextMenuHost = memo(() => {
         <ContextMenu.Positioner
           anchor={state.anchor ?? undefined}
           className={styles.positioner}
+          collisionPadding={getFloatingCollisionPadding()}
           ref={zRef as any}
           sideOffset={6}
           style={{ ...noAnimationStyles, zIndex }}

--- a/src/base-ui/ContextMenu/renderItems.tsx
+++ b/src/base-ui/ContextMenu/renderItems.tsx
@@ -11,6 +11,7 @@ import {
 import { memo, useCallback, useState } from 'react';
 
 import { styles } from '@/base-ui/DropdownMenu/sharedStyle';
+import { getFloatingCollisionPadding } from '@/base-ui/floating';
 import { SubmenuArrowIcon } from '@/base-ui/SubmenuArrowIcon';
 import Switch from '@/base-ui/Switch';
 import common from '@/i18n/resources/en/common';
@@ -45,20 +46,29 @@ type ContextMenuPositionerProps = ComponentProps<typeof ContextMenu.Positioner>;
  * their own layer z-index (same pattern as DropdownMenu) rather than relying on
  * the fixed CSS fallback that can fall behind after repeated root openings (#608).
  */
-const ContextMenuSubmenuPositioner = memo(({ style, ...rest }: ContextMenuPositionerProps) => {
-  const explicitZIndex =
-    typeof style !== 'function' && style?.zIndex != null && typeof style.zIndex === 'number'
-      ? style.zIndex
-      : undefined;
-  const { zIndex, ref: zRef } = useLayerZIndex<HTMLDivElement>('floating', explicitZIndex);
+const ContextMenuSubmenuPositioner = memo(
+  ({ collisionPadding, style, ...rest }: ContextMenuPositionerProps) => {
+    const explicitZIndex =
+      typeof style !== 'function' && style?.zIndex != null && typeof style.zIndex === 'number'
+        ? style.zIndex
+        : undefined;
+    const { zIndex, ref: zRef } = useLayerZIndex<HTMLDivElement>('floating', explicitZIndex);
 
-  const resolvedStyle =
-    typeof style === 'function'
-      ? (state: any) => ({ zIndex, ...style(state) })
-      : { zIndex, ...style };
+    const resolvedStyle =
+      typeof style === 'function'
+        ? (state: any) => ({ zIndex, ...style(state) })
+        : { zIndex, ...style };
 
-  return <ContextMenu.Positioner {...rest} ref={zRef as any} style={resolvedStyle} />;
-});
+    return (
+      <ContextMenu.Positioner
+        {...rest}
+        collisionPadding={collisionPadding ?? getFloatingCollisionPadding()}
+        ref={zRef as any}
+        style={resolvedStyle}
+      />
+    );
+  },
+);
 
 ContextMenuSubmenuPositioner.displayName = 'ContextMenuSubmenuPositioner';
 

--- a/src/base-ui/DropdownMenu/atoms.tsx
+++ b/src/base-ui/DropdownMenu/atoms.tsx
@@ -8,6 +8,7 @@ import type React from 'react';
 import { cloneElement, isValidElement, useCallback, useState } from 'react';
 import { mergeRefs, useMergeRefs } from 'react-merge-refs';
 
+import { getFloatingCollisionPadding } from '@/base-ui/floating';
 import Switch from '@/base-ui/Switch';
 import { FloatingLayerProvider } from '@/hooks/useFloatingLayer';
 import { useNativeButton } from '@/hooks/useNativeButton';
@@ -107,6 +108,7 @@ export type DropdownMenuPositionerProps = React.ComponentProps<typeof Menu.Posit
 
 export const DropdownMenuPositioner = ({
   className,
+  collisionPadding,
   placement,
   hoverTrigger,
   align,
@@ -136,6 +138,7 @@ export const DropdownMenuPositioner = ({
       {...rest}
       align={align ?? placementConfig?.align}
       className={mergeStateClassName(styles.positioner, className as any) as any}
+      collisionPadding={collisionPadding ?? getFloatingCollisionPadding()}
       data-hover-trigger={hoverTrigger || undefined}
       data-placement={placement}
       ref={composedRef as any}

--- a/src/base-ui/Popover/atoms.tsx
+++ b/src/base-ui/Popover/atoms.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react';
 import { mergeRefs, useMergeRefs } from 'react-merge-refs';
 
+import { getFloatingCollisionPadding } from '@/base-ui/floating';
 import { FloatingLayerProvider } from '@/hooks/useFloatingLayer';
 import { useNativeButton } from '@/hooks/useNativeButton';
 import { placementMap } from '@/utils/placement';
@@ -128,6 +129,7 @@ export type PopoverPositionerAtomProps = ComponentProps<typeof BasePopover.Posit
 export const PopoverPositioner = ({
   children,
   className,
+  collisionPadding,
   hoverTrigger,
   placement,
   align,
@@ -153,6 +155,7 @@ export const PopoverPositioner = ({
   return (
     <BasePopover.Positioner
       align={align ?? placementConfig?.align ?? 'center'}
+      collisionPadding={collisionPadding ?? getFloatingCollisionPadding()}
       data-hover-trigger={hoverTrigger || undefined}
       data-placement={placement}
       ref={composedRef as any}

--- a/src/base-ui/Select/Select.tsx
+++ b/src/base-ui/Select/Select.tsx
@@ -182,7 +182,6 @@ const Select = memo<SelectProps<any>>(
     const popupStyle = useMemo(() => {
       const maxHeight = isItemAligned ? '80vh' : `${listHeight}px`;
       const baseStyle: React.CSSProperties = {
-        maxHeight,
         maxWidth: 'var(--available-width)',
         minWidth: 'var(--anchor-width)',
         ['--lobe-select-popup-max-height' as any]: maxHeight,

--- a/src/base-ui/Select/__tests__/Select.popupHeight.test.tsx
+++ b/src/base-ui/Select/__tests__/Select.popupHeight.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { motion } from 'motion/react';
+
+import ConfigProvider from '@/ConfigProvider';
+
+import Select from '../Select';
+
+const options = [{ label: 'Lobe AI', value: 'lobe-ai' }];
+
+describe('Select popup height', () => {
+  test('clamps the whole popup, not only the list, to the available height', () => {
+    render(
+      <ConfigProvider motion={motion}>
+        <Select open showSearch listHeight={200} options={options} />
+      </ConfigProvider>,
+    );
+
+    const popup = screen.getByRole('listbox').parentElement!;
+
+    expect(popup.style.maxHeight).toBe('');
+    expect(popup.style.getPropertyValue('--lobe-select-popup-max-height')).toBe('200px');
+    expect(getComputedStyle(popup).maxHeight).toBe('var(--lobe-select-available-height)');
+  });
+});

--- a/src/base-ui/Select/atoms.tsx
+++ b/src/base-ui/Select/atoms.tsx
@@ -12,6 +12,7 @@ import {
 import { mergeRefs, useMergeRefs } from 'react-merge-refs';
 
 import { styles as menuStyles } from '@/base-ui/DropdownMenu/sharedStyle';
+import { getFloatingCollisionPadding } from '@/base-ui/floating';
 import { useNativeButton } from '@/hooks/useNativeButton';
 import { useAppElement } from '@/ThemeProvider';
 
@@ -142,6 +143,7 @@ export const SelectPositioner = ({
   align,
   alignItemWithTrigger,
   className,
+  collisionPadding,
   side,
   sideOffset,
   style,
@@ -165,6 +167,7 @@ export const SelectPositioner = ({
       align={align ?? 'start'}
       alignItemWithTrigger={alignItemWithTrigger ?? false}
       className={mergeStateClassName(styles.positioner, className) as any}
+      collisionPadding={collisionPadding ?? getFloatingCollisionPadding()}
       ref={composedRef as any}
       side={side ?? 'bottom'}
       sideOffset={sideOffset ?? 6}

--- a/src/base-ui/Select/demos/viewportBounds.tsx
+++ b/src/base-ui/Select/demos/viewportBounds.tsx
@@ -1,0 +1,51 @@
+import { Flexbox, Text } from '@lobehub/ui';
+import { Select, setFloatingCollisionPadding } from '@lobehub/ui/base-ui';
+import { useEffect, useState } from 'react';
+
+const TITLE_BAR_HEIGHT = 40;
+
+const options = Array.from({ length: 80 }, (_, index) => ({
+  label: `Font ${index + 1}`,
+  value: `font-${index + 1}`,
+}));
+
+export default () => {
+  const [value, setValue] = useState<string | null>(null);
+
+  useEffect(() => {
+    setFloatingCollisionPadding({ top: TITLE_BAR_HEIGHT });
+    return () => setFloatingCollisionPadding(undefined);
+  }, []);
+
+  return (
+    <Flexbox gap={8} justify="flex-end" style={{ inset: 0, padding: 16, position: 'fixed' }}>
+      <div
+        style={{
+          alignItems: 'center',
+          background: 'var(--lobe-color-fill-secondary)',
+          borderBottom: '1px solid var(--lobe-color-border)',
+          display: 'flex',
+          fontSize: 12,
+          height: TITLE_BAR_HEIGHT,
+          insetInline: 0,
+          justifyContent: 'center',
+          position: 'fixed',
+          top: 0,
+        }}
+      >
+        Reserved title bar ({TITLE_BAR_HEIGHT}px)
+      </div>
+      <Text type="secondary">
+        The popup flips upward, keeps its search field visible and stops below the title bar.
+      </Text>
+      <Select
+        showSearch
+        options={options}
+        placeholder="Open near the bottom edge"
+        style={{ width: 320 }}
+        value={value}
+        onChange={(next) => setValue(next as string | null)}
+      />
+    </Flexbox>
+  );
+};

--- a/src/base-ui/Select/index.mdx
+++ b/src/base-ui/Select/index.mdx
@@ -12,6 +12,7 @@ import DemoVirtual from './demos/virtual.tsx?demo';
 import DemoClearValue from './demos/clearValue.tsx?demo';
 import DemoReactNodeSearch from './demos/reactNodeSearch.tsx?demo';
 import DemoClosedTags from './demos/closedTags.tsx?demo';
+import DemoViewportBounds from './demos/viewportBounds.tsx?demo';
 
 ## Default
 
@@ -44,6 +45,12 @@ import DemoClosedTags from './demos/closedTags.tsx?demo';
 ## Virtual List
 
 <Demo of={DemoVirtual} layout="bare" />
+
+## Viewport Bounds
+
+The popup is clamped to the space base-ui reports as available, so the search field never leaves the viewport. `setFloatingCollisionPadding` reserves extra space on any side for every base-ui floating layer; here it keeps the popup below a fixed title bar.
+
+<Demo of={DemoViewportBounds} isolated height={280} layout="bare" />
 
 ## APIs
 

--- a/src/base-ui/Select/style.ts
+++ b/src/base-ui/Select/style.ts
@@ -80,7 +80,6 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     flex: 1;
 
     min-height: 0;
-    max-height: var(--lobe-select-available-height, var(--available-height));
     padding-block: 0;
   `,
   listWithSearch: css`
@@ -99,6 +98,8 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
       var(--available-height),
       var(--lobe-select-popup-max-height, var(--available-height))
     );
+
+    max-height: var(--lobe-select-available-height);
 
     transform-origin: var(--transform-origin);
 

--- a/src/base-ui/Tooltip/TooltipGroup.tsx
+++ b/src/base-ui/Tooltip/TooltipGroup.tsx
@@ -4,6 +4,7 @@ import { Tooltip as BaseTooltip } from '@base-ui/react/tooltip';
 import { cx } from 'antd-style';
 import { type FC, useCallback, useRef, useState } from 'react';
 
+import { getFloatingCollisionPadding } from '@/base-ui/floating';
 import { useFloatingLayer } from '@/hooks/useFloatingLayer';
 import { useAppElement } from '@/ThemeProvider';
 import {
@@ -131,6 +132,9 @@ const TooltipGroup: FC<TooltipGroupProps> = ({
                 sideOffset={baseSideOffset}
                 style={resolvedStyles.positioner}
                 {...item.positionerProps}
+                collisionPadding={
+                  item.positionerProps?.collisionPadding ?? getFloatingCollisionPadding()
+                }
               >
                 <BaseTooltip.Popup
                   className={resolvedClassNames.popup}

--- a/src/base-ui/Tooltip/TooltipStandalone.tsx
+++ b/src/base-ui/Tooltip/TooltipStandalone.tsx
@@ -14,6 +14,7 @@ import {
 } from 'react';
 import { mergeRefs } from 'react-merge-refs';
 
+import { getFloatingCollisionPadding } from '@/base-ui/floating';
 import { useFloatingLayer } from '@/hooks/useFloatingLayer';
 import { useIsClient } from '@/hooks/useIsClient';
 import { useNativeButton } from '@/hooks/useNativeButton';
@@ -222,6 +223,7 @@ export const TooltipStandalone = memo<TooltipProps>(
           sideOffset={baseSideOffset}
           style={resolvedStyles.positioner}
           {...positionerProps}
+          collisionPadding={positionerProps?.collisionPadding ?? getFloatingCollisionPadding()}
         >
           <BaseTooltip.Popup
             className={resolvedClassNames.popup}

--- a/src/base-ui/floating/collisionPadding.test.tsx
+++ b/src/base-ui/floating/collisionPadding.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { motion } from 'motion/react';
+
+import Select from '@/base-ui/Select';
+import ConfigProvider from '@/ConfigProvider';
+
+import { getFloatingCollisionPadding, setFloatingCollisionPadding } from './collisionPadding';
+
+const positionerSpy = vi.fn();
+
+vi.mock('@base-ui/react/select', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@base-ui/react/select')>();
+  const Positioner = (props: any) => {
+    positionerSpy(props);
+    return <actual.Select.Positioner {...props} />;
+  };
+  return { ...actual, Select: { ...actual.Select, Positioner } };
+});
+
+afterEach(() => {
+  setFloatingCollisionPadding(undefined);
+  positionerSpy.mockClear();
+});
+
+describe('floating collision padding', () => {
+  test('keeps base-ui default on sides a partial object leaves out', () => {
+    setFloatingCollisionPadding({ top: 40 });
+
+    expect(getFloatingCollisionPadding()).toEqual({ bottom: 5, left: 5, right: 5, top: 40 });
+  });
+
+  test('passes a number through untouched and clears on undefined', () => {
+    setFloatingCollisionPadding(12);
+    expect(getFloatingCollisionPadding()).toBe(12);
+
+    setFloatingCollisionPadding(undefined);
+    expect(getFloatingCollisionPadding()).toBeUndefined();
+  });
+
+  test('positioners read the global padding at render time', () => {
+    setFloatingCollisionPadding({ top: 40 });
+
+    render(
+      <ConfigProvider motion={motion}>
+        <Select open options={[{ label: 'Lobe AI', value: 'lobe-ai' }]} />
+      </ConfigProvider>,
+    );
+
+    expect(screen.getByRole('listbox')).toBeTruthy();
+    expect(positionerSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ collisionPadding: { bottom: 5, left: 5, right: 5, top: 40 } }),
+    );
+  });
+});

--- a/src/base-ui/floating/collisionPadding.ts
+++ b/src/base-ui/floating/collisionPadding.ts
@@ -1,0 +1,24 @@
+export type FloatingCollisionPadding =
+  number | Partial<Record<'bottom' | 'left' | 'right' | 'top', number>>;
+
+const BASE_UI_DEFAULT_PADDING = 5;
+
+let floatingCollisionPadding: FloatingCollisionPadding | undefined;
+
+// Module-level rather than context: it is read at render time by every base-ui positioner,
+// so it must be set once at app bootstrap before any floating layer mounts (e.g. reserve the
+// Electron title bar). Partial objects keep base-ui's 5px default on the unspecified sides.
+export const setFloatingCollisionPadding = (padding?: FloatingCollisionPadding) => {
+  floatingCollisionPadding =
+    padding !== undefined && typeof padding === 'object'
+      ? {
+          bottom: BASE_UI_DEFAULT_PADDING,
+          left: BASE_UI_DEFAULT_PADDING,
+          right: BASE_UI_DEFAULT_PADDING,
+          top: BASE_UI_DEFAULT_PADDING,
+          ...padding,
+        }
+      : padding;
+};
+
+export const getFloatingCollisionPadding = () => floatingCollisionPadding;

--- a/src/base-ui/floating/index.ts
+++ b/src/base-ui/floating/index.ts
@@ -1,0 +1,5 @@
+export {
+  type FloatingCollisionPadding,
+  getFloatingCollisionPadding,
+  setFloatingCollisionPadding,
+} from './collisionPadding';

--- a/src/base-ui/index.ts
+++ b/src/base-ui/index.ts
@@ -25,6 +25,7 @@ export {
 export { controlHeight, type ControlSize } from './controlSize';
 export * from './Drawer';
 export * from './DropdownMenu';
+export * from './floating';
 export * from './FloatingPanel';
 export * from './FloatingSheet';
 export * from './Form';


### PR DESCRIPTION
## Problem

In LobeHub desktop, the Appearance → Interface Font `Select` opened past the top of the window: the search field was cut off and the list overlapped the Electron title bar.

Two separate causes, both in `base-ui`:

1. **Popup taller than `--available-height`.** `Select` set an inline `maxHeight: listHeight` on the popup, which overrode the `--available-height` clamp. Only the list was bounded, so the search field (~40px) pushed the whole popup out of the viewport whenever the popup flipped into tight space.
2. **No way to reserve the title bar.** base-ui positioners accept `collisionPadding`, but none of the lobe-ui wrappers exposed it, so a desktop shell could not keep floating layers clear of its own chrome.

## Changes

- `Select`: the popup itself now carries `max-height: var(--lobe-select-available-height)` (= `min(--available-height, listHeight)`); the list only flexes inside it. Inline `maxHeight` removed.
- New `setFloatingCollisionPadding` / `getFloatingCollisionPadding` exported from `@lobehub/ui/base-ui`. Module-level, same pattern as `setContextMenuInterceptor`; set once at bootstrap. A partial object keeps base-ui's 5px default on the unspecified sides. Read by every base-ui positioner: Select, Popover, DropdownMenu, ContextMenu (host + submenu), AutoComplete, Tooltip (standalone + group). Explicit `collisionPadding` props still win.
- Docs: new **Viewport Bounds** isolated 280px demo on the Select page showing both behaviours against a fixed 40px title bar.

## Verification

- New tests: `Select.popupHeight.test.tsx` (fails before, passes after) and `floating/collisionPadding.test.tsx` (merge semantics + positioner receives the global value).
- Browser (docs dev server, agent-browser):
  - 140px viewport, searchable Select: popup bottom 180px → 135px (viewport 140px), search field visible.
  - Runtime `setFloatingCollisionPadding({ bottom: 60 })`: popup flips to the top side instead of entering the reserved band.
  - New demo at 280px: popup spans 40→226px, i.e. starts exactly under the 40px title bar, search field visible.
- `vitest` for Select / floating / Popover / DropdownMenu / ContextMenu / AutoComplete / Tooltip, lib `tsc --noEmit`, `lint:circular`, inventory contract test all pass.

## Follow-up (lobe-chat)

Call `setFloatingCollisionPadding({ top: TITLE_BAR_HEIGHT })` at desktop bootstrap once this ships.

https://claude.ai/code/session_016gCNG3jtPnmQdrKTY7r7Jg
