### PR TITLE
🐛 fix(base-ui): clip a DraggablePanel that was collapsed by dragging past its threshold

### DIFF
--- a/src/base-ui/DraggablePanel/__tests__/DraggablePanel.test.tsx
+++ b/src/base-ui/DraggablePanel/__tests__/DraggablePanel.test.tsx
@@ -148,6 +148,24 @@ describe('DraggablePanel', () => {
     expect(onExpandChange.mock.calls[0][0]).toBe(false);
   });
 
+  test('a drag-collapsed panel clips the content it is still holding at full size', () => {
+    render(
+      <DraggablePanel
+        collapseThreshold={150}
+        defaultSize={{ width: 280 }}
+        minWidth={100}
+        placement="left"
+      >
+        content
+      </DraggablePanel>,
+    );
+
+    pointerDrag(screen.getByRole('separator'), { x: -200 });
+
+    const box = document.querySelector('.base-draggable-panel-content')!.parentElement!;
+    expect(box.style.overflow).toBe('clip');
+  });
+
   test('the toggle does not submit an enclosing form', () => {
     const onSubmit = vi.fn((event: { preventDefault: () => void }) => event.preventDefault());
     render(

--- a/src/base-ui/DraggablePanel/atoms.tsx
+++ b/src/base-ui/DraggablePanel/atoms.tsx
@@ -213,7 +213,10 @@ export const DraggablePanelContent = memo<DraggablePanelContentProps>(
   ({ children, className, style, ...rest }) => {
     const { axis, controller, expand, placement, state } = useDraggablePanelContext();
     const extent = useTransform(controller.motion.size, (value) => Math.max(0, value));
-    const clipping = state.dragging || state.folding || controller.target === 0;
+    // Subscribed, not read: a collapse that changes only the target would otherwise
+    // leave the content unclipped and painted outside the zero-width box.
+    const target = useStore(controller.subscribe, () => controller.target);
+    const clipping = state.dragging || state.folding || target === 0;
     const shrunk = state.collapsing || !expand;
 
     return (


### PR DESCRIPTION
Follow-up to #650. That PR made `collapseThreshold` fire again at the call sites that hide the toggle — which immediately exposed this.

## The bug

The content layer deliberately holds its expanded size while the box animates to zero (that is what makes the collapse look stable), so the box has to clip it:

```ts
const clipping = state.dragging || state.folding || controller.target === 0;
```

`controller.target` is read, not subscribed. The last step of a drag-collapse changes only that target — `dragging` and `folding` are already back to `false` — so no render follows and the box stays at `overflow: visible`. The content keeps painting at full width across the page.

Collapsing through the panel's own toggle goes through an `expand` prop change, which re-renders for other reasons, so it hid the bug.

## Reproduced

LobeHub desktop, Agent 配置页, `@lobehub/ui@5.42.1`: drag the builder panel below its 320px threshold and release. Box width 0, `overflow: visible`, 446px of panel content still drawn over the page. Patching the installed build with this change makes it `clip` and the content disappears with the box.

The new test drives the drag path and was checked to fail with the subscription removed. 22/22 DraggablePanel tests pass.

Acceptance round that found it: https://app.lobehub.com/acceptance/3bcb3a68-2100-4514-8bb0-ce176e75e304?r=2

https://claude.ai/code/session_016Yc2kk25CBo6DXmeGJo1k9