### PR TITLE
✨ feat(base-ui): dodge the bottom-right toast around an open FloatingPanel

### DIFF
--- a/.agents/acceptance/PROJECT.md
+++ b/.agents/acceptance/PROJECT.md
@@ -1,0 +1,118 @@
+# PROJECT.md — acceptance adapter for @lobehub/ui
+
+## 1. Project summary
+
+`@lobehub/ui` is the React component library behind LobeHub's web products. It ships
+ESM only, from `src/**` to `es/**` via tsdown, and publishes nothing else.
+
+Repo layout that matters for testing:
+
+| Path                 | What it is                                                                |
+| -------------------- | ------------------------------------------------------------------------- |
+| `src/<Component>/`   | One component: implementation, `style.ts`, `index.mdx`, `demos/`          |
+| `src/base-ui/`       | Components built on `@base-ui/react` — published as `@lobehub/ui/base-ui` |
+| `packages/docs-kit/` | `lobedocs`, the React Router + Vite toolkit that builds the docs site     |
+| `es/`                | Build output; the only directory published to npm                         |
+
+A component change has two proving surfaces: the **docs site**, which renders every
+component's demos, and a **consuming app** running the built package. Library changes
+that alter geometry or interaction should be proven on both — the docs site is fast,
+the consuming app proves the shipped artifact.
+
+## 2. Environment
+
+- **Start docs server:** `pnpm run docs:dev` (Vite picks the first free port from
+  5173; read the real URL from the log, never assume one)
+- **Stop docs server:** derive the port from the log and kill only that listener
+- **Build the package:** `pnpm build` → `es/` (required before any consuming-app run)
+- **Required services:** none — the docs site is static-rendered and needs no
+  database, cache, or queue
+- **Detect already running:** `lsof -nP -iTCP:<port> -sTCP:LISTEN -t`; reuse the
+  server already associated with the task rather than starting a second one
+
+```bash
+LOG=/tmp/lobe-ui-docs-dev.log
+nohup pnpm run docs:dev > "$LOG" 2>&1 &
+disown
+for i in $(seq 1 60); do
+  URL=$(grep -Eo 'http://localhost:[0-9]+' "$LOG" | head -1)
+  [ -n "$URL" ] && curl -fsS -o /dev/null "$URL" && break
+  sleep 1
+done
+printf '%s\n' "$URL"
+```
+
+## 3. Auth
+
+None. The docs site is entirely public and has no accounts, sessions, or seeding.
+Per-surface status check: `curl -fsS -o /dev/null -w '%{http_code}' "$URL"` returning
+`200` is the whole gate.
+
+A consuming app may have its own auth; that belongs to the consuming app's adapter,
+not this one.
+
+## 4. Surfaces
+
+| Surface             | Applies | Launch                                   | Base URL       | Session   |
+| ------------------- | ------- | ---------------------------------------- | -------------- | --------- |
+| Web — docs site     | yes     | `pnpm run docs:dev`                      | from the log   | `lobe-ui` |
+| Web — consuming app | yes     | the app's own dev command, against `es/` | the app's port | `lobe-ui` |
+| CLI                 | no      | —                                        | —              | —         |
+| Electron            | no      | —                                        | —              | —         |
+
+**Consuming-app runs must load this working tree's build, not the published package.**
+Replace `es/` inside the app's resolved package directory and keep the original:
+
+```bash
+APP=/path/to/consuming-app
+LIB=/path/to/lobe-ui
+
+STORE=$(cd "$APP/node_modules/@lobehub" && cd "$(dirname "$(readlink ui)")" && pwd)/ui
+[ -d "$STORE/es.orig" ] || mv "$STORE/es" "$STORE/es.orig" # keep the published build
+rm -rf "$STORE/es" && cp -R "$LIB/es" "$STORE/es"
+# restore:  rm -rf "$STORE/es" && mv "$STORE/es.orig" "$STORE/es"
+```
+
+Keeping `es.orig` is not only hygiene: swapping between the two is how a round proves
+the running instance is the working tree's code, and it is the only honest source of a
+`before` screenshot.
+
+## 5. Project probes & quick navigation
+
+Component doc pages are at `/components/<namespace>/<kebab-name>` — `base-ui`
+components sit under `/components/base-ui/<name>`. A 404 still returns HTTP 200, so
+assert the document title, never the status code.
+
+```bash
+agent-browser open "$URL/components/base-ui/floating-panel"
+agent-browser eval 'document.title' # "<Name> - Lobe UI" proves the route resolved
+```
+
+Geometry probe — the pattern these components are verified with. Measure layout
+values, never `getBoundingClientRect` alone: the rect carries in-flight transforms
+from entrance animations.
+
+```bash
+agent-browser eval 'JSON.stringify({ w: el.offsetWidth, h: el.offsetHeight })'
+```
+
+Component demos are ordinary DOM in the page; drive them by accessible name:
+
+```bash
+agent-browser eval '(function(){[...document.querySelectorAll("button")]
+  .find(b => b.textContent.trim() === LABEL).click(); return 1})()'
+```
+
+## 6. Known constraints
+
+- **Node >= 22, pnpm.** The workspace is root + `packages/*`.
+- **Aliases point at source.** `docs.config.ts` and `vitest.config.ts` resolve
+  `@lobehub/ui` back to `src/`, so a docs-site run proves the source, never the build.
+  Only a consuming-app run proves `es/`.
+- **A background browser tab freezes rAF and ResizeObserver.** Anything driven by a
+  ResizeObserver must be measured in the foreground tab, or through headless
+  Playwright.
+- **HMR invalidates element refs.** Re-snapshot after a hot reload before interacting.
+- **`//` is not a CSS comment.** Inside an `antd-style` css template it parses as
+  content, and an apostrophe in the text ends up an unclosed string that fails
+  stylelint at commit time. Use `/* */`.

