### PR TITLE
🐛 fix(theme-provider): provide the motion context above antd App holders

### DIFF
--- a/src/ThemeProvider/ThemeProvider.test.tsx
+++ b/src/ThemeProvider/ThemeProvider.test.tsx
@@ -1,5 +1,9 @@
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { App } from 'antd';
+import { use, useEffect } from 'react';
 import { afterAll, afterEach, beforeAll, expect, it, vi } from 'vitest';
+
+import { MotionComponent, type MotionComponentType } from '@/MotionProvider';
 
 import { LOBE_THEME_APP_ID } from './constants';
 import ThemeProvider from './ThemeProvider';
@@ -37,4 +41,26 @@ it('preserves the default portal app id for existing callers', () => {
   );
 
   expect(document.querySelector(`#${LOBE_THEME_APP_ID}`)?.textContent).toContain('content');
+});
+
+it('provides the motion context to antd static notification holders', async () => {
+  const motion = {} as MotionComponentType;
+  const Probe = () => (
+    <span data-testid="probe">{use(MotionComponent) === motion ? 'ok' : 'missing'}</span>
+  );
+  const Trigger = () => {
+    const { notification } = App.useApp();
+    useEffect(() => {
+      notification.open({ description: <Probe />, title: 'x' });
+    }, [notification]);
+    return null;
+  };
+
+  render(
+    <ThemeProvider enableCustomFonts={false} enableGlobalStyle={false} motion={motion}>
+      <Trigger />
+    </ThemeProvider>,
+  );
+
+  expect((await screen.findByTestId('probe')).textContent).toBe('ok');
 });

--- a/src/ThemeProvider/ThemeProvider.tsx
+++ b/src/ThemeProvider/ThemeProvider.tsx
@@ -12,6 +12,7 @@ import { memo, useCallback, useMemo, useState } from 'react';
 
 import { useCdnFn } from '@/ConfigProvider';
 import FontLoader from '@/FontLoader';
+import { MotionComponent } from '@/MotionProvider';
 import { lobeCustomStylish, lobeCustomToken } from '@/styles';
 import { createLobeAntdTheme } from '@/styles/theme/antdTheme';
 import { type LobeCustomToken } from '@/types/customToken';
@@ -33,6 +34,7 @@ const ThemeProvider = memo<ThemeProviderProps>(
     customFonts,
     customTheme = {},
     className,
+    motion,
     style,
     theme: antdTheme,
     ...rest
@@ -90,7 +92,7 @@ const ThemeProvider = memo<ThemeProviderProps>(
       [customTheme.primaryColor, customTheme.neutralColor, antdTheme],
     );
 
-    return (
+    const app = (
       <>
         {enableCustomFonts &&
           webfontUrls?.length > 0 &&
@@ -128,6 +130,10 @@ const ThemeProvider = memo<ThemeProviderProps>(
         </AntdThemeProvider>
       </>
     );
+
+    // antd <App> hosts the notification / modal holders, so anything rendered through those
+    // static APIs sits above the app-level ConfigProvider and needs the motion context here.
+    return motion ? <MotionComponent value={motion}>{app}</MotionComponent> : app;
   },
 );
 

--- a/src/ThemeProvider/type.ts
+++ b/src/ThemeProvider/type.ts
@@ -5,6 +5,7 @@ import {
 } from 'antd-style';
 import { type CSSProperties } from 'react';
 
+import { type MotionComponentType } from '@/MotionProvider';
 import { type NeutralColors, type PrimaryColors } from '@/styles';
 
 export interface ThemeProviderProps extends AntdThemeProviderProps<any> {
@@ -19,6 +20,7 @@ export interface ThemeProviderProps extends AntdThemeProviderProps<any> {
   customToken?: (theme: CustomTokenParams) => { [key: string]: any };
   enableCustomFonts?: boolean;
   enableGlobalStyle?: boolean;
+  motion?: MotionComponentType;
   style?: CSSProperties;
 }
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

`ThemeProvider` owns antd `<App>`, which hosts the `notification` / `modal` holders returned by `App.useApp()`. The motion context, however, is only supplied by `ConfigProvider`, which apps compose *inside* `ThemeProvider`'s children. So anything rendered through those static APIs (e.g. a lobe-ui `Button` in `notification.error({ actions })`) sits above the motion context and `useMotionComponent()` throws:

> Please wrap your app with `<ConfigProvider>` (or `<MotionProvider>`) and pass the motion component

This crashed the LobeHub renderer on an over-quota upload (lobehub/lobehub#19450 works around it downstream).

`ThemeProvider` now accepts an optional `motion` prop and provides `MotionComponent` above `<App>` when given:

```tsx
<ThemeProvider motion={m} …>
  <ConfigProvider …>{children}</ConfigProvider>
</ThemeProvider>
```

Omitting `motion` keeps today's behavior. Regression test asserts a probe rendered via `App.useApp().notification.open` sees the provided motion.

#### 📝 补充信息 | Additional Information

Follow-up in lobehub: pass `motion={m}` to `ThemeProvider` in the four theme shells and drop the interim `<MotionProvider>` wrapper.

https://claude.ai/code/session_019rSFnGHUE9kq3LMCUxugzR