### PR TITLE
🐛 fix(base-ui): keep DraggablePanel's collapseThreshold working when expandable is false

### DIFF
--- a/src/base-ui/DraggablePanel/__tests__/DraggablePanel.test.tsx
+++ b/src/base-ui/DraggablePanel/__tests__/DraggablePanel.test.tsx
@@ -126,7 +126,7 @@ describe('DraggablePanel', () => {
     expect(screen.getByText('content')).toBeTruthy();
   });
 
-  test('an unexpandable panel cannot be collapsed by keyboard or by drag', () => {
+  test('an unexpandable panel drops the toggle but still honours collapseThreshold', () => {
     const onExpandChange = vi.fn();
     render(
       <DraggablePanel
@@ -141,12 +141,11 @@ describe('DraggablePanel', () => {
       </DraggablePanel>,
     );
 
-    const handle = screen.getByRole('separator');
-    fireEvent.keyDown(handle, { key: 'Enter' });
-    pointerDrag(handle, { x: -260 });
-
-    expect(onExpandChange).not.toHaveBeenCalled();
     expect(screen.queryByRole('button', { name: 'Collapse panel' })).toBeNull();
+
+    pointerDrag(screen.getByRole('separator'), { x: -260 });
+
+    expect(onExpandChange.mock.calls[0][0]).toBe(false);
   });
 
   test('the toggle does not submit an enclosing form', () => {

--- a/src/base-ui/DraggablePanel/__tests__/controller.test.ts
+++ b/src/base-ui/DraggablePanel/__tests__/controller.test.ts
@@ -135,7 +135,7 @@ describe('panel controller', () => {
     expect(listener).toHaveBeenCalled();
   });
 
-  test('an unexpandable panel ignores Enter and the collapse threshold', () => {
+  test('without a collapse threshold or an expand callback, drag clamps at min', () => {
     const onSizeChange = vi.fn();
     const panel = createPanelController(
       baseOptions({

--- a/src/base-ui/DraggablePanel/atoms.tsx
+++ b/src/base-ui/DraggablePanel/atoms.tsx
@@ -138,12 +138,12 @@ export const DraggablePanelRoot = memo<DraggablePanelRootProps>(
     );
 
     const options: PanelControllerOptions = {
-      collapseThreshold: expandable ? collapseThreshold : undefined,
+      collapseThreshold,
       defaultSize: resolvedDefaultSize,
       expand: isExpand,
       max,
       min,
-      onExpandChange: expandable ? setIsExpand : undefined,
+      onExpandChange: setIsExpand,
       onSizeChange: commitSize,
       onSizeDragging,
       placement,


### PR DESCRIPTION
## The bug

`expandable` was gating two things it has no business gating:

```ts
collapseThreshold: expandable ? collapseThreshold : undefined,
onExpandChange: expandable ? setIsExpand : undefined,
```

`expandable` should only decide whether the built-in toggle button renders — the legacy antd `DraggablePanel` never gated drag-to-collapse on it. With the gate in place, `collapseThreshold` is silently dead at every call site that hides the toggle and drives expansion from its own control.

That is exactly how lobe-chat's shared `RightPanel` is wired (`expandable={false}` + an external toggle), so **both** of `collapseThreshold`'s downstream call sites lost the behaviour: the Agent-builder panel and the conversation working sidebar. Dragging either below its 320px threshold clamped at `minWidth` instead of collapsing.

## Verified

Reproduced in the LobeHub desktop app on both call sites, then confirmed fixed. The two tests that encoded the old semantics now assert the corrected ones, and the new assertion was checked to fail with the gate re-introduced. 21/21 DraggablePanel tests pass.

Acceptance round for the downstream migration that surfaced this: https://app.lobehub.com/acceptance/3bcb3a68-2100-4514-8bb0-ce176e75e304

https://claude.ai/code/session_016Yc2kk25CBo6DXmeGJo1k9