--- a/.agents/acceptance/common-mistakes.md
+++ b/.agents/acceptance/common-mistakes.md
@@ -1,0 +1,34 @@
+# common-mistakes.md — @lobehub/ui project layer
+
+Project-specific traps. The generic checklist lives in the skill.
+
+## Checklist
+
+- **P1** A docs-site run proves `src/`, never `es/`. A claim about the shipped
+  package needs a consuming-app run against a replaced `es/`.
+- **P2** Measure geometry with `offsetWidth`/`offsetHeight` and resting insets.
+  `getBoundingClientRect` includes the entrance animation's transform, so a
+  ResizeObserver firing mid-flight reports a scaled-down element.
+- **P3** A CSS custom property written on `:root` reaches every instance of the
+  component on the page. Verify with more than one instance mounted.
+
+## Entries
+
+### P1 — Verifying the source when the claim is about the package
+
+Docs dev and vitest both alias `@lobehub/ui` to `src/`. A geometry or styling
+change verified only there has not been proven to survive the build. Run the
+consuming app against a replaced `es/` and swap back to the published build to
+get an honest `before`.
+
+### P2 — Measuring through a transform
+
+`FloatingPanel` enters with a motion scale. A ResizeObserver fires during that
+animation, and `getBoundingClientRect` at that moment returns the scaled box —
+an offset derived from it lands short. Layout properties are transform-free.
+
+### P3 — A global custom property is shared state
+
+Two panels on one page both write the same `:root` variable, and the second one
+to mount reads the first one's value as its own baseline. Scope a variable that
+describes one instance to that instance's own element.

--- a/.agents/acceptance/probe-mock-patterns.md
+++ b/.agents/acceptance/probe-mock-patterns.md
@@ -1,0 +1,33 @@
+# probe-mock-patterns.md — @lobehub/ui project layer
+
+How to force state on this product.
+
+## Swap the built package under a consuming app
+
+The only way to prove `es/` rather than `src/`, and the only honest source of a
+`before` screenshot. See PROJECT.md §4. Restart the consuming app's dev server
+after each swap — bundler caches survive the file replacement.
+
+## Drive a demo by accessible name
+
+Demos are ordinary DOM. Click by trimmed button text rather than a generated
+class name:
+
+```bash
+agent-browser eval '(function(){[...document.querySelectorAll("button")]
+  .find(b => b.textContent.trim() === "Open panel").click(); return 1})()'
+```
+
+## Force a viewport-relative branch without resizing the window
+
+`agent-browser` in this environment has no viewport command. Express the case in
+viewport-relative CSS instead, so the branch is reached at any window size:
+a panel of `calc(100vw - 200px)` leaves a lane too narrow for a toast on every
+screen, where a fixed `900px` only does so on a small one.
+
+## Read a component's published custom properties
+
+```bash
+agent-browser eval 'getComputedStyle(document.documentElement).getPropertyValue("--toast-shift-x")'
+agent-browser eval 'document.querySelector("[role=dialog]").style.getPropertyValue("--floating-panel-reserve-block-end")'
+```

