### PR TITLE
💄 style(scroll-area): pin the viewport to overscroll-behavior auto

### DIFF
--- a/src/base-ui/ScrollArea/style.ts
+++ b/src/base-ui/ScrollArea/style.ts
@@ -80,6 +80,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
 
   viewport: css`
     position: relative;
+    overscroll-behavior: auto;
     height: 100%;
     outline: none;
 


### PR DESCRIPTION
### 💻 变更类型 | Change Type

- [x] 💄 style

### 🔀 变更说明 | Description of Change

Declare `overscroll-behavior: auto` on the `ScrollArea` viewport.

This is a **no-op today** — `auto` is the CSS initial value, and `overscroll-behavior` is not an inherited property, so nothing an ancestor declares can reach the viewport. It is written explicitly to lock the intent, because the one thing that *can* reach it is a broad descendant selector in a consuming app (`.some-panel * { overscroll-behavior: contain }`). If that ever lands, it would silently kill the platform's elastic overscroll inside every ScrollArea.

lobe-chat's desktop build now enables Electron's `scrollBounce` (lobehub/lobehub#19354), and relies on the viewport staying `auto` for that to have any visible effect.

### 📝 补充信息 | Additional Information

- Verified `@base-ui-components/react`'s ScrollArea ships no `overscroll-behavior` of its own, so `auto` was already the effective value — no behavior change.
- `stylelint src/base-ui/ScrollArea/style.ts` clean.

https://claude.ai/code/session_01UfQZPkguhjsXwvuqdySHB2