### PR TITLE
♻️ refactor(motion): consume the motion context only, never provide it from components

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,31 +119,34 @@ import hotkeyMessages from '@lobehub/ui/i18n/resources/hotkey';
 
 ### ConfigProvider (Motion)
 
-You must pass a motion component via `ConfigProvider`.
-If your app uses `LazyMotion`, pass `m`:
+You must pass a motion component via `ConfigProvider`, and `ConfigProvider` must wrap `ThemeProvider` — never the other way round. `ThemeProvider` renders the antd `App` that hosts the static `notification` / `modal` holders and reads the CDN config for its webfonts, so both need the contexts from `ConfigProvider` above them.
 
 ```tsx
-import { ConfigProvider } from '@lobehub/ui';
+import { ConfigProvider, ThemeProvider } from '@lobehub/ui';
 import { motion } from 'motion/react';
 
 export default () => (
   <ConfigProvider motion={motion}>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </ConfigProvider>
 );
 ```
 
-If your app uses `LazyMotion`:
+If your app uses `LazyMotion`, pass `m`:
 
 ```tsx
-import { ConfigProvider } from '@lobehub/ui';
+import { ConfigProvider, ThemeProvider } from '@lobehub/ui';
 import { LazyMotion, domAnimation } from 'motion/react';
 import * as m from 'motion/react-m';
 
 export default () => (
   <LazyMotion features={domAnimation}>
     <ConfigProvider motion={m}>
-      <App />
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
     </ConfigProvider>
   </LazyMotion>
 );

--- a/src/ConfigProvider/index.mdx
+++ b/src/ConfigProvider/index.mdx
@@ -23,6 +23,18 @@ At the same time, it provides custom CDN configuration, set `proxy` to `custom` 
 
 <Demo of={DemoConfigProvider} />
 
+## Provider order
+
+`ConfigProvider` must wrap `ThemeProvider`, never the other way round. `ThemeProvider` renders the antd `App` that hosts the static `notification` / `modal` holders, and it reads the CDN config for its webfonts — both need the contexts from `ConfigProvider` above them. Components never provide these contexts themselves; anything rendered inside a `ConfigProvider` (including through antd's static APIs) receives them.
+
+```tsx
+<ConfigProvider motion={motion}>
+  <ThemeProvider>
+    <App />
+  </ThemeProvider>
+</ConfigProvider>
+```
+
 ## Motion
 
 Lobe UI uses Motion components via context. You must pass a motion component to `ConfigProvider`. If your app uses `LazyMotion`, pass `m`:

--- a/src/Image/viewer/ImageViewer.test.tsx
+++ b/src/Image/viewer/ImageViewer.test.tsx
@@ -181,9 +181,12 @@ describe('opening', () => {
     );
   });
 
-  it('fades in without a FLIP transform when motion is unavailable', () => {
-    render(<ImageComponent alt="cat" src="https://example.com/cat.png" />);
+  it('fades in without a FLIP transform when the user prefers reduced motion', () => {
+    const matchMedia = vi.fn(() => ({ matches: true }));
+    vi.stubGlobal('matchMedia', matchMedia);
+    renderWithMotion(<ImageComponent alt="cat" src="https://example.com/cat.png" />);
     openViewer();
+    expect(matchMedia).toHaveBeenCalledWith('(prefers-reduced-motion: reduce)');
 
     const image = getViewerImage() as HTMLImageElement;
     expect(image.style.transform).toBe(

--- a/src/Image/viewer/ImageViewer.tsx
+++ b/src/Image/viewer/ImageViewer.tsx
@@ -1,11 +1,9 @@
 'use client';
 
 import { Dialog, type DialogRootProps } from '@base-ui/react/dialog';
-import { motion } from 'motion/react';
 import {
   memo,
   type SyntheticEvent,
-  use,
   useCallback,
   useEffect,
   useMemo,
@@ -16,7 +14,6 @@ import { useMergeRefs } from 'react-merge-refs';
 
 import { ToastHost } from '@/base-ui/Toast';
 import { useLayerZIndex } from '@/base-ui/zIndex';
-import { MotionComponent } from '@/MotionProvider';
 import { useAppElement } from '@/ThemeProvider';
 
 import { styles } from '../style';
@@ -45,8 +42,7 @@ const prefersReducedMotion = () =>
 const ImageViewer = memo<ImageViewerProps>(({ entries, index, openerFocusElement, token }) => {
   const openerEntry = entries[index];
   const appElement = useAppElement();
-  const motionComponent = use(MotionComponent);
-  const [animated] = useState(() => !!motionComponent && !prefersReducedMotion());
+  const [animated] = useState(() => !prefersReducedMotion());
 
   const { ref: layerRef, zIndex } = useLayerZIndex<HTMLDivElement>('modal');
 
@@ -286,88 +282,82 @@ const ImageViewer = memo<ImageViewerProps>(({ entries, index, openerFocusElement
   );
 
   return (
-    // The chrome is built from Base UI controls, which need a motion component to
-    // render at all. The viewer itself still degrades to a plain fade without one —
-    // `animated` stays false — but the toolbar has no such fallback, so an app that
-    // skipped ConfigProvider gets motion here rather than a crash.
-    <MotionComponent value={motionComponent ?? motion}>
-      <Dialog.Root modal open onOpenChange={handleDialogOpenChange}>
-        <Dialog.Portal container={appElement ?? undefined}>
-          {/* Base UI drops a nested dialog's backdrop so overlays don't stack. The viewer is
+    <Dialog.Root modal open onOpenChange={handleDialogOpenChange}>
+      <Dialog.Portal container={appElement ?? undefined}>
+        {/* Base UI drops a nested dialog's backdrop so overlays don't stack. The viewer is
             not an overlay on the surface it opened from — it replaces the screen — so it
             keeps its own scrim, or a viewer opened from a maskless drawer would show the
             page straight through the letterbox around the image. */}
-          <Dialog.Backdrop
-            forceRender
-            className={styles.viewerBackdrop}
-            ref={backdropRef}
-            style={zIndex === undefined ? undefined : { zIndex }}
-            onClick={gestures.onSurfaceClick}
+        <Dialog.Backdrop
+          forceRender
+          className={styles.viewerBackdrop}
+          ref={backdropRef}
+          style={zIndex === undefined ? undefined : { zIndex }}
+          onClick={gestures.onSurfaceClick}
+        />
+        <Dialog.Popup
+          aria-label={currentEntry.element.alt || undefined}
+          className={styles.viewerPopup}
+          finalFocus={finalFocus}
+          // Focus the popup itself instead of Base UI's default (the first
+          // tabbable — the close button): a focus-visible close button pins
+          // the idle auto-hide open forever and pops its tooltip on open.
+          initialFocus={popupNodeRef}
+          ref={popupRef}
+          style={zIndex === undefined ? undefined : { zIndex: zIndex + 1 }}
+          tabIndex={-1}
+          onClick={gestures.onSurfaceClick}
+          onPointerCancel={gestures.onPointerFinish}
+          onPointerDown={gestures.onPointerDown}
+          onPointerMove={gestures.onPointerMove}
+          onPointerUp={gestures.onPointerFinish}
+        >
+          <img
+            alt={currentEntry.element.alt}
+            className={styles.viewerImage}
+            ref={imageRef}
+            src={source}
+            style={{
+              cursor: gestures.cursor,
+              height: imageRect.height,
+              left: imageRect.x,
+              top: imageRect.y,
+              width: imageRect.width,
+            }}
+            onClick={gestures.onImageClick}
+            onDoubleClick={gestures.onImageDoubleClick}
+            onLoad={handleLoad}
           />
-          <Dialog.Popup
-            aria-label={currentEntry.element.alt || undefined}
-            className={styles.viewerPopup}
-            finalFocus={finalFocus}
-            // Focus the popup itself instead of Base UI's default (the first
-            // tabbable — the close button): a focus-visible close button pins
-            // the idle auto-hide open forever and pops its tooltip on open.
-            initialFocus={popupNodeRef}
-            ref={popupRef}
-            style={zIndex === undefined ? undefined : { zIndex: zIndex + 1 }}
-            tabIndex={-1}
-            onClick={gestures.onSurfaceClick}
-            onPointerCancel={gestures.onPointerFinish}
-            onPointerDown={gestures.onPointerDown}
-            onPointerMove={gestures.onPointerMove}
-            onPointerUp={gestures.onPointerFinish}
-          >
-            <img
-              alt={currentEntry.element.alt}
-              className={styles.viewerImage}
-              ref={imageRef}
-              src={source}
-              style={{
-                cursor: gestures.cursor,
-                height: imageRect.height,
-                left: imageRect.x,
-                top: imageRect.y,
-                width: imageRect.width,
-              }}
-              onClick={gestures.onImageClick}
-              onDoubleClick={gestures.onImageDoubleClick}
-              onLoad={handleLoad}
-            />
-            <ViewerChrome
-              canZoomIn={canZoomIn}
-              canZoomOut={canZoomOut}
-              chromeRef={chromeRef}
-              current={currentIndex}
-              fitRect={fitRect}
-              flipHorizontal={flipHorizontal}
-              flipVertical={flipVertical}
-              hasNext={hasNext}
-              hasPrev={hasPrev}
-              natural={natural}
-              next={next}
-              prev={prev}
-              rotateLeft={rotateLeft}
-              rotateRight={rotateRight}
-              rotation={rotation}
-              scale={scale}
-              source={source}
-              toggleActualSize={toggleActualSize}
-              toolbarAddon={currentEntry.options.toolbarAddon}
-              total={entries.length}
-              zoomIn={zoomIn}
-              zoomOut={zoomOut}
-              onClose={handleClose}
-              onDownload={currentEntry.options.onDownload}
-            />
-          </Dialog.Popup>
-          <ToastHost root={appElement ?? undefined} />
-        </Dialog.Portal>
-      </Dialog.Root>
-    </MotionComponent>
+          <ViewerChrome
+            canZoomIn={canZoomIn}
+            canZoomOut={canZoomOut}
+            chromeRef={chromeRef}
+            current={currentIndex}
+            fitRect={fitRect}
+            flipHorizontal={flipHorizontal}
+            flipVertical={flipVertical}
+            hasNext={hasNext}
+            hasPrev={hasPrev}
+            natural={natural}
+            next={next}
+            prev={prev}
+            rotateLeft={rotateLeft}
+            rotateRight={rotateRight}
+            rotation={rotation}
+            scale={scale}
+            source={source}
+            toggleActualSize={toggleActualSize}
+            toolbarAddon={currentEntry.options.toolbarAddon}
+            total={entries.length}
+            zoomIn={zoomIn}
+            zoomOut={zoomOut}
+            onClose={handleClose}
+            onDownload={currentEntry.options.onDownload}
+          />
+        </Dialog.Popup>
+        <ToastHost root={appElement ?? undefined} />
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 });
 

--- a/src/ThemeProvider/index.mdx
+++ b/src/ThemeProvider/index.mdx
@@ -24,6 +24,8 @@ import DemoCustomFonts from './demos/CustomFonts.tsx?demo';
 
 ThemeProvider inherits all properties from antd-style's ThemeProvider component, including the common appearance-related properties.
 
+ThemeProvider must sit inside `ConfigProvider`: it renders the antd `App` that hosts the static `notification` / `modal` holders and reads the CDN config for its webfonts, so it needs the motion and config contexts from above. See [ConfigProvider → Provider order](/components/config-provider#provider-order).
+
 ### ThemeProvider Features
 
 The ThemeProvider component provides several key features:

--- a/src/base-ui/DraggablePanel/__tests__/DraggablePanel.test.tsx
+++ b/src/base-ui/DraggablePanel/__tests__/DraggablePanel.test.tsx
@@ -1,6 +1,13 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render as rtlRender, screen } from '@testing-library/react';
+import { motion } from 'motion/react';
+import type { ReactNode } from 'react';
+
+import ConfigProvider from '@/ConfigProvider';
 
 import DraggablePanel from '../DraggablePanel';
+
+const render = (node: ReactNode) =>
+  rtlRender(<ConfigProvider motion={motion}>{node}</ConfigProvider>);
 
 const pointerDrag = (handle: Element, offset: { x?: number; y?: number }) => {
   fireEvent.pointerDown(handle, { clientX: 0, clientY: 0, pointerId: 1 });

--- a/src/base-ui/DraggablePanel/atoms.tsx
+++ b/src/base-ui/DraggablePanel/atoms.tsx
@@ -3,7 +3,7 @@
 import { cx } from 'antd-style';
 import { ChevronLeft } from 'lucide-react';
 import type { HTMLMotionProps, MotionStyle } from 'motion/react';
-import { motion, useTransform } from 'motion/react';
+import { useTransform } from 'motion/react';
 import {
   type CSSProperties,
   memo,
@@ -17,6 +17,7 @@ import {
 import useControlledState from 'use-merge-value';
 
 import ActionIcon from '@/base-ui/ActionIcon';
+import { useMotionComponent } from '@/MotionProvider';
 import type { DivProps } from '@/types';
 
 import { DraggablePanelContext, useDraggablePanelContext } from './context';
@@ -211,6 +212,7 @@ export interface DraggablePanelContentProps extends Omit<DivProps, 'onDrag'> {}
 
 export const DraggablePanelContent = memo<DraggablePanelContentProps>(
   ({ children, className, style, ...rest }) => {
+    const Motion = useMotionComponent();
     const { axis, controller, expand, placement, state } = useDraggablePanelContext();
     const extent = useTransform(controller.motion.size, (value) => Math.max(0, value));
     // Subscribed, not read: a collapse that changes only the target would otherwise
@@ -220,7 +222,7 @@ export const DraggablePanelContent = memo<DraggablePanelContentProps>(
     const shrunk = state.collapsing || !expand;
 
     return (
-      <motion.div
+      <Motion.div
         inert={!expand}
         style={
           {
@@ -234,7 +236,7 @@ export const DraggablePanelContent = memo<DraggablePanelContentProps>(
           } as MotionStyle
         }
       >
-        <motion.div
+        <Motion.div
           animate={{ scale: shrunk ? COLLAPSED_SCALE : 1 }}
           className={cx(styles.content, className)}
           transition={timing()}
@@ -249,8 +251,8 @@ export const DraggablePanelContent = memo<DraggablePanelContentProps>(
           {...(rest as HTMLMotionProps<'div'>)}
         >
           {children}
-        </motion.div>
-      </motion.div>
+        </Motion.div>
+      </Motion.div>
     );
   },
 );


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [x] 📝 docs

#### 🔀 变更说明 | Description of Change

Two components bypassed the motion context and imported the full `motion` runtime from `motion/react`, which defeats `LazyMotion` + `m` for every consumer and blurs who owns the provider boundary:

- `Image/viewer/ImageViewer.tsx` self-provided `<MotionComponent value={motionComponent ?? motion}>` as a fallback for apps that skipped `ConfigProvider`. That hid a configuration error instead of surfacing it. Removed; the viewer now relies on the app-level context like every other component, and `animated` is driven by `prefers-reduced-motion` only.
- `base-ui/DraggablePanel/atoms.tsx` used `motion.div` directly. Switched to `useMotionComponent()` (the `useTransform` hook import stays — it does not pull the feature bundle).

Rule going forward: components **consume** `useMotionComponent()`; only the app-level `ConfigProvider` **provides** it.

Docs now state the provider order explicitly (README, `ConfigProvider/index.mdx` → *Provider order*, `ThemeProvider/index.mdx`): `ConfigProvider` must wrap `ThemeProvider`. `ThemeProvider` renders the antd `App` that hosts the static `notification` / `modal` holders and reads the CDN config via `useCdnFn()` for its webfonts, so both need `ConfigProvider` above them. lobehub had this inverted in all four theme shells (lobehub/lobehub#19450), which crashed the renderer when a lobe-ui `Button` was rendered through `notification.error({ actions })`.

#### 📝 补充信息 | Additional Information

Tests: `DraggablePanel` tests now render inside `ConfigProvider` (same as `Button.test.tsx`); the ImageViewer "motion unavailable" fallback test is re-pointed at reduced motion since that fallback no longer exists. `src/Image` + `src/base-ui/DraggablePanel`: 288 passed.

https://claude.ai/code/session_019rSFnGHUE9kq3LMCUxugzR