--- a/src/base-ui/FloatingPanel/FloatingPanel.tsx
+++ b/src/base-ui/FloatingPanel/FloatingPanel.tsx
@@ -19,6 +19,7 @@ import {
   ModalTitle,
 } from '../Modal';
 import { styles } from './style';
+import { ToastDodge } from './ToastDodge';
 import type {
   FloatingPanelOffset,
   FloatingPanelPlacement,
@@ -78,13 +79,17 @@ const getPlacementStyle = (
   const isTop = placement.startsWith('top');
   const isLeft = placement.endsWith('Left');
 
+  const px = (value: number | string) => (typeof value === 'number' ? `${value}px` : value);
+  const blockInset = `calc(${px(y)} + var(--floating-panel-reserve-block-end, 0px))`;
+  const inlineInset = `calc(${px(x)} + var(--floating-panel-reserve-inline-end, 0px))`;
+
   return {
     alignItems: isTop ? 'flex-start' : 'flex-end',
     justifyContent: isLeft ? 'flex-start' : 'flex-end',
-    paddingBlockEnd: isTop ? undefined : y,
-    paddingBlockStart: isTop ? y : undefined,
-    paddingInlineEnd: isLeft ? undefined : x,
-    paddingInlineStart: isLeft ? x : undefined,
+    paddingBlockEnd: isTop ? undefined : blockInset,
+    paddingBlockStart: isTop ? blockInset : undefined,
+    paddingInlineEnd: isLeft ? undefined : inlineInset,
+    paddingInlineStart: isLeft ? inlineInset : undefined,
   };
 };
 
@@ -334,6 +339,7 @@ const FloatingPanel = memo<FloatingPanelProps>(
               ...semanticStyles?.panel,
             }}
           >
+            {placement === 'bottomRight' && <ToastDodge />}
             {resizable &&
               resizeHandles.map((handle) => (
                 <div

--- a/src/base-ui/FloatingPanel/ToastDodge.tsx
+++ b/src/base-ui/FloatingPanel/ToastDodge.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useRef } from 'react';
+
+import {
+  PANEL_ALIGN_INLINE_VAR,
+  PANEL_RESERVE_VAR,
+  resolveToastDodge,
+  TOAST_SHIFT_X_VAR,
+  TOAST_SHIFT_Y_VAR,
+  TOAST_WIDTH,
+  TOAST_WIDTH_VAR,
+} from '../Toast/dodge';
+
+const TOAST_VARS = [TOAST_SHIFT_X_VAR, TOAST_SHIFT_Y_VAR, TOAST_WIDTH_VAR];
+
+// A closing panel unmounts after its exit animation, so it can outlive the
+// panel that replaced it. Only the panel that wrote the vars may clear them.
+let owner: object | undefined;
+
+// Mounted inside the panel so it lives exactly as long as the panel does, and
+// reads its own parentElement to measure it.
+export const ToastDodge = () => {
+  const probeRef = useRef<HTMLSpanElement>(null);
+  const reserveRef = useRef(0);
+  const tokenRef = useRef({});
+  const insetRef = useRef<{ x: number; y: number }>(undefined);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const panel = probeRef.current?.parentElement;
+
+    const token = tokenRef.current;
+    const wrapper = panel?.parentElement;
+    const clear = () => {
+      reserveRef.current = 0;
+      // The reserve lives on this panel's own wrapper, so it is always ours to
+      // drop; the toast vars are global and only the last writer may clear them.
+      if (wrapper instanceof HTMLElement) {
+        wrapper.style.removeProperty(PANEL_RESERVE_VAR);
+        wrapper.style.removeProperty(PANEL_ALIGN_INLINE_VAR);
+      }
+      if (owner !== token) return;
+      owner = undefined;
+      for (const name of TOAST_VARS) root.style.removeProperty(name);
+    };
+
+    if (!panel) return;
+
+    const apply = () => {
+      if (!(panel instanceof HTMLElement) || !(wrapper instanceof HTMLElement)) return;
+      // Read the resting insets once, before anything is reserved: the wrapper
+      // padding animates, so sampling it later feeds the transition's midpoint
+      // back into the verdict and the reserve ratchets upward every frame.
+      if (!insetRef.current) {
+        const padding = getComputedStyle(wrapper);
+        insetRef.current = {
+          x: Number.parseFloat(padding.paddingInlineEnd) || 0,
+          y: Number.parseFloat(padding.paddingBlockEnd) || 0,
+        };
+      }
+      // Layout size, never getBoundingClientRect: the rect carries the entrance
+      // animation's transform, so measuring mid-flight reports a scaled-down
+      // panel and the toast lands short of the gutter.
+      const inset = insetRef.current;
+      // Measure the panel as if it were not already yielding, otherwise the
+      // reserve it applies shrinks the panel and flips the next verdict.
+      // Only add the reserve back when max-height is what is holding the panel
+      // down; a panel shorter than its cap was never shrunk by it.
+      const maxHeight = Number.parseFloat(getComputedStyle(panel).maxHeight);
+      const reserved = reserveRef.current;
+      const clamped = panel.offsetHeight >= maxHeight - 0.5 ? reserved : 0;
+      const dodge = resolveToastDodge({
+        panelHeight: panel.offsetHeight + clamped,
+        panelOffsetX: inset.x,
+        panelOffsetY: inset.y,
+        panelWidth: panel.offsetWidth,
+        viewportHeight: wrapper.clientHeight,
+        viewportWidth: wrapper.clientWidth,
+      });
+
+      owner = token;
+      reserveRef.current = dodge.reserve;
+      root.style.setProperty(TOAST_SHIFT_X_VAR, `${dodge.shiftX}px`);
+      root.style.setProperty(TOAST_SHIFT_Y_VAR, `${dodge.shiftY}px`);
+      wrapper.style.setProperty(PANEL_RESERVE_VAR, `${dodge.reserve}px`);
+      wrapper.style.setProperty(PANEL_ALIGN_INLINE_VAR, `${dodge.alignInline}px`);
+      if (dodge.width === TOAST_WIDTH) root.style.removeProperty(TOAST_WIDTH_VAR);
+      else root.style.setProperty(TOAST_WIDTH_VAR, `${dodge.width}px`);
+    };
+
+    const observer = new ResizeObserver(apply);
+    observer.observe(panel);
+    window.addEventListener('resize', apply);
+    apply();
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', apply);
+      clear();
+    };
+  }, []);
+
+  return <span aria-hidden hidden ref={probeRef} />;
+};

--- a/src/base-ui/FloatingPanel/__tests__/FloatingPanel.test.tsx
+++ b/src/base-ui/FloatingPanel/__tests__/FloatingPanel.test.tsx
@@ -6,6 +6,14 @@ import ConfigProvider from '@/ConfigProvider';
 
 import { FloatingPanel } from '../FloatingPanel';
 
+if (!globalThis.ResizeObserver) {
+  globalThis.ResizeObserver = class {
+    disconnect() {}
+    observe() {}
+    unobserve() {}
+  } as any;
+}
+
 vi.mock('antd-style', async (importOriginal) => {
   const actual = await importOriginal<typeof import('antd-style')>();
   return {

--- a/src/base-ui/FloatingPanel/demos/toastDodge.tsx
+++ b/src/base-ui/FloatingPanel/demos/toastDodge.tsx
@@ -1,0 +1,106 @@
+import { Flexbox, Text, toast, ToastHost } from '@lobehub/ui';
+import { Button, FloatingPanel } from '@lobehub/ui/base-ui';
+import { cssVar } from 'antd-style';
+import { Bell, MessageCirclePlus } from 'lucide-react';
+import { useState } from 'react';
+
+// Widths are viewport-relative so each case reaches the same verdict at any
+// window size: a fixed width flips back to a left shift on a wide screen.
+const CASES = {
+  above: {
+    height: 320,
+    hint: 'No lane wide enough, but the panel is short, so the toast rides above it.',
+    label: 'Above',
+    width: 'calc(100vw - 340px)',
+  },
+  left: {
+    height: 'min(640px, calc(100dvh - 16px))',
+    hint: 'A full lane is free beside the panel, so the toast keeps its bottom baseline.',
+    label: 'Left lane',
+    width: 640,
+  },
+  narrowed: {
+    height: 'calc(100dvh - 16px)',
+    hint: 'The lane is under 360px but still over 260px, so the toast narrows to fit it.',
+    label: 'Narrowed',
+    width: 'calc(100vw - 320px)',
+  },
+  yields: {
+    height: 'calc(100dvh - 16px)',
+    hint: 'Nothing is left on either axis, so the panel lifts its own bottom edge instead.',
+    label: 'Panel yields',
+    width: 'calc(100vw - 200px)',
+  },
+} as const;
+
+type CaseKey = keyof typeof CASES;
+
+const ORDER: CaseKey[] = ['left', 'above', 'narrowed', 'yields'];
+
+const Demo = () => {
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState<CaseKey>('left');
+
+  const notify = () =>
+    toast.success({
+      description: 'Switch cases or resize the window to watch the toast pick a lane.',
+      duration: 60_000,
+      title: 'Run finished',
+    });
+
+  return (
+    <Flexbox gap={16}>
+      <ToastHost />
+      <Flexbox gap={4}>
+        <Text style={{ fontSize: 18, fontWeight: 700 }}>Toast dodging</Text>
+        <Text type="secondary">
+          A bottom-right panel pushes the bottom-right toast viewport out of its way, and the toast
+          slides back when the panel closes. Every case keeps a 12px gutter.
+        </Text>
+      </Flexbox>
+      <Flexbox horizontal gap={8} wrap="wrap">
+        <Button icon={<MessageCirclePlus size={16} />} type="primary" onClick={() => setOpen(true)}>
+          Open panel
+        </Button>
+        <Button icon={<Bell size={16} />} onClick={notify}>
+          Show toast
+        </Button>
+        {ORDER.map((key) => (
+          <Button
+            key={key}
+            type={active === key ? 'primary' : 'default'}
+            onClick={() => setActive(key)}
+          >
+            {CASES[key].label}
+          </Button>
+        ))}
+      </Flexbox>
+      <Text type="secondary">{CASES[active].hint}</Text>
+      <FloatingPanel
+        footer={<Button block>Send follow up message</Button>}
+        height={CASES[active].height}
+        maskClosable={false}
+        minHeight={260}
+        minWidth={320}
+        open={open}
+        title={`${CASES[active].label} panel`}
+        width={CASES[active].width}
+        styles={{
+          body: { padding: 16 },
+          panel: { background: cssVar.colorBgContainer },
+        }}
+        onOpenChange={setOpen}
+      >
+        <Flexbox gap={12}>
+          <Text strong>Urgent pending</Text>
+          <Text type="secondary">
+            Toasts fired while this panel is open never land inside it. The panel writes its
+            measured geometry to CSS variables the toast viewport reads.
+          </Text>
+        </Flexbox>
+      </FloatingPanel>
+    </Flexbox>
+  );
+};
+
+export default Demo;

--- a/src/base-ui/FloatingPanel/index.mdx
+++ b/src/base-ui/FloatingPanel/index.mdx
@@ -5,13 +5,19 @@ category: Feedback
 ---
 
 import DemoIndex from './demos/index.tsx?demo';
+import DemoToastDodge from './demos/toastDodge.tsx?demo';
 
 ## Basic
 
 <Demo of={DemoIndex} layout="bare" />
+
+## Toast dodging
+
+<Demo of={DemoToastDodge} layout="bare" />
 
 ## Notes
 
 - `FloatingPanel` is resizable by default. The active resize handles follow the placement anchor so the panel remains attached to its viewport corner.
 - Use `minWidth`, `maxWidth`, `minHeight`, and `maxHeight` to constrain resize bounds.
 - Use `resizable={false}` for fixed auxiliary panels.
+- A `bottomRight` panel moves the bottom-right toast viewport out of its way while it is open, and restores it on close. The verdict is left shift, then up shift, then a narrowed toast, and finally the panel lifting its own bottom edge — so a toast never renders inside the panel.

--- a/src/base-ui/FloatingPanel/style.ts
+++ b/src/base-ui/FloatingPanel/style.ts
@@ -1,5 +1,7 @@
 import { createStaticStyles } from 'antd-style';
 
+import { TOAST_DODGE_DURATION, TOAST_DODGE_EASE } from '../Toast/dodge';
+
 export const styles = createStaticStyles(({ css, cssVar }) => ({
   body: css`
     overflow: hidden auto;
@@ -40,7 +42,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     transform-origin: 100% 100%;
 
     width: calc(100dvw - 32px);
-    max-height: calc(100dvh - 32px);
+    max-height: calc(100dvh - 32px - var(--floating-panel-reserve-block-end, 0px));
     border-radius: 12px;
 
     box-shadow:
@@ -169,5 +171,14 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   wrapper: css`
     overflow: hidden;
+    transition:
+      padding-block-end ${TOAST_DODGE_DURATION} ${TOAST_DODGE_EASE},
+      padding-block-start ${TOAST_DODGE_DURATION} ${TOAST_DODGE_EASE},
+      padding-inline-end ${TOAST_DODGE_DURATION} ${TOAST_DODGE_EASE},
+      padding-inline-start ${TOAST_DODGE_DURATION} ${TOAST_DODGE_EASE};
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
   `,
 }));

--- a/src/base-ui/Toast/dodge.test.ts
+++ b/src/base-ui/Toast/dodge.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveToastDodge } from './dodge';
+
+const input = (
+  viewportWidth: number,
+  viewportHeight: number,
+  panelWidth: number,
+  panelHeight: number,
+) => ({
+  panelHeight,
+  panelOffsetX: 8,
+  panelOffsetY: 8,
+  panelWidth,
+  viewportHeight,
+  viewportWidth,
+});
+
+describe('resolveToastDodge', () => {
+  it('shifts left when the lane fits a full-width toast', () => {
+    expect(resolveToastDodge(input(1440, 900, 640, 640))).toEqual({
+      alignInline: 0,
+      mode: 'left',
+      reserve: 8,
+      shiftX: 644,
+      shiftY: 0,
+      width: 360,
+    });
+  });
+
+  it('shifts up when the panel is too wide but short', () => {
+    const result = resolveToastDodge(input(1280, 800, 900, 320));
+
+    expect(result.mode).toBe('up');
+    expect(result.alignInline).toBe(8);
+    expect(result.shiftX).toBe(0);
+    expect(result.shiftY).toBe(324);
+  });
+
+  it('shrinks the toast when the lane is narrower than the full width', () => {
+    const result = resolveToastDodge(input(1280, 800, 960, 784));
+
+    expect(result.mode).toBe('shrink');
+    expect(result.width).toBe(284);
+    expect(result.shiftX).toBe(964);
+  });
+
+  it('reserves space under the panel when no lane is left', () => {
+    const result = resolveToastDodge(input(1024, 768, 960, 752));
+
+    expect(result.mode).toBe('reserve');
+    expect(result.reserve).toBe(108);
+    expect(result.alignInline).toBe(8);
+    expect(result.shiftX).toBe(0);
+    expect(result.shiftY).toBe(0);
+  });
+
+  it('lifts the panel to the toast inset so their bottom edges line up', () => {
+    const result = resolveToastDodge(input(1440, 900, 640, 640));
+
+    expect(result.reserve).toBe(8);
+    expect(resolveToastDodge({ ...input(1440, 900, 640, 640), panelOffsetY: 16 }).reserve).toBe(0);
+  });
+
+  it('never shifts when the panel already clears the toast corner', () => {
+    const result = resolveToastDodge({
+      panelHeight: 400,
+      panelOffsetX: 8,
+      panelOffsetY: 8,
+      panelWidth: 0,
+      viewportHeight: 900,
+      viewportWidth: 1440,
+    });
+
+    expect(result.shiftX).toBe(4);
+    expect(result.mode).toBe('left');
+  });
+});

--- a/src/base-ui/Toast/dodge.ts
+++ b/src/base-ui/Toast/dodge.ts
@@ -1,0 +1,89 @@
+export const TOAST_WIDTH = 360;
+export const TOAST_MIN_WIDTH = 260;
+export const TOAST_EDGE = 16;
+export const TOAST_ROW_HEIGHT = 88;
+export const TOAST_DODGE_GUTTER = 12;
+
+// Spring baked as linear(): stiffness 460 / damping 53 / mass 2.3, zeta ~0.81
+// with 1.2% overshoot. The duration is the spring's settle time — change them
+// together with the curve, not independently.
+export const TOAST_DODGE_DURATION = '608ms';
+export const TOAST_DODGE_EASE =
+  'linear(0, 0.08, 0.249, 0.437, 0.607, 0.745, 0.847, 0.917, 0.963, 0.99, 1.004, 1.011, 1.012, 1.011, 1.009, 1.007, 1.005, 1.003, 1.002, 1)';
+
+export const TOAST_SHIFT_X_VAR = '--toast-shift-x';
+export const TOAST_SHIFT_Y_VAR = '--toast-shift-y';
+export const TOAST_WIDTH_VAR = '--toast-width';
+export const PANEL_RESERVE_VAR = '--floating-panel-reserve-block-end';
+export const PANEL_ALIGN_INLINE_VAR = '--floating-panel-reserve-inline-end';
+
+export interface ToastDodgeInput {
+  panelHeight: number;
+  panelOffsetX: number;
+  panelOffsetY: number;
+  panelWidth: number;
+  viewportHeight: number;
+  viewportWidth: number;
+}
+
+export type ToastDodgeMode = 'left' | 'reserve' | 'shrink' | 'up';
+
+export interface ToastDodgeResult {
+  alignInline: number;
+  mode: ToastDodgeMode;
+  reserve: number;
+  shiftX: number;
+  shiftY: number;
+  width: number;
+}
+
+export const resolveToastDodge = ({
+  panelHeight,
+  panelOffsetX,
+  panelOffsetY,
+  panelWidth,
+  viewportHeight,
+  viewportWidth,
+}: ToastDodgeInput): ToastDodgeResult => {
+  const shiftX = Math.max(0, panelWidth + panelOffsetX + TOAST_DODGE_GUTTER - TOAST_EDGE);
+  const shiftY = Math.max(0, panelHeight + panelOffsetY + TOAST_DODGE_GUTTER - TOAST_EDGE);
+  const lane = viewportWidth - shiftX - TOAST_EDGE * 2;
+  const headroom = viewportHeight - shiftY - TOAST_EDGE * 2;
+
+  // The panel sits closer to the edge than the toast does, so the pair reads as
+  // misaligned until the panel is pushed out to the toast's inset. Which axis
+  // needs it follows which edge the two end up sharing.
+  const alignBlock = Math.max(0, TOAST_EDGE - panelOffsetY);
+  const alignInline = Math.max(0, TOAST_EDGE - panelOffsetX);
+
+  if (lane >= TOAST_WIDTH) {
+    return {
+      alignInline: 0,
+      mode: 'left',
+      reserve: alignBlock,
+      shiftX,
+      shiftY: 0,
+      width: TOAST_WIDTH,
+    };
+  }
+
+  if (headroom >= TOAST_ROW_HEIGHT) {
+    return { alignInline, mode: 'up', reserve: 0, shiftX: 0, shiftY, width: TOAST_WIDTH };
+  }
+
+  if (lane >= TOAST_MIN_WIDTH) {
+    return { alignInline: 0, mode: 'shrink', reserve: alignBlock, shiftX, shiftY: 0, width: lane };
+  }
+
+  // ponytail: the reserve budget is one toast row, not the live stack height —
+  // measuring the stack would feed panel resizes back into the measurement.
+  // A taller stack overflows upward here; per-stack reserve if that shows up.
+  return {
+    alignInline,
+    mode: 'reserve',
+    reserve: Math.max(0, TOAST_EDGE + TOAST_ROW_HEIGHT + TOAST_DODGE_GUTTER - panelOffsetY),
+    shiftX: 0,
+    shiftY: 0,
+    width: TOAST_WIDTH,
+  };
+};

--- a/src/base-ui/Toast/style.ts
+++ b/src/base-ui/Toast/style.ts
@@ -3,6 +3,8 @@ import { cva } from 'class-variance-authority';
 
 import { focusRing, focusRingColor } from '@/base-ui/focusRing';
 
+import { TOAST_DODGE_DURATION, TOAST_DODGE_EASE } from './dodge';
+
 export const styles = createStaticStyles(({ css, cssVar }) => ({
   action: css`
     cursor: pointer;
@@ -332,7 +334,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     position: fixed;
     z-index: 100000;
 
-    width: 360px;
+    width: var(--toast-width, 360px);
     max-width: calc(100vw - var(--toast-viewport-offset-x, 16px) * 2);
 
     outline: 0;
@@ -356,6 +358,18 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   viewportBottomRight: css`
     inset-block-end: var(--toast-viewport-offset-y, 16px);
     inset-inline-end: var(--toast-viewport-offset-x, 16px);
+
+    /* Percentages in translate() resolve against the element itself, not the
+       viewport, so the dodge offsets have to stay in px. */
+    transform: translate(
+      calc(-1 * var(--toast-shift-x, 0px)),
+      calc(-1 * var(--toast-shift-y, 0px))
+    );
+    transition: transform ${TOAST_DODGE_DURATION} ${TOAST_DODGE_EASE};
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
   `,
 
   viewportTop: css`


### PR DESCRIPTION
## What

A `bottomRight` `FloatingPanel` and the bottom-right toast viewport share a corner, so an open panel covered every toast fired behind it — the case downstream is `AgentTasks/AgentTaskDetail/TopicChatDrawer` in lobe-chat.

While such a panel is open it measures itself and publishes CSS variables the toast viewport reads. Closing it clears them and the toast slides back.

## The verdict, in order

The first one that fits wins. Every case keeps a 12px gutter, and whichever edge the two end up sharing is aligned.

| # | Case | Behaviour |
|---|---|---|
| 1 | Left lane | Toast shifts left, keeps its bottom baseline; panel drops to the toast's bottom inset |
| 2 | Above | No lane, but the panel is short — toast rides above it, right edges aligned |
| 3 | Narrowed | Lane under 360px but over 260px — toast narrows to fit it |
| 4 | Panel yields | Nothing left on either axis — the panel lifts its own bottom edge instead |

Step 4 always holds, so a toast never renders inside the panel.

Left is tried before up because height is the volatile dimension (resize handles, expand/collapse, `FloatingSheet` snap points). Binding the offset to width means fewer recomputes, and the toast keeps a stable baseline.

## Verified in the browser

Measured on the new docs demo at 1280×633, all four cases:

| Case | Layout | Gap | Shared edge | Toast width |
|---|---|---|---|---|
| Left lane | beside | 12 | bottom ✓ | 360 |
| Above | toast above | 12 | right ✓ | 360 |
| Narrowed | beside | 12 | bottom ✓ | 284 |
| Panel yields | toast below | 12 | right ✓ | 360 |

On close: transform back to identity, width back to 360, right inset back to 16, variables cleared.

## Notes

- The easing is a spring baked as `linear()` (stiffness 460 / damping 53 / mass 2.3, 608ms settle), same approach as `Tooltip/style.ts`. Duration and curve are one unit — change them together.
- The panel's reserve is written on its own wrapper, not `:root`. A global one changes the padding of every panel on the page, which corrupts the next panel's baseline measurement.
- Geometry comes from `offsetWidth`/`offsetHeight` and the resting insets, never `getBoundingClientRect`: the rect carries the entrance animation's transform, and the wrapper padding animates.
- A closing panel unmounts after its exit animation, so it can outlive the panel that replaced it. Only the panel that wrote the toast variables may clear them.
- The reserve budget is one toast row rather than the live stack height — measuring the stack would feed panel resizes back into the measurement. Marked in `dodge.ts`.
- Only `placement="bottomRight"` dodges. The other three corners are untouched.

## Follow-up in lobe-chat

`TopicChatDrawer` hard-codes `styles.panel.maxHeight`, which overrides the cap this relies on. That one-line removal ships separately.

https://claude.ai/code/session_01X2C9jktiWMsyDXVQyYYEi3