### PR TITLE
✨ feat(ui): add document-wide GlobalFocusRing installed by ConfigProvider

### DIFF
--- a/docs/superpowers/specs/2026-09-12-base-ui-focus-scope-design.md
+++ b/docs/superpowers/specs/2026-09-12-base-ui-focus-scope-design.md
@@ -1,0 +1,119 @@
+# base-ui FocusScope
+
+Port of `mx-core/apps/admin/src/ui/focus-scope` (Scope + ArrowNav + Switcher) into `@lobehub/ui/base-ui`, and `Tree` rebuilt on top of it. `list-actions` (selection model, action registry) stays in the app layer.
+
+## Model
+
+- A **scope** is a DOM subtree marked `[data-focus-scope="<id>"]`. The **active scope** is the last one the user pointed or focused into (global `pointerdown` / `focusin` capture listeners). It is **sticky**: interacting outside every scope does not clear it; only `Escape` inside a scope or `setActiveScope(null)` does.
+- **Items** inside a scope are `[data-scope-item]` elements (`data-id` optional, used for last-focused memory).
+- **ArrowNav** binds `↑ ↓ Home End` (plus `j k` with `vimKeys`) on `window` and moves DOM focus between the active scope's visible items. Works without the scope holding focus — the point of stickiness.
+- **Switcher** binds `← →` (plus `h l` with `vimKeys`) on `window`, mounted once per app, moving the active scope to its visible left/right sibling in DOM order and restoring that scope's last-focused item.
+
+## Files
+
+```
+src/base-ui/FocusScope/
+  FocusScope.tsx        <div data-focus-scope tabIndex={-1}> + register + Escape
+  store.ts              module singleton + useSyncExternalStore hooks
+  useScopeArrowNav.ts
+  useScopeSwitcher.ts
+  domUtils.ts           isItemVisible, isTextInputTarget, hasSize
+  index.ts
+  index.mdx
+  demos/                twoLists (ArrowNav + Switcher), tree (Tree inside scopes)
+  __tests__/
+    store.test.ts
+    useScopeArrowNav.test.tsx
+    useScopeSwitcher.test.tsx
+```
+
+No zustand, no tinykeys: the store is a plain object with `subscribe` + `useSyncExternalStore`; key bindings are a raw `keydown` listener keyed on `event.key`.
+
+## store.ts
+
+```ts
+interface FocusScopeState {
+  activeScopeId: string | null;
+  knownScopes: Map<string, number>;          // refcount; two mounts of one id are allowed
+  lastFocusedItem: Map<string, string>;      // scopeId → data-id
+}
+getActiveScopeId(): string | null
+setActiveScope(id: string | null): void      // ignored if id is not registered
+registerScope(id): () => void                // attaches document listeners on first call (SSR-safe)
+getLastFocusedItem(scopeId): string | null
+setLastFocusedItem(scopeId, id | null): void
+useActiveScopeId(): string | null
+useFocusScopeActive(id): boolean
+```
+
+Unregistering the last instance of an id clears it from `activeScopeId` and `lastFocusedItem`.
+
+## FocusScope.tsx
+
+```ts
+interface FocusScopeProps extends HTMLAttributes<HTMLDivElement> {
+  id?: string;            // default useId()
+  debugOutline?: boolean; // default false; dashed colorInfo outline on the active scope
+  ref?: Ref<HTMLDivElement>;
+}
+```
+
+Renders `<div data-focus-scope={id} data-scope-active tabIndex={-1} {...rest}>`. `role`, `className`, `style`, `onKeyDown` pass through — `Tree` renders `<FocusScope role="tree">`. `onKeyDown`: after the caller's handler, `Escape` (not `defaultPrevented`) → `setActiveScope(null)`.
+
+Exports `useFocusScopeId()` (context) so descendants can find their scope id without prop drilling.
+
+## useScopeArrowNav.ts
+
+```ts
+interface UseScopeArrowNavOptions {
+  scopeId: string;
+  itemSelector?: string;          // default '[data-scope-item]'
+  enabled?: boolean;              // default true
+  vimKeys?: boolean;              // default false: adds j / k
+  onItemFocus?: (el: HTMLElement) => void;
+  extra?: Record<string, (event: KeyboardEvent) => void>;  // keyed by event.key, same gating
+}
+```
+
+Listener: `window.addEventListener('keydown', handler, { capture: true })`. Gate, in order:
+
+1. `event.defaultPrevented` → skip.
+2. Modifier held (`meta / ctrl / alt`) → skip (extra keys included; `$mod+…` combos belong to app hotkeys).
+3. Reachable: `getActiveScopeId() === scopeId`, or `document.activeElement` is inside `[data-focus-scope=scopeId]`.
+4. `isTextInputTarget(event.target)` → skip.
+5. Same `KeyboardEvent` already handled by a sibling instance → skip (dedupe for double mounts).
+
+Then `preventDefault()` and run. Scope root resolution and item discovery copy mx-admin: prefer the root containing `activeElement`, else the first visible `[data-focus-scope=id]`; items = `root.querySelectorAll(itemSelector)` filtered by `isItemVisible`. `move(±1)` wraps; no current item → first / last. `focusAt` = `focus({ preventScroll })` + `scrollIntoView({ block: 'nearest' })` + `setLastFocusedItem` + fan out `onItemFocus` to every instance registered on the scope.
+
+Capture phase is deliberate: it runs before the bubble-phase Switcher, so a scope whose `extra` claims `←`/`→` (Tree) wins by `preventDefault`.
+
+## useScopeSwitcher.ts
+
+```ts
+interface UseScopeSwitcherOptions { enabled?: boolean; vimKeys?: boolean }
+```
+
+Bubble-phase `window` `keydown`. Skips `defaultPrevented`, modifiers, text inputs. Scopes = `[data-focus-scope]` in DOM order, deduped by id, filtered by `isItemVisible` and non-zero size. No wrap. On switch: `setActiveScope(next)` then focus, in order, last-focused item (`[data-id]` still in DOM) → first `[data-scope-item]` → the scope element. Focusing via the same `notifyScopeItemFocus` path as ArrowNav so `onItemFocus` consumers stay in sync.
+
+## Tree on FocusScope
+
+- Root becomes `<FocusScope id={scopeId} role="tree" …>`; new props `scopeId?: string`, `vimKeys?: boolean`.
+- Rows get `data-scope-item` and `data-id={key}`.
+- Delete `Tree`'s `onKeyDown`, `rowsRef`, `focusRow`. `activeKey` (roving `tabIndex`) is set from `onItemFocus` and row `onFocus`.
+- `useScopeArrowNav({ scopeId, itemSelector: '[role="treeitem"]', vimKeys, onItemFocus, extra })` with `extra`:
+  - `ArrowRight`: collapsed parent → expand; expanded → focus next row; leaf → no-op (still `preventDefault`, so Switcher does not steal it).
+  - `ArrowLeft`: expanded → collapse; else → focus parent row.
+  - `Enter`: select. `' '`: check if `checkable`, else select. `'*'`: expand siblings.
+- The "current row" for `extra` handlers is `document.activeElement.closest('[role=treeitem]')`, falling back to `activeKey`.
+- Tree tests change from `fireEvent.keyDown(row)` to `fireEvent.keyDown(window)` after `fireEvent.pointerDown(row)` — that is the behaviour being bought.
+
+## Tests
+
+- `store.test.ts`: refcount register / unregister; `setActiveScope` ignores unknown ids; unregister clears active + last-focused.
+- `useScopeArrowNav.test.tsx`: pointerdown into scope A then `ArrowDown` on window focuses A's next item; clicking outside keeps A reachable; `ArrowDown` from an `<input>` inside A is ignored; an event with `defaultPrevented` is ignored; two instances with one id move focus once.
+- `useScopeSwitcher.test.tsx`: A and B side by side; `ArrowRight` activates B and focuses its first item; back to A restores the last-focused item; `ArrowRight` prevented by a capture listener does nothing.
+- `Tree.test.tsx`: existing keyboard cases rewritten to window-level keys; add "←/→ inside Tree never switches scope" with a sibling scope mounted.
+
+## Out of scope
+
+`useListKeyboard`, `useListSelection`, action registries, `$mod+a` / multi-select extras — app layer. Typeahead. Grid (2-D) navigation.

--- a/docs/superpowers/specs/2026-09-12-base-ui-tree-design.md
+++ b/docs/superpowers/specs/2026-09-12-base-ui-tree-design.md
@@ -1,0 +1,152 @@
+# base-ui Tree
+
+Data-driven replacement for antd `Tree`, exported from `@lobehub/ui/base-ui`. No compound atoms.
+
+## Scope
+
+In: `treeData`, expand (controlled / default / `defaultExpandAll`), select (single / `multiple`), `checkable` with parent-child linkage (`checkStrictly` opt-out), keyboard navigation, expand/collapse height animation, `showLine`, `showIcon`, custom `switcherIcon`, `blockNode`, `titleRender`, `onRightClick`, per-node `disabled` / `selectable` / `checkable` / `isLeaf`.
+
+Out (not in v1): `draggable`, `virtual` / `height`, `loadData`, `fieldNames`, `filterTreeNode`, `autoExpandParent`, search highlight.
+
+## Files
+
+```
+src/base-ui/Tree/
+  Tree.tsx          root: state, flatten, keyboard, renders rows
+  TreeNode.tsx      one row + Collapsible.Panel for children
+  utils.ts          pure helpers: flattenVisible, getAllKeys, conductCheck
+  type.ts
+  style.ts
+  index.ts
+  index.mdx
+  demos/            basic, checkable, controlled, showLine, contextMenu
+  __tests__/
+    utils.test.ts
+    Tree.test.tsx
+```
+
+`src/base-ui/index.ts` gets `export { default as Tree } from './Tree'; export * from './Tree';`.
+
+## Types
+
+```ts
+export interface TreeDataNode {
+  checkable?: boolean;
+  children?: TreeDataNode[];
+  disabled?: boolean;
+  icon?: ReactNode;
+  isLeaf?: boolean;
+  key: string;
+  selectable?: boolean;
+  title: ReactNode;
+}
+
+export interface TreeProps {
+  blockNode?: boolean;
+  checkable?: boolean;
+  checkedKeys?: string[];
+  checkStrictly?: boolean;
+  className?: string;
+  classNames?: { indent?: string; node?: string; root?: string; switcher?: string; title?: string };
+  defaultCheckedKeys?: string[];
+  defaultExpandAll?: boolean;
+  defaultExpandedKeys?: string[];
+  defaultSelectedKeys?: string[];
+  disabled?: boolean;
+  expandedKeys?: string[];
+  indent?: number;                       // px per depth, default 20
+  multiple?: boolean;
+  onCheck?: (keys: string[], info: { checked: boolean; node: TreeDataNode }) => void;
+  onExpand?: (keys: string[], info: { expanded: boolean; node: TreeDataNode }) => void;
+  onRightClick?: (info: { event: MouseEvent; node: TreeDataNode }) => void;
+  onSelect?: (keys: string[], info: { node: TreeDataNode; selected: boolean }) => void;
+  selectedKeys?: string[];
+  showIcon?: boolean;
+  showLine?: boolean;
+  size?: ControlSize;                    // row height via controlHeight, default 'middle'
+  style?: CSSProperties;
+  styles?: { ...same slots as classNames };
+  switcherIcon?: ReactNode | ((info: { expanded: boolean; node: TreeDataNode }) => ReactNode);
+  titleRender?: (node: TreeDataNode) => ReactNode;
+  treeData: TreeDataNode[];
+}
+```
+
+Keys are `string` only. antd's `Key` union is not carried over.
+
+## State
+
+`Tree.tsx` holds three `useControlledState` pairs (`use-merge-value`, already used by `SearchBar`, `HotkeyInput`): `expandedKeys`, `selectedKeys`, `checkedKeys`. All three accept controlled + `default*`, mirroring antd.
+
+Derived once per render with `useMemo`:
+
+- `flat = flattenVisible(treeData, expandedSet)` → `{ node, depth, parentKey, index, hasChildren }[]` in document order. This is the single source of truth for rendering order and keyboard navigation.
+- `keyIndex = Map<key, flatIndex>` for O(1) lookup.
+- `checkState = checkStrictly ? { checked: Set, halfChecked: ∅ } : conductCheck(treeData, checkedKeys)`.
+
+## Rendering
+
+`Tree` renders `<div role="tree">` and maps `flat` to `TreeNode` rows. Nesting for animation is the only DOM nesting: each parent renders its children inside a `Collapsible.Root open={expanded}` / `Collapsible.Panel`, so the recursion is in `TreeNode`, but the row order and depth still come from `flat` (passed by key lookup, not recomputed).
+
+Row layout, left to right, `paddingInlineStart = depth * indent`:
+
+1. `showLine` guides: absolutely positioned vertical borders per depth, drawn on the row (not on ancestors), so hidden subtrees cost nothing.
+2. Switcher: 16px `ActionIcon`-less button; `ChevronRight` rotated 90deg when expanded, `transition: transform 200ms`. Leaf → empty spacer of same width.
+3. Checkbox (base-ui `Checkbox`, `indeterminate` from halfChecked) when `checkable && node.checkable !== false`.
+4. Icon when `showIcon`.
+5. Title: `titleRender?.(node) ?? node.title`. `blockNode` makes the whole row the hit target; otherwise only the title span is.
+
+Row `role="treeitem"`, `aria-expanded` (only when has children), `aria-selected`, `aria-checked` (only when checkable), `aria-level`, `aria-disabled`, `tabIndex` = `0` for the active row else `-1` (roving tabindex).
+
+Height animation: `Collapsible.Panel` sets `--collapsible-panel-height`; style.ts transitions `height 200ms cssVar.motionEaseOut` with `prefers-reduced-motion: reduce` → `0s`, identical to `Accordion/style.ts`. `Collapsible` does the `hidden` toggling after exit; no manual timers.
+
+## Interaction
+
+Click on switcher → toggle expand. Click on title (or row when `blockNode`) → select:
+
+- single: `[key]`, clicking the selected one keeps it selected (antd behaviour without `multiple`).
+- `multiple`: plain click → `[key]`; ⌘/ctrl click → toggle; shift click → range over `flat` between anchor and target. Anchor = last plain-clicked key, kept in a ref.
+
+Checkbox change → `conductCheck` toggles the subtree and re-derives ancestors, then `onCheck(checkedKeysWithoutHalf, info)`. `checkStrictly` → toggles that key only.
+
+`onRightClick` on row `contextmenu`. Does not `preventDefault` — caller decides (matches how `TaskSubtasks.tsx` uses it).
+
+Disabled (`props.disabled || node.disabled`): row gets `aria-disabled`, no select/check; expand still allowed (antd parity).
+
+## Keyboard
+
+One `onKeyDown` on the root, operating on `flat` and an `activeKey` state (initial: first selected key, else first row). Focus is moved imperatively via `rowRefs.get(key)?.focus()`.
+
+| Key        | Action                                                                |
+| ---------- | --------------------------------------------------------------------- |
+| ↓ / ↑      | next / previous row in `flat`                                         |
+| Home / End | first / last row                                                      |
+| →          | collapsed parent → expand; expanded parent → first child; leaf → noop |
+| ←          | expanded parent → collapse; else → move to `parentKey`                |
+| Enter      | select active (respects `multiple` + modifiers)                       |
+| Space      | `checkable` → toggle check; else same as Enter                        |
+| `*`        | expand all siblings of the active row                                 |
+
+Typeahead is out of scope.
+
+## Styling
+
+`style.ts` via `createStyles`. Row height from `controlHeight[size]`. Hover/selected backgrounds use `cssVar.colorFillTertiary` / `cssVar.colorFillSecondary`; focus ring from `base-ui/focusRing.ts`. `showLine` guide colour `cssVar.colorBorderSecondary`. No antd `ConfigProvider` token dependency — the `titleHeight` override lobe-chat does today becomes `size` or `styles.node`.
+
+## Tests
+
+`utils.test.ts`:
+
+- `flattenVisible`: respects expanded set, depth, parentKey, skips hidden subtrees.
+- `conductCheck`: check parent → all descendants; uncheck one child → parent half; all children → parent full; disabled / `checkable: false` nodes are skipped and never make a parent half-checked.
+
+`Tree.test.tsx` (RTL + user-event):
+
+- click switcher toggles `aria-expanded` and calls `onExpand`.
+- controlled `expandedKeys` does not toggle without the callback updating it.
+- ↓ ↓ → ← moves focus as tabled; Space toggles checkbox and `onCheck` receives linked keys.
+- `multiple` + shift click yields the range.
+
+## Migration note
+
+`TaskSubtasks.tsx` in lobe-chat: `import { Tree } from '@lobehub/ui/base-ui'`, drop the `ConfigProvider` wrapper, replace `titleHeight: 36` with `size="large"` (or `styles.node`). Props used there (`blockNode defaultExpandAll showLine switcherIcon treeData onRightClick onSelect`) all exist with the same names.

--- a/docs/superpowers/specs/2026-09-12-base-ui-tree-design.md
+++ b/docs/superpowers/specs/2026-09-12-base-ui-tree-design.md
@@ -80,7 +80,7 @@ Keys are `string` only. antd's `Key` union is not carried over.
 
 Derived once per render with `useMemo`:
 
-- `flat = flattenVisible(treeData, expandedSet)` → `{ node, depth, parentKey, index, hasChildren }[]` in document order. This is the single source of truth for rendering order and keyboard navigation.
+- `flat = flattenVisible(treeData, expandedSet)` → `{ node, depth, parentKey, index, hasChildren, isLast, trail: boolean[] }[]` in document order (`trail[i]` = ancestor at depth `i` still has following siblings; drives `showLine`). This is the single source of truth for rendering order and keyboard navigation.
 - `keyIndex = Map<key, flatIndex>` for O(1) lookup.
 - `checkState = checkStrictly ? { checked: Set, halfChecked: ∅ } : conductCheck(treeData, checkedKeys)`.
 
@@ -90,11 +90,11 @@ Derived once per render with `useMemo`:
 
 Row layout, left to right, `paddingInlineStart = depth * indent`:
 
-1. `showLine` guides: absolutely positioned vertical borders per depth, drawn on the row (not on ancestors), so hidden subtrees cost nothing.
+1. `showLine` guides: one absolutely positioned `<svg>` per row (width `depth * indent`, height = row height), a single `<path>`: a full-height vertical at every `trail[i] === true` depth, and at `depth - 1` a vertical that turns into the row through a 6px quarter arc (`A 6 6 0 0 0`) then a horizontal to the switcher; `isLast` rows stop the vertical at the arc. `stroke: colorBorderSecondary`, `stroke-linecap: round`. Drawn on the row, never on ancestors, so hidden subtrees cost nothing. CSS borders can't do the arc, hence SVG.
 2. Switcher: 16px `ActionIcon`-less button; `ChevronRight` rotated 90deg when expanded, `transition: transform 200ms`. Leaf → empty spacer of same width.
 3. Checkbox (base-ui `Checkbox`, `indeterminate` from halfChecked) when `checkable && node.checkable !== false`.
 4. Icon when `showIcon`.
-5. Title: `titleRender?.(node) ?? node.title`. `blockNode` makes the whole row the hit target; otherwise only the title span is.
+5. Title: `titleRender?.(node) ?? node.title`. `blockNode` makes the whole row the hit target and the title span `flex: 1; min-width: 0` so a custom title can lay out edge-to-edge (TaskSubtasks needs `justify-content: space-between`); otherwise only the title span is the target and it shrink-wraps.
 
 Row `role="treeitem"`, `aria-expanded` (only when has children), `aria-selected`, `aria-checked` (only when checkable), `aria-level`, `aria-disabled`, `tabIndex` = `0` for the active row else `-1` (roving tabindex).
 

--- a/src/ConfigProvider/index.mdx
+++ b/src/ConfigProvider/index.mdx
@@ -33,6 +33,24 @@ If your app uses [`LazyMotion`](https://motion.dev/docs/react-lazy-motion):
 
 <Demo of={DemoLazyMotion} />
 
+## Global keyboard focus
+
+ConfigProvider installs one global focus ring per document, including native controls and controls outside the provider's React subtree. No component focus class or registration is required. Set `config={{ globalFocusRing: false }}` on all providers to disable installation.
+
+Without ConfigProvider, install it directly and call the returned cleanup when your application unmounts:
+
+```ts
+import { installGlobalFocusRing } from '@lobehub/ui';
+
+const cleanup = installGlobalFocusRing();
+```
+
+The decorative top-layer ring uses CSS anchors to follow scrolling, resizing and translation without a continuous JavaScript measurement loop. It preserves `:focus-visible`, reduced-motion and forced-colors preferences. Only successfully covered controls lose their local outline; existing Base UI rings remain the fallback.
+
+Text inputs, textareas and contenteditable regions retain their existing focus styles. To opt out another control or an entire region, add `data-lobe-focus-ring="off"` to the element or an ancestor. This only skips the global ring; keep an appropriate local focus indication for keyboard users.
+
+Unsupported browsers, fragmented multiline links and shadow-root controls retain their original focus treatment. Install separately in each iframe document. Rotated shapes are not reproduced; the ring follows a rectangular bounding box. Partially clipped controls receive a full ring; fully clipped anchors are hidden by the browser.
+
 ## APIs
 
 ### ConfigProvider
@@ -47,6 +65,7 @@ If your app uses [`LazyMotion`](https://motion.dev/docs/react-lazy-motion):
 | customCdnFn | Custom function for generating CDN URLs when proxy is 'custom' | `CdnFn` | - |
 | aAs | Custom component to use for rendering anchor tags | `ElementType` | - |
 | imgAs | Custom component to use for rendering image tags | `ElementType` | - |
+| globalFocusRing | Install the document-wide keyboard focus ring | `boolean` | `true` |
 | imgUnoptimized | Whether to disable image optimization | `boolean` | - |
 
 ### CdnFn

--- a/src/ConfigProvider/index.tsx
+++ b/src/ConfigProvider/index.tsx
@@ -12,6 +12,7 @@ import {
   useState,
 } from 'react';
 
+import { installGlobalFocusRing } from '@/GlobalFocusRing';
 import {
   type I18nContextValue,
   type TranslationKey,
@@ -24,6 +25,7 @@ import { type CDN, type CdnApi, genCdnUrl } from '@/utils/genCdnUrl';
 export interface Config {
   aAs?: ElementType;
   customCdnFn?: CdnFn;
+  globalFocusRing?: boolean;
   imgAs?: ElementType;
   imgUnoptimized?: boolean;
   proxy?: CDN | 'custom';
@@ -51,6 +53,11 @@ const isThenable = (value: unknown): value is Promise<TranslationResourcesMap> =
 
 const ConfigProvider = memo<ConfigProviderProps>(
   ({ children, config, locale, resources, motion }) => {
+    useEffect(() => {
+      if (config?.globalFocusRing === false) return;
+      return installGlobalFocusRing();
+    }, [config?.globalFocusRing]);
+
     const fallbackLocale = locale ?? 'en';
     const [resolvedResources, setResolvedResources] = useState<TranslationResourcesMap | undefined>(
       () => (resources && !isThenable(resources) ? resources : undefined),

--- a/src/GlobalFocusRing/index.ts
+++ b/src/GlobalFocusRing/index.ts
@@ -1,0 +1,181 @@
+import { globalFocusRingCSS } from './style';
+
+const installations = new WeakMap<Document, { dispose: () => void; users: number }>();
+
+/** Install once per document. The returned cleanup is safe for nested providers and Strict Mode. */
+export const installGlobalFocusRing = (doc: Document = document): (() => void) => {
+  const existing = installations.get(doc);
+  if (existing) {
+    existing.users += 1;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      if (--existing.users === 0) existing.dispose();
+    };
+  }
+
+  const win = doc.defaultView;
+  if (
+    !win ||
+    !doc.body ||
+    !win.CSS?.supports('top', 'anchor(top)') ||
+    !win.CSS.supports('position-visibility', 'anchors-visible') ||
+    !('showPopover' in doc.createElement('div'))
+  )
+    return () => {};
+
+  const sheet = doc.createElement('style');
+  sheet.textContent = globalFocusRingCSS;
+  const ring = doc.createElement('div');
+  ring.setAttribute('data-lobe-global-focus-ring', '');
+  ring.setAttribute('aria-hidden', 'true');
+  ring.setAttribute('popover', 'manual');
+  doc.head.append(sheet);
+  doc.body.append(ring);
+
+  let target: HTMLElement | undefined;
+  let restoreTarget: (() => void) | undefined;
+  let frame = 0;
+  let disposed = false;
+
+  const clear = () => {
+    if (ring.matches(':popover-open')) ring.hidePopover();
+    restoreTarget?.();
+    restoreTarget = undefined;
+    target = undefined;
+  };
+
+  const sync = () => {
+    if (disposed) return;
+    const next = doc.activeElement;
+    if (next === target && next?.matches(':focus-visible') && next.isConnected) return;
+    clear();
+    // Shadow roots and fragmented inline text retain their own focus treatment.
+    if (
+      !next ||
+      next === doc.body ||
+      next.namespaceURI !== 'http://www.w3.org/1999/xhtml' ||
+      next.shadowRoot ||
+      next.closest('[data-lobe-focus-ring="off"]') ||
+      next.matches('textarea') ||
+      (next as HTMLElement).isContentEditable ||
+      (next.matches('input') &&
+        ![
+          'button',
+          'submit',
+          'reset',
+          'image',
+          'checkbox',
+          'radio',
+          'range',
+          'color',
+          'file',
+        ].includes((next as HTMLInputElement).type)) ||
+      !next.matches(':focus-visible') ||
+      next.getClientRects().length !== 1
+    )
+      return;
+
+    const element = next as HTMLElement;
+    const computed = win.getComputedStyle(element);
+    const rect = element.getBoundingClientRect();
+    if (!rect.width || !rect.height || computed.visibility !== 'visible') return;
+
+    const saved = ['anchor-name', 'outline'].map((property) => ({
+      priority: element.style.getPropertyPriority(property),
+      property,
+      value: element.style.getPropertyValue(property),
+    }));
+    const oldMarker = element.getAttribute('data-lobe-focus-ring');
+    const anchor = computed.getPropertyValue('anchor-name').trim();
+    const assignedAnchor =
+      anchor && anchor !== 'none' ? `${anchor}, --lobe-global-focus` : '--lobe-global-focus';
+    element.style.setProperty('anchor-name', assignedAnchor, 'important');
+    ring.style.borderRadius = computed.borderRadius;
+    ring.style.setProperty(
+      '--lobe-focus-ring-color',
+      computed.getPropertyValue('--lobe-focus-ring-color').trim() ||
+        computed.getPropertyValue('--ant-color-info').trim() ||
+        '#1677ff',
+    );
+
+    restoreTarget = () => {
+      for (const { property, value, priority } of saved) {
+        const assigned = property === 'anchor-name' ? assignedAnchor : 'none';
+        if (element.style.getPropertyValue(property) !== assigned) continue;
+        if (value) element.style.setProperty(property, value, priority);
+        else element.style.removeProperty(property);
+      }
+      if (element.getAttribute('data-lobe-focus-ring') === 'managed') {
+        if (oldMarker === null) element.removeAttribute('data-lobe-focus-ring');
+        else element.setAttribute('data-lobe-focus-ring', oldMarker);
+      }
+    };
+    try {
+      ring.showPopover();
+      // Do not suppress a working native outline when an anchor cannot resolve.
+      const bounds = ring.getBoundingClientRect();
+      if (
+        Math.max(
+          ...(['top', 'right', 'bottom', 'left'] as const).map((edge) =>
+            Math.abs(bounds[edge] - rect[edge]),
+          ),
+        ) > 1
+      ) {
+        clear();
+        return;
+      }
+      element.style.setProperty('outline', 'none', 'important');
+      element.setAttribute('data-lobe-focus-ring', 'managed');
+      target = element;
+    } catch {
+      clear();
+    }
+  };
+
+  const schedule = () => {
+    if (!frame)
+      frame = win.requestAnimationFrame(() => {
+        frame = 0;
+        sync();
+      });
+  };
+  const blur = () => {
+    win.cancelAnimationFrame(frame);
+    frame = 0;
+    clear();
+  };
+  const observer = new MutationObserver(() => {
+    if (target && !target.isConnected) clear();
+  });
+  observer.observe(doc.body, { childList: true, subtree: true });
+  doc.addEventListener('focusin', sync, true);
+  doc.addEventListener('focusout', schedule, true);
+  doc.addEventListener('keydown', schedule, true);
+  doc.addEventListener('pointerdown', schedule, true);
+  win.addEventListener('blur', blur);
+  win.addEventListener('focus', schedule);
+
+  const installation = {
+    dispose: () => {
+      disposed = true;
+      win.cancelAnimationFrame(frame);
+      observer.disconnect();
+      doc.removeEventListener('focusin', sync, true);
+      doc.removeEventListener('focusout', schedule, true);
+      doc.removeEventListener('keydown', schedule, true);
+      doc.removeEventListener('pointerdown', schedule, true);
+      win.removeEventListener('blur', blur);
+      win.removeEventListener('focus', schedule);
+      clear();
+      ring.remove();
+      sheet.remove();
+      installations.delete(doc);
+    },
+    users: 0,
+  };
+  installations.set(doc, installation);
+  sync();
+  return installGlobalFocusRing(doc);
+};

--- a/src/GlobalFocusRing/style.ts
+++ b/src/GlobalFocusRing/style.ts
@@ -1,0 +1,31 @@
+export const focusRingColor = (color: string) => `color-mix(in srgb, ${color} 90%, transparent)`;
+
+export const globalFocusRingCSS = `
+[data-lobe-global-focus-ring] {
+  all: initial;
+  position: fixed;
+  position-anchor: --lobe-global-focus;
+  top: anchor(top);
+  right: anchor(right);
+  bottom: anchor(bottom);
+  left: anchor(left);
+  position-visibility: anchors-visible;
+  pointer-events: none;
+  border-radius: inherit;
+  outline: 2px solid ${focusRingColor('var(--lobe-focus-ring-color)')};
+  outline-offset: 2px;
+  animation: lobe-global-focus-in 200ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+[data-lobe-global-focus-ring]:not(:popover-open) { display: none; }
+[data-lobe-global-focus-ring]::backdrop { background: transparent; pointer-events: none; }
+@keyframes lobe-global-focus-in {
+  from { opacity: 0.25; outline-offset: 5px; }
+  to { opacity: 1; outline-offset: 2px; }
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-lobe-global-focus-ring] { animation: none; }
+}
+@media (forced-colors: active) {
+  [data-lobe-global-focus-ring] { outline-color: CanvasText; animation: none; }
+}
+`;

--- a/src/base-ui/FocusScope/FocusScope.tsx
+++ b/src/base-ui/FocusScope/FocusScope.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { cx } from 'antd-style';
+import { createContext, type HTMLAttributes, type Ref, use, useEffect, useId } from 'react';
+
+import { registerScope, setActiveScope, useFocusScopeActive } from './store';
+import { styles } from './style';
+
+export interface FocusScopeProps extends HTMLAttributes<HTMLDivElement> {
+  debugOutline?: boolean;
+  id?: string;
+  ref?: Ref<HTMLDivElement>;
+}
+
+const FocusScopeIdContext = createContext<string | null>(null);
+
+export const useFocusScopeId = () => use(FocusScopeIdContext);
+
+export const FocusScope = ({
+  id,
+  debugOutline = false,
+  className,
+  children,
+  onKeyDown,
+  ...rest
+}: FocusScopeProps) => {
+  const generatedId = useId();
+  const scopeId = id ?? generatedId;
+  const isActive = useFocusScopeActive(scopeId);
+
+  useEffect(() => registerScope(scopeId), [scopeId]);
+
+  return (
+    <FocusScopeIdContext value={scopeId}>
+      <div
+        data-focus-scope={scopeId}
+        data-scope-active={isActive ? '' : undefined}
+        tabIndex={-1}
+        {...rest}
+        className={cx(styles.root, debugOutline && styles.debugOutline, className)}
+        onKeyDown={(event) => {
+          onKeyDown?.(event);
+          if (event.defaultPrevented) return;
+          if (event.key === 'Escape') setActiveScope(null);
+        }}
+      >
+        {children}
+      </div>
+    </FocusScopeIdContext>
+  );
+};
+
+FocusScope.displayName = 'FocusScope';

--- a/src/base-ui/FocusScope/__tests__/store.test.ts
+++ b/src/base-ui/FocusScope/__tests__/store.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getActiveScopeId,
+  getLastFocusedItem,
+  registerScope,
+  setActiveScope,
+  setLastFocusedItem,
+} from '../store';
+
+describe('focus scope store', () => {
+  it('ignores activation of unknown scopes', () => {
+    setActiveScope('nope');
+    expect(getActiveScopeId()).toBeNull();
+  });
+
+  it('refcounts registrations of the same id', () => {
+    const off1 = registerScope('a');
+    const off2 = registerScope('a');
+    setActiveScope('a');
+    off1();
+    expect(getActiveScopeId()).toBe('a');
+    off2();
+    expect(getActiveScopeId()).toBeNull();
+  });
+
+  it('clears last-focused memory when the scope unregisters', () => {
+    const off = registerScope('b');
+    setLastFocusedItem('b', 'row-2');
+    expect(getLastFocusedItem('b')).toBe('row-2');
+    off();
+    expect(getLastFocusedItem('b')).toBeNull();
+  });
+
+  it('activates the scope containing a pointerdown target', () => {
+    const off = registerScope('c');
+    const el = document.createElement('div');
+    el.dataset.focusScope = 'c';
+    const inner = document.createElement('button');
+    el.append(inner);
+    document.body.append(el);
+    inner.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    expect(getActiveScopeId()).toBe('c');
+    document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    expect(getActiveScopeId()).toBe('c');
+    off();
+    el.remove();
+  });
+});

--- a/src/base-ui/FocusScope/__tests__/useScopeArrowNav.test.tsx
+++ b/src/base-ui/FocusScope/__tests__/useScopeArrowNav.test.tsx
@@ -1,0 +1,127 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import { FocusScope } from '../FocusScope';
+import { getActiveScopeId, setActiveScope } from '../store';
+import { useScopeArrowNav } from '../useScopeArrowNav';
+
+const List = ({
+  id,
+  items,
+  onItemFocus,
+  vimKeys,
+}: {
+  id: string;
+  items: string[];
+  onItemFocus?: (el: HTMLElement) => void;
+  vimKeys?: boolean;
+}) => {
+  useScopeArrowNav({ onItemFocus, scopeId: id, vimKeys });
+  return (
+    <FocusScope id={id}>
+      {items.map((item) => (
+        <div data-scope-item data-id={item} key={item} tabIndex={-1}>
+          {item}
+        </div>
+      ))}
+      <input aria-label={`${id}-input`} />
+    </FocusScope>
+  );
+};
+
+afterEach(() => act(() => setActiveScope(null)));
+
+describe('useScopeArrowNav', () => {
+  test('ArrowDown moves focus inside the scope that was pointed into, without focus', () => {
+    render(<List id="a" items={['a1', 'a2', 'a3']} />);
+    fireEvent.pointerDown(screen.getByText('a1'));
+    expect(getActiveScopeId()).toBe('a');
+    fireEvent.keyDown(window, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(screen.getByText('a1'));
+    fireEvent.keyDown(window, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(screen.getByText('a2'));
+    fireEvent.keyDown(window, { key: 'End' });
+    expect(document.activeElement).toBe(screen.getByText('a3'));
+    fireEvent.keyDown(window, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(screen.getByText('a1'));
+  });
+
+  test('stays reachable after clicking outside every scope', () => {
+    render(
+      <>
+        <List id="a" items={['a1', 'a2']} />
+        <button>outside</button>
+      </>,
+    );
+    fireEvent.pointerDown(screen.getByText('a1'));
+    fireEvent.pointerDown(screen.getByText('outside'));
+    fireEvent.keyDown(window, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(screen.getByText('a1'));
+  });
+
+  test('ignores keys typed into text inputs and already-handled events', () => {
+    let block = false;
+    const stop = (event: KeyboardEvent) => block && event.preventDefault();
+    window.addEventListener('keydown', stop, true);
+    render(<List id="a" items={['a1', 'a2']} />);
+    fireEvent.pointerDown(screen.getByText('a1'));
+    const input = screen.getByLabelText('a-input');
+    act(() => input.focus());
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(input);
+
+    act(() => screen.getByText('a1').focus());
+    block = true;
+    fireEvent.keyDown(window, { key: 'ArrowDown' });
+    window.removeEventListener('keydown', stop, true);
+    expect(document.activeElement).toBe(screen.getByText('a1'));
+  });
+
+  test('j / k only work with vimKeys', () => {
+    const { rerender } = render(<List id="a" items={['a1', 'a2']} />);
+    fireEvent.pointerDown(screen.getByText('a1'));
+    act(() => screen.getByText('a1').focus());
+    fireEvent.keyDown(window, { key: 'j' });
+    expect(document.activeElement).toBe(screen.getByText('a1'));
+    rerender(<List vimKeys id="a" items={['a1', 'a2']} />);
+    fireEvent.keyDown(window, { key: 'j' });
+    expect(document.activeElement).toBe(screen.getByText('a2'));
+  });
+
+  test('only the active scope responds', () => {
+    render(
+      <>
+        <List id="a" items={['a1', 'a2']} />
+        <List id="b" items={['b1', 'b2']} />
+      </>,
+    );
+    fireEvent.pointerDown(screen.getByText('b1'));
+    fireEvent.keyDown(window, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(screen.getByText('b1'));
+  });
+
+  test('double-mounted scope moves focus once and fans out onItemFocus to both', () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    render(
+      <>
+        <List id="a" items={['a1', 'a2']} onItemFocus={a} />
+        <div hidden>
+          <List id="a" items={['a1', 'a2']} onItemFocus={b} />
+        </div>
+      </>,
+    );
+    fireEvent.pointerDown(screen.getAllByText('a1')[0]);
+    act(() => screen.getAllByText('a1')[0].focus());
+    fireEvent.keyDown(window, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(screen.getAllByText('a2')[0]);
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  test('Escape inside the scope deactivates it', () => {
+    render(<List id="a" items={['a1']} />);
+    fireEvent.pointerDown(screen.getByText('a1'));
+    fireEvent.keyDown(screen.getByText('a1'), { key: 'Escape' });
+    expect(getActiveScopeId()).toBeNull();
+  });
+});

--- a/src/base-ui/FocusScope/__tests__/useScopeSwitcher.test.tsx
+++ b/src/base-ui/FocusScope/__tests__/useScopeSwitcher.test.tsx
@@ -1,0 +1,85 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import { FocusScope } from '../FocusScope';
+import { getActiveScopeId, setActiveScope } from '../store';
+import { useScopeArrowNav } from '../useScopeArrowNav';
+import { useScopeSwitcher } from '../useScopeSwitcher';
+
+const List = ({ id, items }: { id: string; items: string[] }) => {
+  useScopeArrowNav({ scopeId: id });
+  return (
+    <FocusScope id={id}>
+      {items.map((item) => (
+        <div data-scope-item data-id={item} key={item} tabIndex={-1}>
+          {item}
+        </div>
+      ))}
+    </FocusScope>
+  );
+};
+
+const Shell = ({ vimKeys }: { vimKeys?: boolean }) => {
+  useScopeSwitcher({ vimKeys });
+  return (
+    <>
+      <List id="a" items={['a1', 'a2']} />
+      <List id="b" items={['b1', 'b2']} />
+    </>
+  );
+};
+
+vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+  bottom: 10,
+  height: 10,
+  left: 0,
+  right: 10,
+  toJSON: () => ({}),
+  top: 0,
+  width: 10,
+  x: 0,
+  y: 0,
+});
+
+afterEach(() => act(() => setActiveScope(null)));
+
+describe('useScopeSwitcher', () => {
+  test('ArrowRight activates the next scope and focuses its first item; no wrap', () => {
+    render(<Shell />);
+    fireEvent.pointerDown(screen.getByText('a1'));
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    expect(getActiveScopeId()).toBe('b');
+    expect(document.activeElement).toBe(screen.getByText('b1'));
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    expect(getActiveScopeId()).toBe('b');
+  });
+
+  test('switching back restores the last focused item', () => {
+    render(<Shell />);
+    fireEvent.pointerDown(screen.getByText('a1'));
+    act(() => screen.getByText('a1').focus());
+    fireEvent.keyDown(window, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(screen.getByText('a2'));
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+    expect(document.activeElement).toBe(screen.getByText('a2'));
+  });
+
+  test('a prevented ArrowRight does not switch', () => {
+    render(<Shell />);
+    fireEvent.pointerDown(screen.getByText('a1'));
+    const stop = (event: KeyboardEvent) => event.preventDefault();
+    window.addEventListener('keydown', stop, true);
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    window.removeEventListener('keydown', stop, true);
+    expect(getActiveScopeId()).toBe('a');
+  });
+
+  test('h / l only with vimKeys', () => {
+    render(<Shell vimKeys />);
+    fireEvent.pointerDown(screen.getByText('a1'));
+    fireEvent.keyDown(window, { key: 'l' });
+    expect(getActiveScopeId()).toBe('b');
+    fireEvent.keyDown(window, { key: 'h' });
+    expect(getActiveScopeId()).toBe('a');
+  });
+});

--- a/src/base-ui/FocusScope/demos/index.tsx
+++ b/src/base-ui/FocusScope/demos/index.tsx
@@ -1,0 +1,49 @@
+import { Flexbox } from '@lobehub/ui';
+import { FocusScope, Text, useFocusScopeActive, useScopeArrowNav, useScopeSwitcher } from '@lobehub/ui/base-ui';
+import { cssVar } from 'antd-style';
+
+const List = ({ id, items }: { id: string; items: string[] }) => {
+  useScopeArrowNav({ scopeId: id, vimKeys: true });
+  const active = useFocusScopeActive(id);
+  return (
+    <FocusScope
+      debugOutline
+      id={id}
+      style={{ borderRadius: 8, flex: 1, minWidth: 0, padding: 8 }}
+    >
+      <Text fontSize={12} style={{ paddingInline: 8 }} type="secondary">
+        {id} {active ? '· active' : ''}
+      </Text>
+      {items.map((item) => (
+        <div
+          data-scope-item
+          data-id={item}
+          key={item}
+          style={{ borderRadius: 6, cursor: 'default', outline: 'none', padding: '6px 8px' }}
+          tabIndex={-1}
+          onBlur={(e) => (e.currentTarget.style.background = '')}
+          onFocus={(e) => (e.currentTarget.style.background = cssVar.colorFillSecondary)}
+        >
+          {item}
+        </div>
+      ))}
+    </FocusScope>
+  );
+};
+
+export default () => {
+  useScopeSwitcher({ vimKeys: true });
+  return (
+    <Flexbox gap={16} padding={16}>
+      <Text type="secondary">
+        Click into a list, then use ↑ ↓ (j k) to move and ← → (h l) to jump between lists — no
+        focus required after the first click. Esc releases the scope.
+      </Text>
+      <Flexbox horizontal gap={12}>
+        <List id="inbox" items={['Welcome', 'Release notes', 'Weekly digest']} />
+        <List id="drafts" items={['Untitled', 'Q3 plan', 'Reply to Sam']} />
+        <List id="archive" items={['2025 recap', 'Old invoice']} />
+      </Flexbox>
+    </Flexbox>
+  );
+};

--- a/src/base-ui/FocusScope/domUtils.ts
+++ b/src/base-ui/FocusScope/domUtils.ts
@@ -1,0 +1,25 @@
+export const isItemVisible = (el: HTMLElement): boolean => {
+  if (typeof el.checkVisibility === 'function') {
+    return el.checkVisibility({ checkOpacity: true, checkVisibilityCSS: true });
+  }
+  for (let node: HTMLElement | null = el; node; node = node.parentElement) {
+    const style = getComputedStyle(node);
+    if (style.display === 'none' || style.visibility === 'hidden') return false;
+  }
+  return true;
+};
+
+export const hasSize = (el: HTMLElement) => {
+  const rect = el.getBoundingClientRect();
+  return rect.width > 0 && rect.height > 0;
+};
+
+export const isTextInputTarget = (target: EventTarget | null) => {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  return ['INPUT', 'SELECT', 'TEXTAREA'].includes(target.tagName);
+};
+
+export const hasModifier = (event: KeyboardEvent) => event.metaKey || event.ctrlKey || event.altKey;
+
+export const scopeSelector = (id: string) => `[data-focus-scope="${id.replaceAll('"', '\\"')}"]`;

--- a/src/base-ui/FocusScope/index.mdx
+++ b/src/base-ui/FocusScope/index.mdx
@@ -1,0 +1,51 @@
+---
+title: FocusScope
+description: Sticky keyboard regions. Point into a scope once and ↑ ↓ keep working there without holding focus; ← → jump between scopes and restore the last focused item.
+category: Utils
+---
+
+import DemoIndex from './demos/index.tsx?demo';
+
+## Model
+
+- `<FocusScope id>` marks a DOM subtree. The **active scope** is the last one the user pointed or focused into, and it stays active until `Esc` or `setActiveScope(null)` — clicking elsewhere does not clear it.
+- Items are `[data-scope-item]` elements; give them `data-id` to enable last-focused memory.
+- `useScopeArrowNav({ scopeId })` binds `↑ ↓ Home End` on `window` (capture phase) and moves DOM focus between the active scope's visible items. `extra` adds scope-local keys under the same gating; `vimKeys` adds `j k`.
+- `useScopeSwitcher()` — mount once per app — binds `← →` (`h l` with `vimKeys`) on `window` (bubble phase). A scope whose `extra` claims `←`/`→` wins by `preventDefault`, which is how `Tree` keeps expand / collapse.
+
+All bindings skip text inputs, modifier combos and already-prevented events.
+
+<Demo of={DemoIndex} layout="bare" />
+
+## APIs
+
+### FocusScope
+
+| Property     | Description                                             | Type      | Default    |
+| ------------ | ------------------------------------------------------- | --------- | ---------- |
+| id           | Stable scope id; the same id may be mounted twice       | `string`  | `useId()`  |
+| debugOutline | Dashed outline on the active scope                      | `boolean` | `false`    |
+
+Every other `div` prop passes through (`role`, `className`, `style`, `onKeyDown`, `ref`).
+
+### useScopeArrowNav
+
+| Option       | Description                                        | Type                                   | Default               |
+| ------------ | -------------------------------------------------- | -------------------------------------- | --------------------- |
+| scopeId      | Scope to navigate                                  | `string`                               | -                     |
+| itemSelector | Items inside the scope                             | `string`                               | `'[data-scope-item]'` |
+| vimKeys      | Also bind `j` / `k`                                | `boolean`                              | `false`               |
+| extra        | Extra keys (`event.key`) with the same gating      | `Record<string, (e: KeyboardEvent) => void>` | -               |
+| onItemFocus  | Called after keyboard focus lands on an item       | `(el: HTMLElement) => void`            | -                     |
+| enabled      |                                                    | `boolean`                              | `true`                |
+
+### useScopeSwitcher
+
+| Option  | Description          | Type      | Default |
+| ------- | -------------------- | --------- | ------- |
+| vimKeys | Also bind `h` / `l`  | `boolean` | `false` |
+| enabled |                      | `boolean` | `true`  |
+
+### Store
+
+`getActiveScopeId()`, `setActiveScope(id | null)`, `useActiveScopeId()`, `useFocusScopeActive(id)`, `getLastFocusedItem(scopeId)`, `setLastFocusedItem(scopeId, id | null)`, `registerScope(id)`.

--- a/src/base-ui/FocusScope/index.ts
+++ b/src/base-ui/FocusScope/index.ts
@@ -1,0 +1,18 @@
+export { FocusScope, type FocusScopeProps, useFocusScopeId } from './FocusScope';
+export {
+  getActiveScopeId,
+  getLastFocusedItem,
+  registerScope,
+  setActiveScope,
+  setLastFocusedItem,
+  useActiveScopeId,
+  useFocusScopeActive,
+} from './store';
+export { styles as focusScopeStyles } from './style';
+export {
+  focusScopeItem,
+  notifyScopeItemFocus,
+  useScopeArrowNav,
+  type UseScopeArrowNavOptions,
+} from './useScopeArrowNav';
+export { useScopeSwitcher, type UseScopeSwitcherOptions } from './useScopeSwitcher';

--- a/src/base-ui/FocusScope/store.ts
+++ b/src/base-ui/FocusScope/store.ts
@@ -1,0 +1,96 @@
+import { useSyncExternalStore } from 'react';
+
+interface FocusScopeState {
+  activeScopeId: string | null;
+  knownScopes: Map<string, number>;
+  lastFocusedItem: Map<string, string>;
+}
+
+let state: FocusScopeState = {
+  activeScopeId: null,
+  knownScopes: new Map(),
+  lastFocusedItem: new Map(),
+};
+
+const listeners = new Set<() => void>();
+
+const setState = (patch: Partial<FocusScopeState>) => {
+  state = { ...state, ...patch };
+  listeners.forEach((listener) => listener());
+};
+
+export const subscribe = (listener: () => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+export const getActiveScopeId = () => state.activeScopeId;
+
+export const setActiveScope = (id: string | null) => {
+  if (id !== null && !state.knownScopes.has(id)) return;
+  if (state.activeScopeId === id) return;
+  setState({ activeScopeId: id });
+};
+
+export const getLastFocusedItem = (scopeId: string) => state.lastFocusedItem.get(scopeId) ?? null;
+
+export const setLastFocusedItem = (scopeId: string, itemId: string | null) => {
+  if ((state.lastFocusedItem.get(scopeId) ?? null) === itemId) return;
+  const next = new Map(state.lastFocusedItem);
+  if (itemId === null) next.delete(scopeId);
+  else next.set(scopeId, itemId);
+  setState({ lastFocusedItem: next });
+};
+
+const findScopeId = (event: Event) => {
+  const target = event.target instanceof Element ? event.target : null;
+  return target?.closest<HTMLElement>('[data-focus-scope]')?.dataset.focusScope ?? null;
+};
+
+const onGlobalInteract = (event: Event) => {
+  const id = findScopeId(event);
+  if (id !== null) setActiveScope(id);
+};
+
+let listening = false;
+
+const ensureDocumentListeners = () => {
+  if (listening || typeof document === 'undefined') return;
+  listening = true;
+  document.addEventListener('pointerdown', onGlobalInteract, true);
+  document.addEventListener('focusin', onGlobalInteract, true);
+};
+
+export const registerScope = (id: string) => {
+  ensureDocumentListeners();
+  const next = new Map(state.knownScopes);
+  next.set(id, (next.get(id) ?? 0) + 1);
+  setState({ knownScopes: next });
+
+  return () => {
+    const count = state.knownScopes.get(id) ?? 0;
+    const scopes = new Map(state.knownScopes);
+    if (count > 1) {
+      scopes.set(id, count - 1);
+      setState({ knownScopes: scopes });
+      return;
+    }
+    scopes.delete(id);
+    const lastFocused = new Map(state.lastFocusedItem);
+    lastFocused.delete(id);
+    setState({
+      activeScopeId: state.activeScopeId === id ? null : state.activeScopeId,
+      knownScopes: scopes,
+      lastFocusedItem: lastFocused,
+    });
+  };
+};
+
+export const useActiveScopeId = () => useSyncExternalStore(subscribe, getActiveScopeId, () => null);
+
+export const useFocusScopeActive = (id: string) =>
+  useSyncExternalStore(
+    subscribe,
+    () => state.activeScopeId === id,
+    () => false,
+  );

--- a/src/base-ui/FocusScope/style.ts
+++ b/src/base-ui/FocusScope/style.ts
@@ -1,0 +1,14 @@
+import { createStaticStyles } from 'antd-style';
+
+export const styles = createStaticStyles(({ css, cssVar }) => ({
+  debugOutline: css`
+    &[data-scope-active] {
+      outline: 2px dashed color-mix(in srgb, ${cssVar.colorInfo} 60%, transparent);
+      outline-offset: -2px;
+    }
+  `,
+  root: css`
+    position: relative;
+    outline: none;
+  `,
+}));

--- a/src/base-ui/FocusScope/useScopeArrowNav.ts
+++ b/src/base-ui/FocusScope/useScopeArrowNav.ts
@@ -1,0 +1,137 @@
+import { useEffect, useRef } from 'react';
+
+import { hasModifier, isItemVisible, isTextInputTarget, scopeSelector } from './domUtils';
+import { getActiveScopeId, setLastFocusedItem } from './store';
+
+export interface UseScopeArrowNavOptions {
+  enabled?: boolean;
+  extra?: Record<string, (event: KeyboardEvent) => void>;
+  itemSelector?: string;
+  onItemFocus?: (el: HTMLElement) => void;
+  scopeId: string;
+  vimKeys?: boolean;
+}
+
+// Sibling instances for one scope id (mobile + desktop mounts) all see the same
+// KeyboardEvent; the first one claims it so focus only moves once.
+let lastHandledEvent: KeyboardEvent | null = null;
+
+const focusListeners = new Map<string, Set<(el: HTMLElement) => void>>();
+
+const registerItemFocus = (scopeId: string, listener: (el: HTMLElement) => void) => {
+  const set = focusListeners.get(scopeId) ?? new Set();
+  set.add(listener);
+  focusListeners.set(scopeId, set);
+  return () => {
+    set.delete(listener);
+    if (set.size === 0) focusListeners.delete(scopeId);
+  };
+};
+
+export const notifyScopeItemFocus = (scopeId: string, el: HTMLElement) => {
+  const id = el.dataset.id;
+  if (id) setLastFocusedItem(scopeId, id);
+  focusListeners.get(scopeId)?.forEach((listener) => listener(el));
+};
+
+export const getScopeRoot = (scopeId: string): HTMLElement | null => {
+  const selector = scopeSelector(scopeId);
+  const active = document.activeElement;
+  if (active instanceof HTMLElement) {
+    const owned = active.closest<HTMLElement>(selector);
+    if (owned) return owned;
+  }
+  const candidates = [...document.querySelectorAll<HTMLElement>(selector)];
+  return candidates.find(isItemVisible) ?? candidates[0] ?? null;
+};
+
+export const focusScopeItem = (scopeId: string, el: HTMLElement) => {
+  el.focus({ preventScroll: true });
+  el.scrollIntoView?.({ block: 'nearest' });
+  notifyScopeItemFocus(scopeId, el);
+};
+
+export const useScopeArrowNav = ({
+  scopeId,
+  itemSelector = '[data-scope-item]',
+  enabled = true,
+  vimKeys = false,
+  onItemFocus,
+  extra,
+}: UseScopeArrowNavOptions) => {
+  const optionsRef = useRef({ extra, itemSelector, onItemFocus, scopeId });
+  optionsRef.current = { extra, itemSelector, onItemFocus, scopeId };
+
+  useEffect(() => {
+    if (!onItemFocus) return;
+    return registerItemFocus(scopeId, (el) => optionsRef.current.onItemFocus?.(el));
+  }, [scopeId, !!onItemFocus]);
+
+  useEffect(() => {
+    if (!enabled || typeof window === 'undefined') return;
+
+    const getItems = () => {
+      const root = getScopeRoot(optionsRef.current.scopeId);
+      if (!root) return [];
+      return [...root.querySelectorAll<HTMLElement>(optionsRef.current.itemSelector)].filter(
+        isItemVisible,
+      );
+    };
+
+    const currentIndex = (items: HTMLElement[]) => {
+      const active = document.activeElement;
+      if (!(active instanceof HTMLElement)) return -1;
+      const item = active.closest<HTMLElement>(optionsRef.current.itemSelector);
+      return item ? items.indexOf(item) : -1;
+    };
+
+    const move = (direction: 1 | -1) => {
+      const items = getItems();
+      if (items.length === 0) return;
+      const index = currentIndex(items);
+      const next =
+        index === -1
+          ? direction === 1
+            ? 0
+            : items.length - 1
+          : (index + direction + items.length) % items.length;
+      focusScopeItem(optionsRef.current.scopeId, items[next]);
+    };
+
+    const edge = (which: 'first' | 'last') => {
+      const items = getItems();
+      if (items.length === 0) return;
+      focusScopeItem(optionsRef.current.scopeId, items[which === 'first' ? 0 : items.length - 1]);
+    };
+
+    const isReachable = () => {
+      const id = optionsRef.current.scopeId;
+      if (getActiveScopeId() === id) return true;
+      const active = document.activeElement;
+      return active instanceof HTMLElement && !!active.closest(scopeSelector(id));
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || lastHandledEvent === event) return;
+      if (hasModifier(event) || isTextInputTarget(event.target) || !isReachable()) return;
+
+      const builtin: Record<string, () => void> = {
+        ArrowDown: () => move(1),
+        ArrowUp: () => move(-1),
+        End: () => edge('last'),
+        Home: () => edge('first'),
+        ...(vimKeys && { j: () => move(1), k: () => move(-1) }),
+      };
+      const extraHandler = optionsRef.current.extra?.[event.key];
+      const handler = builtin[event.key] ?? (extraHandler && (() => extraHandler(event)));
+      if (!handler) return;
+
+      lastHandledEvent = event;
+      event.preventDefault();
+      handler();
+    };
+
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => window.removeEventListener('keydown', onKeyDown, true);
+  }, [enabled, vimKeys]);
+};

--- a/src/base-ui/FocusScope/useScopeSwitcher.ts
+++ b/src/base-ui/FocusScope/useScopeSwitcher.ts
@@ -1,0 +1,67 @@
+import { useEffect } from 'react';
+
+import { hasModifier, hasSize, isItemVisible, isTextInputTarget } from './domUtils';
+import { getActiveScopeId, getLastFocusedItem, setActiveScope } from './store';
+import { focusScopeItem } from './useScopeArrowNav';
+
+export interface UseScopeSwitcherOptions {
+  enabled?: boolean;
+  vimKeys?: boolean;
+}
+
+const getOrderedScopes = () => {
+  const seen = new Set<string>();
+  const out: HTMLElement[] = [];
+  for (const el of document.querySelectorAll<HTMLElement>('[data-focus-scope]')) {
+    const id = el.dataset.focusScope;
+    if (!id || seen.has(id) || !isItemVisible(el) || !hasSize(el)) continue;
+    seen.add(id);
+    out.push(el);
+  }
+  return out;
+};
+
+const focusInto = (scope: HTMLElement) => {
+  const id = scope.dataset.focusScope!;
+  setActiveScope(id);
+  const lastId = getLastFocusedItem(id);
+  const last =
+    lastId &&
+    [...scope.querySelectorAll<HTMLElement>('[data-scope-item]')].find(
+      (el) => el.dataset.id === lastId && isItemVisible(el),
+    );
+  const target =
+    last ||
+    [...scope.querySelectorAll<HTMLElement>('[data-scope-item]')].find(isItemVisible) ||
+    scope;
+  focusScopeItem(id, target);
+};
+
+export const useScopeSwitcher = ({ enabled = true, vimKeys = false }: UseScopeSwitcherOptions = {}) => {
+  useEffect(() => {
+    if (!enabled || typeof window === 'undefined') return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || hasModifier(event) || isTextInputTarget(event.target)) return;
+      const direction =
+        event.key === 'ArrowRight' || (vimKeys && event.key === 'l')
+          ? 1
+          : event.key === 'ArrowLeft' || (vimKeys && event.key === 'h')
+            ? -1
+            : 0;
+      if (!direction) return;
+
+      const scopes = getOrderedScopes();
+      if (scopes.length === 0) return;
+      const activeId = getActiveScopeId();
+      const index = scopes.findIndex((el) => el.dataset.focusScope === activeId);
+      const next = index === -1 ? (direction === 1 ? scopes[0] : scopes.at(-1)!) : scopes[index + direction];
+      if (!next) return;
+      event.preventDefault();
+      focusInto(next);
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [enabled, vimKeys]);
+};

--- a/src/base-ui/Tree/Tree.tsx
+++ b/src/base-ui/Tree/Tree.tsx
@@ -1,0 +1,227 @@
+'use client';
+
+import { cx } from 'antd-style';
+import { type KeyboardEvent, memo, useCallback, useMemo, useRef, useState } from 'react';
+import useControlledState from 'use-merge-value';
+
+import { TreeContext, type TreeContextValue } from './context';
+import { styles } from './style';
+import TreeNode from './TreeNode';
+import type { TreeDataNode, TreeProps } from './type';
+import { conductCheck, flattenVisible, getAllKeys, getAncestorKeys, getSubtreeKeys } from './utils';
+
+const EMPTY: string[] = [];
+
+const Tree = memo<TreeProps>(
+  ({
+    blockNode = false,
+    checkStrictly = false,
+    checkable = false,
+    checkedKeys: checkedKeysProp,
+    className,
+    classNames = {},
+    defaultCheckedKeys = EMPTY,
+    defaultExpandAll = false,
+    defaultExpandedKeys = EMPTY,
+    defaultSelectedKeys = EMPTY,
+    disabled = false,
+    expandedKeys: expandedKeysProp,
+    indent = 20,
+    multiple = false,
+    onCheck,
+    onExpand,
+    onRightClick,
+    onSelect,
+    selectedKeys: selectedKeysProp,
+    showIcon = false,
+    showLine = false,
+    size = 'middle',
+    style,
+    styles: customStyles = {},
+    switcherIcon,
+    titleRender,
+    treeData,
+  }) => {
+    const [expandedKeys, setExpandedKeys] = useControlledState<string[]>(
+      defaultExpandAll ? getAllKeys(treeData) : defaultExpandedKeys,
+      { value: expandedKeysProp },
+    );
+    const [selectedKeys, setSelectedKeys] = useControlledState<string[]>(defaultSelectedKeys, {
+      value: selectedKeysProp,
+    });
+    const [checkedKeys, setCheckedKeys] = useControlledState<string[]>(defaultCheckedKeys, {
+      value: checkedKeysProp,
+    });
+
+    const expanded = useMemo(() => new Set(expandedKeys), [expandedKeys]);
+    const selected = useMemo(() => new Set(selectedKeys), [selectedKeys]);
+    const flat = useMemo(() => flattenVisible(treeData, expanded), [treeData, expanded]);
+    const { checked, halfChecked } = useMemo(
+      () =>
+        checkStrictly
+          ? { checked: new Set(checkedKeys), halfChecked: new Set<string>() }
+          : conductCheck(treeData, checkedKeys),
+      [checkStrictly, treeData, checkedKeys],
+    );
+
+    const [activeKeyState, setActiveKeyState] = useState<string | null>(null);
+    const setActiveKey = setActiveKeyState;
+    const activeKey =
+      activeKeyState && flat.some((row) => row.node.key === activeKeyState)
+        ? activeKeyState
+        : (selectedKeys.find((key) => flat.some((row) => row.node.key === key)) ??
+          flat[0]?.node.key ??
+          null);
+
+    const rowsRef = useRef(new Map<string, HTMLDivElement>());
+    const anchorRef = useRef<string | null>(null);
+
+    const registerRow = useCallback((key: string, el: HTMLDivElement | null) => {
+      if (el) rowsRef.current.set(key, el);
+      else rowsRef.current.delete(key);
+    }, []);
+
+    const focusRow = (key: string) => {
+      setActiveKey(key);
+      rowsRef.current.get(key)?.focus();
+    };
+
+    const isDisabled = (node: TreeDataNode) => disabled || !!node.disabled;
+
+    const toggleExpand = (node: TreeDataNode) => {
+      const willExpand = !expanded.has(node.key);
+      const next = willExpand
+        ? [...expandedKeys, node.key]
+        : expandedKeys.filter((key) => key !== node.key);
+      setExpandedKeys(next);
+      onExpand?.(next, { expanded: willExpand, node });
+    };
+
+    const toggleSelect: TreeContextValue['toggleSelect'] = (node, event) => {
+      if (isDisabled(node) || node.selectable === false) return;
+      let next: string[];
+      if (multiple && event?.shiftKey && anchorRef.current) {
+        const a = flat.findIndex((row) => row.node.key === anchorRef.current);
+        const b = flat.findIndex((row) => row.node.key === node.key);
+        next = flat
+          .slice(Math.min(a, b), Math.max(a, b) + 1)
+          .filter((row) => !isDisabled(row.node) && row.node.selectable !== false)
+          .map((row) => row.node.key);
+      } else if (multiple && (event?.metaKey || event?.ctrlKey)) {
+        next = selected.has(node.key)
+          ? selectedKeys.filter((key) => key !== node.key)
+          : [...selectedKeys, node.key];
+        anchorRef.current = node.key;
+      } else {
+        next = [node.key];
+        anchorRef.current = node.key;
+      }
+      setSelectedKeys(next);
+      setActiveKey(node.key);
+      onSelect?.(next, { node, selected: next.includes(node.key) });
+    };
+
+    const toggleCheck = (node: TreeDataNode) => {
+      if (isDisabled(node) || node.checkable === false) return;
+      const willCheck = !checked.has(node.key);
+      const keys = checkStrictly ? [node.key] : getSubtreeKeys(node);
+      const base = new Set(checkStrictly ? checkedKeys : checked);
+      keys.forEach((key) => (willCheck ? base.add(key) : base.delete(key)));
+      if (!willCheck && !checkStrictly) getAncestorKeys(treeData, node.key).forEach((key) => base.delete(key));
+      const next = checkStrictly ? [...base] : [...conductCheck(treeData, base).checked];
+      setCheckedKeys(next);
+      setActiveKey(node.key);
+      onCheck?.(next, { checked: willCheck, node });
+    };
+
+    const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+      const index = flat.findIndex((row) => row.node.key === activeKey);
+      if (index < 0) return;
+      const row = flat[index];
+      const isOpen = row.hasChildren && expanded.has(row.node.key);
+      const handlers: Record<string, () => void> = {
+        ' ': () => {
+          if (checkable && row.node.checkable !== false) toggleCheck(row.node);
+          else toggleSelect(row.node, event);
+        },
+        '*': () => {
+          const siblings = flat.filter(
+            (r) => r.parentKey === row.parentKey && r.hasChildren && !expanded.has(r.node.key),
+          );
+          if (siblings.length === 0) return;
+          const next = [...expandedKeys, ...siblings.map((r) => r.node.key)];
+          setExpandedKeys(next);
+          onExpand?.(next, { expanded: true, node: row.node });
+        },
+        ArrowDown: () => flat[index + 1] && focusRow(flat[index + 1].node.key),
+        ArrowLeft: () => {
+          if (isOpen) toggleExpand(row.node);
+          else if (row.parentKey) focusRow(row.parentKey);
+        },
+        ArrowRight: () => {
+          if (!row.hasChildren) return;
+          if (isOpen) focusRow(flat[index + 1].node.key);
+          else toggleExpand(row.node);
+        },
+        ArrowUp: () => flat[index - 1] && focusRow(flat[index - 1].node.key),
+        End: () => focusRow(flat.at(-1)!.node.key),
+        Enter: () => toggleSelect(row.node, event),
+        Home: () => focusRow(flat[0].node.key),
+      };
+      const handler = handlers[event.key];
+      if (!handler) return;
+      event.preventDefault();
+      handler();
+    };
+
+    const ctx: TreeContextValue = {
+      activeKey,
+      blockNode,
+      checkable,
+      checked,
+      classNames,
+      disabled,
+      expanded,
+      halfChecked,
+      indent,
+      onRightClick: (event, node) => onRightClick?.({ event, node }),
+      registerRow,
+      selected,
+      setActiveKey,
+      showIcon,
+      showLine,
+      size,
+      styles: customStyles,
+      switcherIcon,
+      titleRender,
+      toggleCheck,
+      toggleExpand,
+      toggleSelect,
+    };
+
+    return (
+      <TreeContext value={ctx}>
+        <div
+          className={cx(styles.root, classNames.root, className)}
+          role="tree"
+          style={{ ...customStyles.root, ...style }}
+          onKeyDown={onKeyDown}
+        >
+          {treeData.map((node, i) => (
+            <TreeNode
+              depth={0}
+              isLast={i === treeData.length - 1}
+              key={node.key}
+              node={node}
+              trail={[]}
+            />
+          ))}
+        </div>
+      </TreeContext>
+    );
+  },
+);
+
+Tree.displayName = 'Tree';
+
+export default Tree;

--- a/src/base-ui/Tree/Tree.tsx
+++ b/src/base-ui/Tree/Tree.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { cx } from 'antd-style';
-import { type KeyboardEvent, memo, useCallback, useMemo, useRef, useState } from 'react';
+import { memo, useId, useMemo, useRef, useState } from 'react';
 import useControlledState from 'use-merge-value';
+
+import { FocusScope, focusScopeItem, useScopeArrowNav } from '@/base-ui/FocusScope';
 
 import { TreeContext, type TreeContextValue } from './context';
 import { styles } from './style';
@@ -32,6 +34,7 @@ const Tree = memo<TreeProps>(
     onExpand,
     onRightClick,
     onSelect,
+    scopeId: scopeIdProp,
     selectedKeys: selectedKeysProp,
     showIcon = false,
     showLine = false,
@@ -41,7 +44,10 @@ const Tree = memo<TreeProps>(
     switcherIcon,
     titleRender,
     treeData,
+    vimKeys = false,
   }) => {
+    const generatedId = useId();
+    const scopeId = scopeIdProp ?? generatedId;
     const [expandedKeys, setExpandedKeys] = useControlledState<string[]>(
       defaultExpandAll ? getAllKeys(treeData) : defaultExpandedKeys,
       { value: expandedKeysProp },
@@ -73,17 +79,14 @@ const Tree = memo<TreeProps>(
           flat[0]?.node.key ??
           null);
 
-    const rowsRef = useRef(new Map<string, HTMLDivElement>());
     const anchorRef = useRef<string | null>(null);
 
-    const registerRow = useCallback((key: string, el: HTMLDivElement | null) => {
-      if (el) rowsRef.current.set(key, el);
-      else rowsRef.current.delete(key);
-    }, []);
-
+    const rowOf = (key: string) =>
+      document.querySelector<HTMLElement>(`[data-focus-scope="${scopeId}"] [data-id="${key}"]`);
     const focusRow = (key: string) => {
       setActiveKey(key);
-      rowsRef.current.get(key)?.focus();
+      const row = rowOf(key);
+      if (row) focusScopeItem(scopeId, row);
     };
 
     const isDisabled = (node: TreeDataNode) => disabled || !!node.disabled;
@@ -134,17 +137,25 @@ const Tree = memo<TreeProps>(
       onCheck?.(next, { checked: willCheck, node });
     };
 
-    const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-      const index = flat.findIndex((row) => row.node.key === activeKey);
-      if (index < 0) return;
-      const row = flat[index];
-      const isOpen = row.hasChildren && expanded.has(row.node.key);
-      const handlers: Record<string, () => void> = {
-        ' ': () => {
+    const currentRow = () => {
+      const focused = document.activeElement?.closest<HTMLElement>('[role="treeitem"]');
+      const key = focused?.dataset.id ?? activeKey;
+      return flat.find((row) => row.node.key === key);
+    };
+
+    const withRow = (fn: (row: (typeof flat)[number], event: KeyboardEvent) => void) =>
+      (event: KeyboardEvent) => {
+        const row = currentRow();
+        if (row) fn(row, event);
+      };
+
+    useScopeArrowNav({
+      extra: {
+        ' ': withRow((row, event) => {
           if (checkable && row.node.checkable !== false) toggleCheck(row.node);
           else toggleSelect(row.node, event);
-        },
-        '*': () => {
+        }),
+        '*': withRow((row) => {
           const siblings = flat.filter(
             (r) => r.parentKey === row.parentKey && r.hasChildren && !expanded.has(r.node.key),
           );
@@ -152,27 +163,23 @@ const Tree = memo<TreeProps>(
           const next = [...expandedKeys, ...siblings.map((r) => r.node.key)];
           setExpandedKeys(next);
           onExpand?.(next, { expanded: true, node: row.node });
-        },
-        ArrowDown: () => flat[index + 1] && focusRow(flat[index + 1].node.key),
-        ArrowLeft: () => {
-          if (isOpen) toggleExpand(row.node);
+        }),
+        ArrowLeft: withRow((row) => {
+          if (row.hasChildren && expanded.has(row.node.key)) toggleExpand(row.node);
           else if (row.parentKey) focusRow(row.parentKey);
-        },
-        ArrowRight: () => {
+        }),
+        ArrowRight: withRow((row) => {
           if (!row.hasChildren) return;
-          if (isOpen) focusRow(flat[index + 1].node.key);
+          if (expanded.has(row.node.key)) focusRow(flat[row.index + 1].node.key);
           else toggleExpand(row.node);
-        },
-        ArrowUp: () => flat[index - 1] && focusRow(flat[index - 1].node.key),
-        End: () => focusRow(flat.at(-1)!.node.key),
-        Enter: () => toggleSelect(row.node, event),
-        Home: () => focusRow(flat[0].node.key),
-      };
-      const handler = handlers[event.key];
-      if (!handler) return;
-      event.preventDefault();
-      handler();
-    };
+        }),
+        Enter: withRow((row, event) => toggleSelect(row.node, event)),
+      },
+      itemSelector: '[role="treeitem"]',
+      onItemFocus: (el) => el.dataset.id && setActiveKey(el.dataset.id),
+      scopeId,
+      vimKeys,
+    });
 
     const ctx: TreeContextValue = {
       activeKey,
@@ -185,7 +192,6 @@ const Tree = memo<TreeProps>(
       halfChecked,
       indent,
       onRightClick: (event, node) => onRightClick?.({ event, node }),
-      registerRow,
       selected,
       setActiveKey,
       showIcon,
@@ -201,11 +207,11 @@ const Tree = memo<TreeProps>(
 
     return (
       <TreeContext value={ctx}>
-        <div
+        <FocusScope
           className={cx(styles.root, classNames.root, className)}
+          id={scopeId}
           role="tree"
           style={{ ...customStyles.root, ...style }}
-          onKeyDown={onKeyDown}
         >
           {treeData.map((node, i) => (
             <TreeNode
@@ -216,7 +222,7 @@ const Tree = memo<TreeProps>(
               trail={[]}
             />
           ))}
-        </div>
+        </FocusScope>
       </TreeContext>
     );
   },

--- a/src/base-ui/Tree/TreeNode.tsx
+++ b/src/base-ui/Tree/TreeNode.tsx
@@ -66,12 +66,13 @@ const TreeNode = memo<TreeNodeProps>(({ node, depth, isLast, trail }) => {
   return (
     <>
       <div
+        data-scope-item
         aria-checked={checkable ? (checkState === 'mixed' ? 'mixed' : checkState === 'checked') : undefined}
         aria-disabled={disabled || undefined}
         aria-expanded={expandable ? expanded : undefined}
         aria-level={depth + 1}
         aria-selected={ctx.selected.has(node.key)}
-        ref={(el) => ctx.registerRow(node.key, el)}
+        data-id={node.key}
         role="treeitem"
         style={rowStyle}
         tabIndex={ctx.activeKey === node.key ? 0 : -1}

--- a/src/base-ui/Tree/TreeNode.tsx
+++ b/src/base-ui/Tree/TreeNode.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { Collapsible } from '@base-ui/react/collapsible';
+import { cx } from 'antd-style';
+import { ChevronRight, File, Folder } from 'lucide-react';
+import { type CSSProperties, memo, type MouseEvent } from 'react';
+
+import { Checkbox } from '@/base-ui/Checkbox';
+import { controlHeight } from '@/base-ui/controlSize';
+import Icon from '@/Icon';
+
+import { useTreeContext } from './context';
+import { styles } from './style';
+import type { TreeDataNode } from './type';
+import { hasChildren as isExpandable } from './utils';
+
+interface TreeNodeProps {
+  depth: number;
+  isLast: boolean;
+  node: TreeDataNode;
+  trail: boolean[];
+}
+
+const ARC = 6;
+const SWITCHER_CENTER = 11.5;
+
+const guidePath = (depth: number, isLast: boolean, trail: boolean[], indent: number, height: number) => {
+  const cx = (i: number) => i * indent + SWITCHER_CENTER;
+  let d = '';
+  trail.forEach((more, i) => {
+    if (more) d += `M${cx(i)} 0V${height}`;
+  });
+  const x = cx(depth - 1);
+  const y = height / 2;
+  const elbow = `M${x} ${y - ARC}A${ARC} ${ARC} 0 0 0 ${x + ARC} ${y}H${x + indent - 2}`;
+  d += isLast ? `M${x} 0V${y - ARC}${elbow.slice(elbow.indexOf('A'))}` : `M${x} 0V${height}${elbow}`;
+  return d;
+};
+
+const TreeNode = memo<TreeNodeProps>(({ node, depth, isLast, trail }) => {
+  const ctx = useTreeContext();
+  const expandable = isExpandable(node);
+  const expanded = expandable && ctx.expanded.has(node.key);
+  const disabled = ctx.disabled || !!node.disabled;
+  const checkable = ctx.checkable && node.checkable !== false;
+  const checkState = ctx.checked.has(node.key)
+    ? 'checked'
+    : ctx.halfChecked.has(node.key)
+      ? 'mixed'
+      : 'unchecked';
+  const rowHeight = controlHeight[ctx.size];
+
+  const switcherIcon =
+    typeof ctx.switcherIcon === 'function'
+      ? ctx.switcherIcon({ expanded, node })
+      : (ctx.switcherIcon ?? <Icon icon={ChevronRight} size={14} />);
+
+  const rowStyle: CSSProperties = {
+    height: rowHeight,
+    paddingInlineStart: depth * ctx.indent,
+    ...ctx.styles.node,
+  };
+
+  const select = (event: MouseEvent) => ctx.toggleSelect(node, event);
+
+  return (
+    <>
+      <div
+        aria-checked={checkable ? (checkState === 'mixed' ? 'mixed' : checkState === 'checked') : undefined}
+        aria-disabled={disabled || undefined}
+        aria-expanded={expandable ? expanded : undefined}
+        aria-level={depth + 1}
+        aria-selected={ctx.selected.has(node.key)}
+        ref={(el) => ctx.registerRow(node.key, el)}
+        role="treeitem"
+        style={rowStyle}
+        tabIndex={ctx.activeKey === node.key ? 0 : -1}
+        className={cx(
+          styles.node,
+          ctx.blockNode && styles.nodeBlock,
+          disabled && styles.nodeDisabled,
+          ctx.classNames.node,
+        )}
+        onClick={ctx.blockNode ? select : undefined}
+        onContextMenu={(event) => ctx.onRightClick(event, node)}
+        onFocus={() => ctx.setActiveKey(node.key)}
+      >
+        {ctx.showLine && depth > 0 && (
+          <svg
+            aria-hidden
+            className={cx(styles.guide, ctx.classNames.guide)}
+            height={rowHeight}
+            style={ctx.styles.guide}
+            width={depth * ctx.indent}
+          >
+            <path d={guidePath(depth, isLast, trail, ctx.indent, rowHeight)} />
+          </svg>
+        )}
+        <button
+          aria-hidden
+          className={cx(styles.switcher, !expandable && styles.switcherLeaf, ctx.classNames.switcher)}
+          style={ctx.styles.switcher}
+          tabIndex={-1}
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            ctx.toggleExpand(node);
+          }}
+        >
+          {switcherIcon}
+        </button>
+        {checkable && (
+          <Checkbox
+            checked={checkState === 'checked'}
+            className={styles.checkbox}
+            disabled={disabled}
+            indeterminate={checkState === 'mixed'}
+            onChange={() => ctx.toggleCheck(node)}
+            onClick={(event) => event.stopPropagation()}
+          />
+        )}
+        {ctx.showIcon && (
+          <span className={styles.icon}>
+            {node.icon ?? <Icon icon={expandable ? Folder : File} size={16} />}
+          </span>
+        )}
+        <span
+          style={ctx.styles.title}
+          className={cx(
+            styles.title,
+            ctx.blockNode ? styles.titleBlock : styles.titleInline,
+            ctx.classNames.title,
+          )}
+          onClick={ctx.blockNode ? undefined : select}
+        >
+          {ctx.titleRender ? ctx.titleRender(node) : node.title}
+        </span>
+      </div>
+      {expandable && (
+        <Collapsible.Root open={expanded}>
+          <Collapsible.Panel className={styles.panel}>
+            {node.children!.map((child, i) => (
+              <TreeNode
+                depth={depth + 1}
+                isLast={i === node.children!.length - 1}
+                key={child.key}
+                node={child}
+                trail={[...trail, !isLast]}
+              />
+            ))}
+          </Collapsible.Panel>
+        </Collapsible.Root>
+      )}
+    </>
+  );
+});
+
+TreeNode.displayName = 'TreeNode';
+
+export default TreeNode;

--- a/src/base-ui/Tree/__tests__/Tree.test.tsx
+++ b/src/base-ui/Tree/__tests__/Tree.test.tsx
@@ -1,0 +1,124 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import Tree from '../Tree';
+import type { TreeDataNode } from '../type';
+
+const data: TreeDataNode[] = [
+  {
+    children: [
+      { key: 'a-1', title: 'a-1' },
+      { key: 'a-2', title: 'a-2' },
+    ],
+    key: 'a',
+    title: 'a',
+  },
+  { children: [{ key: 'b-1', title: 'b-1' }], key: 'b', title: 'b' },
+  { key: 'c', title: 'c' },
+];
+
+const item = (name: string) => screen.getByRole('treeitem', { name });
+
+describe('Tree', () => {
+  test('renders only expanded subtrees and toggles via switcher', () => {
+    const onExpand = vi.fn();
+    render(<Tree defaultExpandedKeys={['a']} treeData={data} onExpand={onExpand} />);
+
+    expect(screen.getByText('a-1')).toBeTruthy();
+    expect(screen.queryByText('b-1')).toBeNull();
+    expect(item('a').getAttribute('aria-expanded')).toBe('true');
+
+    fireEvent.click(item('b').querySelector('button')!);
+    expect(onExpand).toHaveBeenCalledWith(['a', 'b'], expect.objectContaining({ expanded: true }));
+    expect(screen.getByText('b-1')).toBeTruthy();
+  });
+
+  test('controlled expandedKeys does not toggle on its own', () => {
+    const onExpand = vi.fn();
+    render(<Tree expandedKeys={[]} treeData={data} onExpand={onExpand} />);
+    fireEvent.click(item('a').querySelector('button')!);
+    expect(onExpand).toHaveBeenCalledWith(['a'], expect.anything());
+    expect(screen.queryByText('a-1')).toBeNull();
+  });
+
+  test('selects a single node on title click', () => {
+    const onSelect = vi.fn();
+    render(<Tree treeData={data} onSelect={onSelect} />);
+    fireEvent.click(screen.getByText('c'));
+    expect(onSelect).toHaveBeenCalledWith(['c'], expect.objectContaining({ selected: true }));
+    expect(item('c').getAttribute('aria-selected')).toBe('true');
+    fireEvent.click(screen.getByText('a'));
+    expect(item('c').getAttribute('aria-selected')).toBe('false');
+    expect(item('a').getAttribute('aria-selected')).toBe('true');
+  });
+
+  test('multiple: shift click selects a visible range', () => {
+    const onSelect = vi.fn();
+    render(<Tree multiple defaultExpandedKeys={['a']} treeData={data} onSelect={onSelect} />);
+    fireEvent.click(screen.getByText('a-1'));
+    fireEvent.click(screen.getByText('b'), { shiftKey: true });
+    expect(onSelect).toHaveBeenLastCalledWith(['a-1', 'a-2', 'b'], expect.anything());
+  });
+
+  test('checkable: checking a parent links descendants and reports checked keys', () => {
+    const onCheck = vi.fn();
+    render(<Tree checkable defaultExpandedKeys={['a']} treeData={data} onCheck={onCheck} />);
+    fireEvent.click(item('a').querySelector('[role="checkbox"]')!);
+    expect(onCheck).toHaveBeenCalledWith(
+      expect.arrayContaining(['a', 'a-1', 'a-2']),
+      expect.objectContaining({ checked: true }),
+    );
+    expect(item('a-1').getAttribute('aria-checked')).toBe('true');
+
+    fireEvent.click(item('a-1').querySelector('[role="checkbox"]')!);
+    expect(item('a').getAttribute('aria-checked')).toBe('mixed');
+  });
+
+  test('keyboard: arrows move focus, right expands, left collapses', () => {
+    render(<Tree treeData={data} />);
+    const a = item('a');
+    act(() => a.focus());
+    fireEvent.keyDown(a, { key: 'ArrowRight' });
+    expect(a.getAttribute('aria-expanded')).toBe('true');
+    fireEvent.keyDown(a, { key: 'ArrowRight' });
+    expect(document.activeElement).toBe(item('a-1'));
+    fireEvent.keyDown(item('a-1'), { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(item('a-2'));
+    fireEvent.keyDown(item('a-2'), { key: 'ArrowLeft' });
+    expect(document.activeElement).toBe(item('a'));
+    fireEvent.keyDown(item('a'), { key: 'ArrowLeft' });
+    expect(item('a').getAttribute('aria-expanded')).toBe('false');
+    fireEvent.keyDown(item('a'), { key: 'End' });
+    expect(document.activeElement).toBe(item('c'));
+  });
+
+  test('keyboard: Enter selects, Space checks', () => {
+    const onSelect = vi.fn();
+    const onCheck = vi.fn();
+    render(<Tree checkable treeData={data} onCheck={onCheck} onSelect={onSelect} />);
+    const c = item('c');
+    act(() => c.focus());
+    fireEvent.keyDown(c, { key: 'Enter' });
+    expect(onSelect).toHaveBeenCalledWith(['c'], expect.anything());
+    fireEvent.keyDown(c, { key: ' ' });
+    expect(onCheck).toHaveBeenCalledWith(['c'], expect.objectContaining({ checked: true }));
+  });
+
+  test('disabled node ignores select but still expands', () => {
+    const onSelect = vi.fn();
+    const disabledData: TreeDataNode[] = [{ ...data[0], disabled: true }];
+    render(<Tree treeData={disabledData} onSelect={onSelect} />);
+    fireEvent.click(screen.getByText('a'));
+    expect(onSelect).not.toHaveBeenCalled();
+    fireEvent.click(item('a').querySelector('button')!);
+    expect(screen.getByText('a-1')).toBeTruthy();
+  });
+
+  test('onRightClick receives the node', () => {
+    const onRightClick = vi.fn();
+    render(<Tree treeData={data} onRightClick={onRightClick} />);
+    fireEvent.contextMenu(item('c'));
+    expect(onRightClick).toHaveBeenCalledWith(
+      expect.objectContaining({ node: expect.objectContaining({ key: 'c' }) }),
+    );
+  });
+});

--- a/src/base-ui/Tree/__tests__/Tree.test.tsx
+++ b/src/base-ui/Tree/__tests__/Tree.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 
+import { FocusScope, setActiveScope, useScopeSwitcher } from '../../FocusScope';
 import Tree from '../Tree';
 import type { TreeDataNode } from '../type';
 
@@ -17,6 +18,21 @@ const data: TreeDataNode[] = [
 ];
 
 const item = (name: string) => screen.getByRole('treeitem', { name });
+const key = (k: string) => fireEvent.keyDown(window, { key: k });
+
+vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+  bottom: 10,
+  height: 10,
+  left: 0,
+  right: 10,
+  toJSON: () => ({}),
+  top: 0,
+  width: 10,
+  x: 0,
+  y: 0,
+});
+
+afterEach(() => act(() => setActiveScope(null)));
 
 describe('Tree', () => {
   test('renders only expanded subtrees and toggles via switcher', () => {
@@ -73,21 +89,22 @@ describe('Tree', () => {
     expect(item('a').getAttribute('aria-checked')).toBe('mixed');
   });
 
-  test('keyboard: arrows move focus, right expands, left collapses', () => {
+  test('keyboard works after pointing into the tree, without focusing it', () => {
     render(<Tree treeData={data} />);
-    const a = item('a');
-    act(() => a.focus());
-    fireEvent.keyDown(a, { key: 'ArrowRight' });
-    expect(a.getAttribute('aria-expanded')).toBe('true');
-    fireEvent.keyDown(a, { key: 'ArrowRight' });
-    expect(document.activeElement).toBe(item('a-1'));
-    fireEvent.keyDown(item('a-1'), { key: 'ArrowDown' });
-    expect(document.activeElement).toBe(item('a-2'));
-    fireEvent.keyDown(item('a-2'), { key: 'ArrowLeft' });
+    fireEvent.pointerDown(item('a'));
+    key('ArrowDown');
     expect(document.activeElement).toBe(item('a'));
-    fireEvent.keyDown(item('a'), { key: 'ArrowLeft' });
+    key('ArrowRight');
+    expect(item('a').getAttribute('aria-expanded')).toBe('true');
+    key('ArrowRight');
+    expect(document.activeElement).toBe(item('a-1'));
+    key('ArrowDown');
+    expect(document.activeElement).toBe(item('a-2'));
+    key('ArrowLeft');
+    expect(document.activeElement).toBe(item('a'));
+    key('ArrowLeft');
     expect(item('a').getAttribute('aria-expanded')).toBe('false');
-    fireEvent.keyDown(item('a'), { key: 'End' });
+    key('End');
     expect(document.activeElement).toBe(item('c'));
   });
 
@@ -95,12 +112,34 @@ describe('Tree', () => {
     const onSelect = vi.fn();
     const onCheck = vi.fn();
     render(<Tree checkable treeData={data} onCheck={onCheck} onSelect={onSelect} />);
-    const c = item('c');
-    act(() => c.focus());
-    fireEvent.keyDown(c, { key: 'Enter' });
+    fireEvent.pointerDown(item('c'));
+    act(() => item('c').focus());
+    key('Enter');
     expect(onSelect).toHaveBeenCalledWith(['c'], expect.anything());
-    fireEvent.keyDown(c, { key: ' ' });
+    key(' ');
     expect(onCheck).toHaveBeenCalledWith(['c'], expect.objectContaining({ checked: true }));
+  });
+
+  test('arrow left/right inside the tree never switch to a sibling scope', () => {
+    const Shell = () => {
+      useScopeSwitcher();
+      return (
+        <>
+          <Tree scopeId="tree" treeData={data} />
+          <FocusScope id="other">
+            <div data-scope-item tabIndex={-1}>
+              other
+            </div>
+          </FocusScope>
+        </>
+      );
+    };
+    render(<Shell />);
+    fireEvent.pointerDown(item('c'));
+    act(() => item('c').focus());
+    key('ArrowRight');
+    key('ArrowLeft');
+    expect(document.activeElement).toBe(item('c'));
   });
 
   test('disabled node ignores select but still expands', () => {

--- a/src/base-ui/Tree/__tests__/utils.test.ts
+++ b/src/base-ui/Tree/__tests__/utils.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TreeDataNode } from '../type';
+import { conductCheck, flattenVisible, getAllKeys, getAncestorKeys } from '../utils';
+
+const data: TreeDataNode[] = [
+  {
+    children: [
+      { children: [{ key: 'a-1-x', title: 'a-1-x' }], key: 'a-1', title: 'a-1' },
+      { key: 'a-2', title: 'a-2' },
+      { checkable: false, key: 'a-3', title: 'a-3' },
+    ],
+    key: 'a',
+    title: 'a',
+  },
+  { children: [{ key: 'b-1', title: 'b-1' }], key: 'b', title: 'b' },
+  { children: [], isLeaf: true, key: 'c', title: 'c' },
+];
+
+describe('flattenVisible', () => {
+  it('only walks into expanded nodes', () => {
+    expect(flattenVisible(data, new Set(['a'])).map((r) => r.node.key)).toEqual([
+      'a',
+      'a-1',
+      'a-2',
+      'a-3',
+      'b',
+      'c',
+    ]);
+  });
+
+  it('records depth, parentKey, hasChildren and isLast', () => {
+    const rows = flattenVisible(data, new Set(['a', 'a-1']));
+    const byKey = Object.fromEntries(rows.map((r) => [r.node.key, r]));
+    expect(byKey['a-1-x']).toMatchObject({ depth: 2, hasChildren: false, isLast: true, parentKey: 'a-1' });
+    expect(byKey['a-1']).toMatchObject({ depth: 1, hasChildren: true, isLast: false, parentKey: 'a' });
+    expect(byKey['a-3'].isLast).toBe(true);
+    expect(byKey['c']).toMatchObject({ depth: 0, hasChildren: false, isLast: true, parentKey: null });
+  });
+
+  it('trail marks ancestors that still have following siblings', () => {
+    const rows = flattenVisible(data, new Set(['a', 'a-1', 'b']));
+    const byKey = Object.fromEntries(rows.map((r) => [r.node.key, r]));
+    expect(byKey['a-1-x'].trail).toEqual([true, true]);
+    expect(byKey['b-1'].trail).toEqual([true]);
+  });
+});
+
+describe('getAllKeys', () => {
+  it('returns every key in document order', () => {
+    expect(getAllKeys(data)).toEqual(['a', 'a-1', 'a-1-x', 'a-2', 'a-3', 'b', 'b-1', 'c']);
+  });
+});
+
+describe('conductCheck', () => {
+  it('checks every descendant when a parent is checked', () => {
+    const { checked, halfChecked } = conductCheck(data, ['b']);
+    expect([...checked].sort()).toEqual(['b', 'b-1']);
+    expect(halfChecked.size).toBe(0);
+  });
+
+  it('marks parent half-checked when only some children are checked', () => {
+    const { checked, halfChecked } = conductCheck(data, ['a-2']);
+    expect([...checked]).toEqual(['a-2']);
+    expect([...halfChecked]).toEqual(['a']);
+  });
+
+  it('checks the parent when all checkable children are checked', () => {
+    const { checked, halfChecked } = conductCheck(data, ['a-1-x', 'a-2']);
+    expect([...checked].sort()).toEqual(['a', 'a-1', 'a-1-x', 'a-2']);
+    expect(halfChecked.size).toBe(0);
+  });
+
+  it('propagates half-checked through grandparents', () => {
+    const { halfChecked } = conductCheck(data, ['a-1-x']);
+    expect([...halfChecked].sort()).toEqual(['a']);
+  });
+
+  it('ignores disabled and checkable:false nodes', () => {
+    const withDisabled: TreeDataNode[] = [
+      { children: [{ key: 'p-1', title: 'p-1' }, { disabled: true, key: 'p-2', title: 'p-2' }], key: 'p', title: 'p' },
+    ];
+    const { checked } = conductCheck(withDisabled, ['p']);
+    expect([...checked].sort()).toEqual(['p', 'p-1']);
+  });
+});
+
+describe('getAncestorKeys', () => {
+  it('returns ancestors nearest first', () => {
+    expect(getAncestorKeys(data, 'a-1-x')).toEqual(['a-1', 'a']);
+    expect(getAncestorKeys(data, 'c')).toEqual([]);
+  });
+});

--- a/src/base-ui/Tree/context.ts
+++ b/src/base-ui/Tree/context.ts
@@ -14,7 +14,6 @@ export interface TreeContextValue {
   halfChecked: Set<string>;
   indent: number;
   onRightClick: (event: MouseEvent<HTMLDivElement>, node: TreeDataNode) => void;
-  registerRow: (key: string, el: HTMLDivElement | null) => void;
   selected: Set<string>;
   setActiveKey: (key: string) => void;
   showIcon: boolean;

--- a/src/base-ui/Tree/context.ts
+++ b/src/base-ui/Tree/context.ts
@@ -1,0 +1,37 @@
+import { createContext, type MouseEvent, type ReactNode, use } from 'react';
+
+import type { ControlSize } from '../controlSize';
+import type { TreeClassNames, TreeDataNode, TreeProps, TreeStyles } from './type';
+
+export interface TreeContextValue {
+  activeKey: string | null;
+  blockNode: boolean;
+  checkable: boolean;
+  checked: Set<string>;
+  classNames: TreeClassNames;
+  disabled: boolean;
+  expanded: Set<string>;
+  halfChecked: Set<string>;
+  indent: number;
+  onRightClick: (event: MouseEvent<HTMLDivElement>, node: TreeDataNode) => void;
+  registerRow: (key: string, el: HTMLDivElement | null) => void;
+  selected: Set<string>;
+  setActiveKey: (key: string) => void;
+  showIcon: boolean;
+  showLine: boolean;
+  size: ControlSize;
+  styles: TreeStyles;
+  switcherIcon?: TreeProps['switcherIcon'];
+  titleRender?: (node: TreeDataNode) => ReactNode;
+  toggleCheck: (node: TreeDataNode) => void;
+  toggleExpand: (node: TreeDataNode) => void;
+  toggleSelect: (node: TreeDataNode, event?: { metaKey?: boolean; ctrlKey?: boolean; shiftKey?: boolean }) => void;
+}
+
+export const TreeContext = createContext<TreeContextValue | null>(null);
+
+export const useTreeContext = () => {
+  const ctx = use(TreeContext);
+  if (!ctx) throw new Error('Tree components must be rendered inside <Tree>');
+  return ctx;
+};

--- a/src/base-ui/Tree/demos/checkable.tsx
+++ b/src/base-ui/Tree/demos/checkable.tsx
@@ -1,0 +1,22 @@
+import { Tree } from '@lobehub/ui/base-ui';
+import { useState } from 'react';
+
+import { files } from './data';
+
+export default () => {
+  const [checkedKeys, setCheckedKeys] = useState<string[]>(['src/base-ui/Tree']);
+  return (
+    <div style={{ maxWidth: 360, padding: 16 }}>
+      <Tree
+        checkable
+        defaultExpandAll
+        checkedKeys={checkedKeys}
+        treeData={files}
+        onCheck={setCheckedKeys}
+      />
+      <pre style={{ fontSize: 12, marginTop: 12, opacity: 0.65 }}>
+        {JSON.stringify(checkedKeys, null, 2)}
+      </pre>
+    </div>
+  );
+};

--- a/src/base-ui/Tree/demos/data.ts
+++ b/src/base-ui/Tree/demos/data.ts
@@ -1,0 +1,38 @@
+import type { TreeDataNode } from '@lobehub/ui/base-ui';
+
+export const files: TreeDataNode[] = [
+  {
+    children: [
+      {
+        children: [
+          {
+            children: [
+              { key: 'Tree.tsx', title: 'Tree.tsx' },
+              { key: 'TreeNode.tsx', title: 'TreeNode.tsx' },
+              { key: 'utils.ts', title: 'utils.ts' },
+              { key: 'style.ts', title: 'style.ts' },
+            ],
+            key: 'src/base-ui/Tree',
+            title: 'Tree',
+          },
+          {
+            children: [
+              { key: 'Accordion.tsx', title: 'Accordion.tsx' },
+              { key: 'atoms.tsx', title: 'atoms.tsx' },
+            ],
+            key: 'src/base-ui/Accordion',
+            title: 'Accordion',
+          },
+          { key: 'index.ts', title: 'index.ts' },
+        ],
+        key: 'src/base-ui',
+        title: 'base-ui',
+      },
+      { children: [{ key: 'Message.tsx', title: 'Message.tsx' }], key: 'src/chat', title: 'chat' },
+    ],
+    key: 'src',
+    title: 'src',
+  },
+  { children: [{ key: 'docs/home', title: 'home' }], disabled: true, key: 'docs', title: 'docs' },
+  { isLeaf: true, key: 'package.json', title: 'package.json' },
+];

--- a/src/base-ui/Tree/demos/index.tsx
+++ b/src/base-ui/Tree/demos/index.tsx
@@ -1,0 +1,15 @@
+import { Tree } from '@lobehub/ui/base-ui';
+
+import { files } from './data';
+
+export default () => (
+  <div style={{ maxWidth: 360, padding: 16 }}>
+    <Tree
+      blockNode
+      showIcon
+      defaultExpandedKeys={['src', 'src/base-ui']}
+      defaultSelectedKeys={['src/base-ui']}
+      treeData={files}
+    />
+  </div>
+);

--- a/src/base-ui/Tree/demos/multiple.tsx
+++ b/src/base-ui/Tree/demos/multiple.tsx
@@ -1,0 +1,23 @@
+import { Tree } from '@lobehub/ui/base-ui';
+import { useState } from 'react';
+
+import { files } from './data';
+
+export default () => {
+  const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+  return (
+    <div style={{ maxWidth: 360, padding: 16 }}>
+      <Tree
+        blockNode
+        defaultExpandAll
+        multiple
+        selectedKeys={selectedKeys}
+        treeData={files}
+        onSelect={setSelectedKeys}
+      />
+      <pre style={{ fontSize: 12, marginTop: 12, opacity: 0.65 }}>
+        {selectedKeys.join(', ') || 'Click, ⌘-click, or shift-click rows'}
+      </pre>
+    </div>
+  );
+};

--- a/src/base-ui/Tree/demos/showLine.tsx
+++ b/src/base-ui/Tree/demos/showLine.tsx
@@ -1,0 +1,34 @@
+import { Flexbox } from '@lobehub/ui';
+import { Text, Tree, type TreeDataNode } from '@lobehub/ui/base-ui';
+
+const task = (id: string, name: string, children?: TreeDataNode[]): TreeDataNode => ({
+  children,
+  key: id,
+  title: (
+    <Flexbox horizontal align="center" gap={8} style={{ minWidth: 0, width: '100%' }}>
+      <Text fontSize={12} style={{ flex: 'none' }} type="secondary">
+        {id}
+      </Text>
+      <Text ellipsis fontSize={13} style={{ flex: 1, minWidth: 0 }}>
+        {name}
+      </Text>
+    </Flexbox>
+  ),
+});
+
+const tasks: TreeDataNode[] = [
+  task('LOBE-412', 'Research Collapsible height animation', [
+    task('LOBE-413', 'Compare with the Accordion panel-height approach'),
+  ]),
+  task('LOBE-414', 'Implement flattenVisible / conductCheck', [
+    task('LOBE-415', 'utils.test.ts'),
+    task('LOBE-416', 'checkStrictly branch'),
+  ]),
+  task('LOBE-417', 'Keyboard navigation + roving tabindex'),
+];
+
+export default () => (
+  <div style={{ maxWidth: 480, padding: 16 }}>
+    <Tree blockNode defaultExpandAll showLine size="large" treeData={tasks} />
+  </div>
+);

--- a/src/base-ui/Tree/index.mdx
+++ b/src/base-ui/Tree/index.mdx
@@ -1,0 +1,65 @@
+---
+title: Tree
+description: Data-driven tree with expand, single/multiple selection, linked checkboxes, keyboard navigation and rounded SVG guide lines. A drop-in for the common antd Tree props.
+category: Data Display
+---
+
+import DemoIndex from './demos/index.tsx?demo';
+import DemoShowLine from './demos/showLine.tsx?demo';
+import DemoCheckable from './demos/checkable.tsx?demo';
+import DemoMultiple from './demos/multiple.tsx?demo';
+
+## Default
+
+`blockNode` makes the whole row the hit target; `showIcon` renders folder / file icons (or `node.icon`).
+
+<Demo of={DemoIndex} layout="bare" />
+
+## Guide lines
+
+`showLine` draws one SVG path per row, so collapsed subtrees cost nothing. Custom titles get `flex: 1` under `blockNode`, so `space-between` layouts work.
+
+<Demo of={DemoShowLine} layout="bare" />
+
+## Checkable
+
+Parent / child linkage is on by default; pass `checkStrictly` to make every checkbox independent. `onCheck` receives the fully-checked keys only (half-checked parents are excluded).
+
+<Demo of={DemoCheckable} layout="bare" />
+
+## Multiple selection
+
+`multiple` enables ⌘ / ctrl-click to toggle and shift-click to select a visible range.
+
+<Demo of={DemoMultiple} layout="bare" />
+
+## Keyboard
+
+| Key           | Action                                          |
+| ------------- | ----------------------------------------------- |
+| `↓` / `↑`     | Move to the next / previous visible row         |
+| `Home` / `End`| First / last row                                |
+| `→`           | Expand, or move to the first child when open    |
+| `←`           | Collapse, or move to the parent when closed     |
+| `Enter`       | Select                                          |
+| `Space`       | Toggle the checkbox (`checkable`), else select  |
+| `*`           | Expand all siblings                             |
+
+## APIs
+
+### Tree
+
+<Api name="Tree" from=".." />
+
+### TreeDataNode
+
+| Property   | Description                                   | Type             | Default |
+| ---------- | --------------------------------------------- | ---------------- | ------- |
+| key        | Unique key                                    | `string`         | -       |
+| title      | Row content                                   | `ReactNode`      | -       |
+| children   | Child nodes                                   | `TreeDataNode[]` | -       |
+| icon       | Icon shown with `showIcon`                    | `ReactNode`      | -       |
+| disabled   | Not selectable / checkable; still expandable  | `boolean`        | `false` |
+| selectable | Whether the row can be selected               | `boolean`        | `true`  |
+| checkable  | Whether the row renders a checkbox            | `boolean`        | `true`  |
+| isLeaf     | Force leaf rendering even with `children`     | `boolean`        | `false` |

--- a/src/base-ui/Tree/index.mdx
+++ b/src/base-ui/Tree/index.mdx
@@ -35,6 +35,8 @@ Parent / child linkage is on by default; pass `checkStrictly` to make every chec
 
 ## Keyboard
 
+The tree is a [FocusScope](/components/base-ui/focus-scope): after pointing into it once, keys keep working without focus. `scopeId` names the scope; `vimKeys` adds `j` / `k`.
+
 | Key           | Action                                          |
 | ------------- | ----------------------------------------------- |
 | `↓` / `↑`     | Move to the next / previous visible row         |

--- a/src/base-ui/Tree/index.ts
+++ b/src/base-ui/Tree/index.ts
@@ -1,0 +1,4 @@
+export { styles as treeStyles } from './style';
+export { default } from './Tree';
+export type { TreeClassNames, TreeDataNode, TreeFlatRow, TreeProps, TreeStyles } from './type';
+export { conductCheck, flattenVisible, getAllKeys } from './utils';

--- a/src/base-ui/Tree/style.ts
+++ b/src/base-ui/Tree/style.ts
@@ -1,0 +1,146 @@
+import { createStaticStyles } from 'antd-style';
+
+import { focusRing } from '@/base-ui/focusRing';
+
+export const styles = createStaticStyles(({ css, cssVar }) => ({
+  checkbox: css`
+    margin-inline-end: 8px;
+  `,
+  guide: css`
+    pointer-events: none;
+    position: absolute;
+    inset-block-start: 0;
+    inset-inline-start: 0;
+    height: 100%;
+    overflow: visible;
+
+    path {
+      fill: none;
+      stroke: ${cssVar.colorBorderSecondary};
+      stroke-width: 1;
+      stroke-linecap: round;
+    }
+  `,
+  icon: css`
+    display: inline-flex;
+    flex: none;
+    align-items: center;
+    margin-inline-end: 6px;
+    color: ${cssVar.colorTextSecondary};
+  `,
+  node: css`
+    position: relative;
+    display: flex;
+    align-items: center;
+    border-radius: ${cssVar.borderRadius};
+    color: ${cssVar.colorText};
+    outline: none;
+    ${focusRing}
+  `,
+  nodeBlock: css`
+    cursor: pointer;
+
+    &:hover {
+      background: ${cssVar.colorFillTertiary};
+    }
+
+    &[aria-selected='true'] {
+      background: ${cssVar.colorFillSecondary};
+    }
+  `,
+  nodeDisabled: css`
+    cursor: not-allowed;
+    color: ${cssVar.colorTextDisabled};
+
+    &:hover {
+      background: transparent;
+    }
+  `,
+  panel: css`
+    height: var(--collapsible-panel-height);
+    overflow: hidden;
+    transition: height 200ms ${cssVar.motionEaseOut};
+
+    &[data-starting-style],
+    &[data-ending-style] {
+      height: 0;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      transition-duration: 0s;
+    }
+  `,
+  root: css`
+    display: flex;
+    flex-direction: column;
+    user-select: none;
+    outline: none;
+  `,
+  switcher: css`
+    display: grid;
+    flex: none;
+    place-items: center;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: 0;
+    border-radius: ${cssVar.borderRadiusSM};
+    background: none;
+    color: ${cssVar.colorTextSecondary};
+    cursor: pointer;
+
+    &:hover {
+      background: ${cssVar.colorFillSecondary};
+      color: ${cssVar.colorText};
+    }
+
+    svg {
+      transition: transform 200ms ${cssVar.motionEaseOut};
+    }
+
+    [aria-expanded='true'] > & svg {
+      transform: rotate(90deg);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      svg {
+        transition-duration: 0s;
+      }
+    }
+  `,
+  switcherLeaf: css`
+    visibility: hidden;
+    pointer-events: none;
+  `,
+  title: css`
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    padding-block: 2px;
+    padding-inline: 6px;
+    border-radius: ${cssVar.borderRadiusSM};
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  `,
+  titleBlock: css`
+    flex: 1;
+  `,
+  titleInline: css`
+    cursor: pointer;
+
+    &:hover {
+      background: ${cssVar.colorFillTertiary};
+    }
+
+    [aria-selected='true'] > & {
+      background: ${cssVar.colorFillSecondary};
+    }
+
+    [aria-disabled='true'] > & {
+      cursor: not-allowed;
+      background: transparent;
+    }
+  `,
+}));

--- a/src/base-ui/Tree/type.ts
+++ b/src/base-ui/Tree/type.ts
@@ -1,0 +1,70 @@
+import type { CSSProperties, MouseEvent, ReactNode } from 'react';
+
+import type { ControlSize } from '../controlSize';
+
+export interface TreeDataNode {
+  checkable?: boolean;
+  children?: TreeDataNode[];
+  disabled?: boolean;
+  icon?: ReactNode;
+  isLeaf?: boolean;
+  key: string;
+  selectable?: boolean;
+  title: ReactNode;
+}
+
+export interface TreeFlatRow {
+  depth: number;
+  hasChildren: boolean;
+  index: number;
+  isLast: boolean;
+  node: TreeDataNode;
+  parentKey: string | null;
+  trail: boolean[];
+}
+
+export interface TreeClassNames {
+  guide?: string;
+  node?: string;
+  root?: string;
+  switcher?: string;
+  title?: string;
+}
+
+export interface TreeStyles {
+  guide?: CSSProperties;
+  node?: CSSProperties;
+  root?: CSSProperties;
+  switcher?: CSSProperties;
+  title?: CSSProperties;
+}
+
+export interface TreeProps {
+  blockNode?: boolean;
+  checkable?: boolean;
+  checkedKeys?: string[];
+  checkStrictly?: boolean;
+  className?: string;
+  classNames?: TreeClassNames;
+  defaultCheckedKeys?: string[];
+  defaultExpandAll?: boolean;
+  defaultExpandedKeys?: string[];
+  defaultSelectedKeys?: string[];
+  disabled?: boolean;
+  expandedKeys?: string[];
+  indent?: number;
+  multiple?: boolean;
+  onCheck?: (keys: string[], info: { checked: boolean; node: TreeDataNode }) => void;
+  onExpand?: (keys: string[], info: { expanded: boolean; node: TreeDataNode }) => void;
+  onRightClick?: (info: { event: MouseEvent<HTMLDivElement>; node: TreeDataNode }) => void;
+  onSelect?: (keys: string[], info: { node: TreeDataNode; selected: boolean }) => void;
+  selectedKeys?: string[];
+  showIcon?: boolean;
+  showLine?: boolean;
+  size?: ControlSize;
+  style?: CSSProperties;
+  styles?: TreeStyles;
+  switcherIcon?: ReactNode | ((info: { expanded: boolean; node: TreeDataNode }) => ReactNode);
+  titleRender?: (node: TreeDataNode) => ReactNode;
+  treeData: TreeDataNode[];
+}

--- a/src/base-ui/Tree/type.ts
+++ b/src/base-ui/Tree/type.ts
@@ -58,6 +58,7 @@ export interface TreeProps {
   onExpand?: (keys: string[], info: { expanded: boolean; node: TreeDataNode }) => void;
   onRightClick?: (info: { event: MouseEvent<HTMLDivElement>; node: TreeDataNode }) => void;
   onSelect?: (keys: string[], info: { node: TreeDataNode; selected: boolean }) => void;
+  scopeId?: string;
   selectedKeys?: string[];
   showIcon?: boolean;
   showLine?: boolean;
@@ -67,4 +68,5 @@ export interface TreeProps {
   switcherIcon?: ReactNode | ((info: { expanded: boolean; node: TreeDataNode }) => ReactNode);
   titleRender?: (node: TreeDataNode) => ReactNode;
   treeData: TreeDataNode[];
+  vimKeys?: boolean;
 }

--- a/src/base-ui/Tree/utils.ts
+++ b/src/base-ui/Tree/utils.ts
@@ -1,0 +1,92 @@
+import type { TreeDataNode, TreeFlatRow } from './type';
+
+export const hasChildren = (node: TreeDataNode) =>
+  !node.isLeaf && !!node.children && node.children.length > 0;
+
+export const flattenVisible = (
+  data: TreeDataNode[],
+  expanded: Set<string>,
+  depth = 0,
+  parentKey: string | null = null,
+  trail: boolean[] = [],
+  out: TreeFlatRow[] = [],
+): TreeFlatRow[] => {
+  data.forEach((node, i) => {
+    const isLast = i === data.length - 1;
+    const expandable = hasChildren(node);
+    out.push({ depth, hasChildren: expandable, index: out.length, isLast, node, parentKey, trail });
+    if (expandable && expanded.has(node.key)) {
+      flattenVisible(node.children!, expanded, depth + 1, node.key, [...trail, !isLast], out);
+    }
+  });
+  return out;
+};
+
+export const getAllKeys = (data: TreeDataNode[], out: string[] = []): string[] => {
+  for (const node of data) {
+    out.push(node.key);
+    if (node.children) getAllKeys(node.children, out);
+  }
+  return out;
+};
+
+export const findNode = (data: TreeDataNode[], key: string): TreeDataNode | undefined => {
+  for (const node of data) {
+    if (node.key === key) return node;
+    const found = node.children && findNode(node.children, key);
+    if (found) return found;
+  }
+};
+
+const isCheckable = (node: TreeDataNode) => node.checkable !== false && !node.disabled;
+
+export const getSubtreeKeys = (node: TreeDataNode, out: string[] = []): string[] => {
+  if (isCheckable(node)) out.push(node.key);
+  node.children?.forEach((child) => getSubtreeKeys(child, out));
+  return out;
+};
+
+export const conductCheck = (data: TreeDataNode[], checkedKeys: Iterable<string>) => {
+  const checked = new Set(checkedKeys);
+  const halfChecked = new Set<string>();
+
+  const down = (node: TreeDataNode, inherited: boolean) => {
+    const on = inherited || checked.has(node.key);
+    if (on && isCheckable(node)) checked.add(node.key);
+    node.children?.forEach((child) => down(child, on && isCheckable(node)));
+  };
+  data.forEach((node) => down(node, false));
+
+  const walk = (node: TreeDataNode): boolean => {
+    const kids = (node.children ?? []).filter(isCheckable);
+    if (kids.length === 0) return checked.has(node.key);
+    const results = kids.map(walk);
+    if (results.every(Boolean)) {
+      checked.add(node.key);
+      return true;
+    }
+    checked.delete(node.key);
+    if (results.some(Boolean) || kids.some((kid) => halfChecked.has(kid.key))) {
+      halfChecked.add(node.key);
+    }
+    return false;
+  };
+
+  data.forEach(walk);
+  return { checked, halfChecked };
+};
+
+export const getAncestorKeys = (
+  data: TreeDataNode[],
+  key: string,
+  path: string[] = [],
+): string[] => {
+  for (const node of data) {
+    if (node.key === key) return [...path].reverse();
+    if (node.children) {
+      const found = getAncestorKeys(node.children, key, [...path, node.key]);
+      if (found.length > 0 || node.children.some((c) => c.key === key)) return found;
+    }
+  }
+  return [];
+};

--- a/src/base-ui/focusRing.ts
+++ b/src/base-ui/focusRing.ts
@@ -1,29 +1,28 @@
 import { css, cssVar, keyframes } from 'antd-style';
 
-const tint = (color: string, alpha: number) =>
-  `color-mix(in srgb, ${color} ${alpha}%, transparent)`;
+import { focusRingColor as ringColor } from '@/GlobalFocusRing/style';
 
-const glow = (color: string, scale = 1) =>
-  `0 0 0 ${3 * scale}px ${tint(color, 70)}, 0 0 ${5 * scale}px ${4 * scale}px ${tint(color, 35)}`;
-
-const ringIn = (color: string) => keyframes`
+const ringIn = keyframes`
   from {
-    box-shadow: ${glow(color, 2.5)};
+    outline-color: transparent;
+    outline-offset: 5px;
   }
 `;
 
 const ring = (color: string) => css`
-  &:focus-visible {
-    outline: none;
-    box-shadow: ${glow(color)};
-    animation: ${ringIn(color)} 560ms cubic-bezier(0.32, 0.72, 0, 1);
+  --lobe-focus-ring-color: ${color};
+
+  &:focus-visible:not([data-lobe-focus-ring='managed']) {
+    outline: 2px solid ${ringColor(color)};
+    outline-offset: 2px;
+    animation: ${ringIn} 200ms cubic-bezier(0.22, 1, 0.36, 1);
 
     @media (prefers-reduced-motion: reduce) {
       animation: none;
     }
 
     @media (forced-colors: active) {
-      outline: 2px solid CanvasText;
+      outline-color: CanvasText;
       animation: none;
     }
   }

--- a/src/base-ui/index.ts
+++ b/src/base-ui/index.ts
@@ -68,3 +68,5 @@ export { default as ToggleGroup } from './ToggleGroup';
 export * from './ToggleGroup';
 export { default as Tooltip } from './Tooltip';
 export * from './Tooltip';
+export { default as Tree } from './Tree';
+export * from './Tree';

--- a/src/base-ui/index.ts
+++ b/src/base-ui/index.ts
@@ -29,6 +29,7 @@ export * from './DropdownMenu';
 export * from './floating';
 export * from './FloatingPanel';
 export * from './FloatingSheet';
+export * from './FocusScope';
 export * from './Form';
 export * from './Input';
 export * from './Modal';

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,6 +150,7 @@ export {
 } from './Form';
 export { default as FormModal, type FormModalProps } from './FormModal';
 export { default as Freeze, type FreezeProps } from './Freeze';
+export { installGlobalFocusRing } from './GlobalFocusRing';
 export { default as Grid, type GridProps } from './Grid';
 export { default as GroupAvatar, type GroupAvatarProps } from './GroupAvatar';
 export { default as GuideCard, type GuideCardProps } from './GuideCard';

--- a/tests/global-focus-ring.browser.ts
+++ b/tests/global-focus-ring.browser.ts
@@ -1,0 +1,374 @@
+/** Run against docs:dev: pnpm exec tsx tests/global-focus-ring.browser.ts http://localhost:<port> */
+import assert from 'node:assert/strict';
+import { mkdir, writeFile } from 'node:fs/promises';
+
+import { chromium } from '@playwright/test';
+
+const main = async () => {
+  const origin = process.argv[2];
+  assert(origin, 'Pass the running docs:dev URL');
+  const output = process.env.FOCUS_PROOF_DIR || '/tmp/lobe-global-focus-proof/assets';
+  await mkdir(output, { recursive: true });
+  const browser = await chromium.launch({
+    channel: 'chrome',
+  });
+  const page = await browser.newPage({ viewport: { height: 720, width: 1000 } });
+  const errors: string[] = [];
+  const consoleErrors: string[] = [];
+  const requestFailures: { url: string; error: string | undefined }[] = [];
+  page.on('requestfailed', (request) =>
+    requestFailures.push({ url: request.url(), error: request.failure()?.errorText }),
+  );
+  page.on('console', (message) => {
+    if (message.type() === 'error') consoleErrors.push(message.text());
+  });
+  page.on('pageerror', (error) => errors.push(error.message));
+  const results: string[] = [];
+  const check = (name: string) => {
+    results.push(`PASS ${name}`);
+    console.info(`PASS ${name}`);
+  };
+  try {
+    await page.route('**/__focus-check', (route) =>
+      route.fulfill({
+        contentType: 'text/html',
+        body: `<!doctype html><html lang="en"><title>Global keyboard focus verification</title>
+      <style>body { font: 16px system-ui; padding: 40px; } button,input { padding: 12px; border-radius: 8px; } #clip { overflow: hidden; width: 360px; height: 140px; margin-top: 40px; border: 1px solid #999; } #edge { margin: 0; } #multiline { display: block; width: 70px; margin-top: 30px; } dialog { padding: 35px; }</style>
+      <h1>Global keyboard focus</h1><p>Native controls, with no component focus class.</p>
+      <button id="first">First control</button>
+      <div id="clip"><button id="edge">Clipped native button</button><input aria-label="Native input" id="input"><div style="height:400px"></div></div>
+      <span id="multiline"><a href="#" id="link">A link wrapping across multiple lines</a></span>
+      <dialog id="dialog"><button id="inside">Modal button</button></dialog>
+      <script type="module">import { installGlobalFocusRing } from '/src/GlobalFocusRing/index.ts'; window.install = installGlobalFocusRing; window.cleanup = installGlobalFocusRing();</script>
+      </html>`,
+      }),
+    );
+    await page.goto(`${origin}/__focus-check`);
+    await page.waitForFunction(() => !!(window as any).cleanup);
+    const settle = () =>
+      page.evaluate(
+        () =>
+          new Promise<void>((resolve) =>
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+          ),
+      );
+    const aligned = () =>
+      page.evaluate(() => {
+        const target = document.activeElement!;
+        const ring = document.querySelector('[data-lobe-global-focus-ring]')!;
+        const a = target.getBoundingClientRect(),
+          b = ring.getBoundingClientRect();
+        return (
+          ring.matches(':popover-open') &&
+          target.getAttribute('data-lobe-focus-ring') === 'managed' &&
+          Math.max(
+            ...(['top', 'right', 'bottom', 'left'] as const).map((edge) =>
+              Math.abs(a[edge] - b[edge]),
+            ),
+          ) < 1
+        );
+      });
+    await page.keyboard.press('Tab');
+    assert.equal(await page.locator('#first').evaluate((e) => e === document.activeElement), true);
+    assert(await aligned());
+    check('keyboard focus on native button');
+    await page.keyboard.press('Tab');
+    assert(await aligned());
+    await page.screenshot({ path: `${output}/clipped-light.png` });
+    check('clipping boundary and native outline suppression');
+    await page.evaluate(() => {
+      document.querySelector('#clip')!.scrollTop = 12;
+      (document.querySelector('#clip') as HTMLElement).style.marginLeft = '50px';
+      (document.querySelector('#edge') as HTMLElement).style.width = '260px';
+    });
+    await settle();
+    assert(await aligned());
+    check('nested scrolling, layout shift, resize');
+    assert(
+      await page.evaluate(async () => {
+        const target = document.activeElement!;
+        const animation = target.animate(
+          [{ transform: 'translateX(0)' }, { transform: 'translateX(50px)' }],
+          { duration: 500, iterations: Infinity, direction: 'alternate' },
+        );
+        let pass = true;
+        for (let i = 0; i < 40; i++) {
+          await new Promise(requestAnimationFrame);
+          const a = target.getBoundingClientRect(),
+            b = document.querySelector('[data-lobe-global-focus-ring]')!.getBoundingClientRect();
+          if (Math.abs(a.left - b.left) > 1) pass = false;
+        }
+        animation.cancel();
+        return pass;
+      }),
+    );
+    check('40 animation frames track within 1px');
+    await page.evaluate(() => {
+      (document.querySelector('#edge') as HTMLElement).style.transform = 'scale(1.1)';
+    });
+    await settle();
+    assert(await aligned());
+    check('scale follows bounding box');
+    await page.evaluate(() => {
+      document.querySelector('#clip')!.scrollTop = 300;
+    });
+    await settle();
+    await page.screenshot({ path: `${output}/scrolled-away.png` });
+    // anchors-visible uses strong hiding; CSS visibility/getBoundingClientRect do not expose that paint state.
+    check('fully scrolled-out paint captured for visual inspection');
+    await page.evaluate(() => {
+      (document.querySelector('#dialog') as HTMLDialogElement).showModal();
+    });
+    await settle();
+    assert(await aligned());
+    assert.equal(await page.locator('#inside').evaluate((e) => document.activeElement === e), true);
+    await page.screenshot({ path: `${output}/modal.png` });
+    check('modal top layer and actual focus');
+    await page.evaluate(() => {
+      (document.querySelector('#dialog') as HTMLDialogElement).close();
+      (document.querySelector('#link') as HTMLElement).focus();
+    });
+    await settle();
+    assert.equal(await page.locator('#link').getAttribute('data-lobe-focus-ring'), null);
+    assert.equal(
+      await page
+        .locator('[data-lobe-global-focus-ring]')
+        .evaluate((e) => e.matches(':popover-open')),
+      false,
+    );
+    check('multiline links retain native focus');
+    await page.evaluate(() => {
+      const button = document.createElement('button');
+      button.id = 'dynamic';
+      button.textContent = 'Dynamic button';
+      button.style.setProperty('anchor-name', '--existing', 'important');
+      button.style.setProperty('outline', '4px dotted red', 'important');
+      document.body.append(button);
+      button.focus();
+    });
+    await settle();
+    assert(await aligned());
+    await page.evaluate(() => {
+      (document.querySelector('#first') as HTMLElement).focus();
+    });
+    assert.equal(
+      await page
+        .locator('#dynamic')
+        .evaluate((e: HTMLElement) => e.style.getPropertyValue('anchor-name')),
+      '--existing',
+    );
+    assert.equal(
+      await page
+        .locator('#dynamic')
+        .evaluate((e: HTMLElement) => e.style.getPropertyValue('outline')),
+      'red dotted 4px',
+    );
+    check('dynamic controls and original inline styles restored');
+    await page.evaluate(() => document.activeElement!.remove());
+    await settle();
+    assert.equal(
+      await page
+        .locator('[data-lobe-global-focus-ring]')
+        .evaluate((e) => e.matches(':popover-open')),
+      false,
+    );
+    check('removed target clears ring');
+    await page.locator('#dynamic').click();
+    await settle();
+    assert.equal(await page.locator('#dynamic').getAttribute('data-lobe-focus-ring'), null);
+    check('pointer focus follows focus-visible semantics');
+    await page.locator('#input').click();
+    await settle();
+    assert.equal(await aligned(), false);
+    assert.equal(await page.locator('#input').getAttribute('data-lobe-focus-ring'), null);
+    assert.notEqual(
+      await page.locator('#input').evaluate((e) => getComputedStyle(e).outlineStyle),
+      'none',
+    );
+    check('native text input retains its own focus outline');
+    await page.evaluate(() => {
+      document.querySelector('#clip')!.scrollTop = 0;
+      document.body.insertAdjacentHTML(
+        'beforeend',
+        `
+        <div id="composer" style="border:1px solid #aaa;border-radius:12px;padding:16px">
+          <textarea id="textarea" style="outline:none" aria-label="Message"></textarea>
+          <div contenteditable="true" id="editor" style="outline:none">Rich editor
+            <span id="inherited-editor" tabindex="0">Nested editable content</span>
+            <button id="noneditable" contenteditable="false">Editor action</button>
+          </div>
+        </div>
+        <section data-lobe-focus-ring="off"><button id="optout">Local focus</button></section>
+        <button id="self-optout" data-lobe-focus-ring="off">Own focus</button>
+        <input id="checkbox" type="checkbox" aria-label="Checkbox">
+      `,
+      );
+    });
+    for (const selector of [
+      '#textarea',
+      '#editor',
+      '#inherited-editor',
+      '#optout',
+      '#self-optout',
+    ]) {
+      await page.locator(selector).click();
+      await page.keyboard.press('Shift');
+      await page.locator(selector).focus();
+      await settle();
+      assert.equal(
+        await page.locator(selector).evaluate((e) => e === document.activeElement),
+        true,
+      );
+      assert.equal(
+        await page.locator(selector).getAttribute('data-lobe-focus-ring'),
+        selector === '#self-optout' ? 'off' : null,
+      );
+      assert.equal(
+        await page
+          .locator('[data-lobe-global-focus-ring]')
+          .evaluate((e) => e.matches(':popover-open')),
+        false,
+      );
+    }
+    await page.locator('#textarea').focus();
+    await page.keyboard.press('Tab');
+    assert.equal(await page.locator('#editor').evaluate((e) => e === document.activeElement), true);
+    assert.equal(await aligned(), false);
+    await page.screenshot({ path: `${output}/editor-no-ring.png` });
+    check('pointer and keyboard editing preserve local styles; element and ancestor opt-out');
+    for (const selector of ['#noneditable', '#checkbox']) {
+      await page.locator(selector).focus();
+      await settle();
+      assert(await aligned());
+    }
+    check('noneditable editor actions and checkbox retain global keyboard ring');
+    await page.emulateMedia({ reducedMotion: 'reduce', colorScheme: 'dark' });
+    await page.evaluate(() => {
+      document.body.style.background = '#141414';
+      document.body.style.color = '#eee';
+    });
+    assert.equal(
+      await page
+        .locator('[data-lobe-global-focus-ring]')
+        .evaluate((e) => getComputedStyle(e).animationName),
+      'none',
+    );
+    await page.screenshot({ path: `${output}/dark-reduced-motion.png` });
+    check('dark surface and reduced motion');
+    await page.emulateMedia({ forcedColors: 'active' });
+    assert.equal(
+      await page
+        .locator('[data-lobe-global-focus-ring]')
+        .evaluate((e) => getComputedStyle(e).outlineWidth),
+      '2px',
+    );
+    check('forced colors visible outline');
+    await page.evaluate(() => {
+      (window as any).cleanup2 = (window as any).install();
+      (window as any).cleanup();
+      (window as any).cleanup();
+    });
+    assert.equal(await page.locator('[data-lobe-global-focus-ring]').count(), 1);
+    await page.evaluate(() => (window as any).cleanup2());
+    assert.equal(await page.locator('[data-lobe-global-focus-ring]').count(), 0);
+    assert.equal(await page.locator('[data-lobe-focus-ring="managed"]').count(), 0);
+    check('shared installation, idempotent cleanup and target restoration');
+    await page.evaluate(() => {
+      const original = CSS.supports;
+      CSS.supports = () => false;
+      (window as any).install()();
+      CSS.supports = original;
+    });
+    assert.equal(await page.locator('[data-lobe-global-focus-ring]').count(), 0);
+    check('unsupported browsers retain native behavior');
+    await page.emulateMedia({
+      forcedColors: 'none',
+      reducedMotion: 'no-preference',
+      colorScheme: 'light',
+    });
+    assert.equal(consoleErrors.length, 0);
+    await page.goto(`${origin}/components/config-provider`, { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('[data-lobe-global-focus-ring]', { state: 'attached' });
+    assert.match(await page.title(), /ConfigProvider/);
+    assert.match(await page.locator('[aria-current=page]').first().innerText(), /ConfigProvider/);
+    await page.keyboard.press('Tab');
+    await settle();
+    assert(await aligned());
+    await page.screenshot({ path: `${output}/docs-native.png` });
+    check('ConfigProvider automatically covers native documentation link');
+    await page.goto(`${origin}/~demos/src-base-ui-button-demo-demos`);
+    await page.waitForSelector('[data-standalone-demo] button');
+    await page.keyboard.press('Tab');
+    await settle();
+    assert(await aligned());
+    assert.deepEqual(
+      await page.evaluate(() => {
+        const style = getComputedStyle(document.activeElement!);
+        return { animation: style.animationName, shadow: style.boxShadow };
+      }),
+      { animation: 'none', shadow: 'none' },
+    );
+    await page.screenshot({ path: `${output}/base-button.png` });
+    check('manifest-backed Base UI demo has one ring without local shadow or animation');
+    await page.setViewportSize({ width: 390, height: 844 });
+    await settle();
+    assert(await aligned());
+    check('mobile viewport remains aligned');
+    const integrationErrors = [...new Set(consoleErrors)];
+    await page.setViewportSize({ width: 1000, height: 720 });
+    consoleErrors.length = 0;
+    await page.route('**/src/GlobalFocusRing/index.ts*', (route) =>
+      route.fulfill({
+        contentType: 'text/javascript',
+        body: 'export const installGlobalFocusRing = () => { window.__focusDisabled = true; return () => {}; };',
+      }),
+    );
+    await page.goto(`${origin}/components/config-provider`, { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(() => (window as any).__focusDisabled);
+    await page.waitForSelector('[aria-current=page]', { state: 'attached' });
+    await page.keyboard.press('Tab');
+    assert.equal(await page.locator('[data-lobe-global-focus-ring]').count(), 0);
+    const withoutNetworkErrors = (messages: string[]) =>
+      messages.filter((message) => !message.startsWith('Failed to load resource:'));
+    assert.deepEqual(
+      withoutNetworkErrors(integrationErrors),
+      withoutNetworkErrors([...new Set(consoleErrors)]),
+    );
+    assert.deepEqual(
+      requestFailures.filter((failure) => failure.url.startsWith(origin)),
+      [],
+    );
+    if (
+      [...integrationErrors, ...consoleErrors].some((message) =>
+        message.startsWith('Failed to load resource:'),
+      )
+    )
+      assert(requestFailures.length > 0);
+
+    await writeFile(
+      `${output}/console-baseline.txt`,
+      JSON.stringify(
+        {
+          enabled: integrationErrors,
+          requestFailures,
+          disabled: [...new Set(consoleErrors)],
+          conclusion:
+            'Documentation console errors reproduce with the global manager disabled; native fixture has none.',
+        },
+        null,
+        2,
+      ),
+    );
+    check('documentation console baseline unchanged with manager disabled');
+    assert.deepEqual(errors, []);
+    check('no uncaught browser errors');
+  } finally {
+    await browser.close();
+    await writeFile(`${output}/browser.txt`, results.join('\n') + '\n');
+  }
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- Add `src/GlobalFocusRing`: a per-document keyboard focus ring (CSS anchor–positioned top-layer ring, ref-counted install, Strict Mode / nested provider safe) exported as `installGlobalFocusRing`
- `ConfigProvider` installs it by default; opt out with `config={{ globalFocusRing: false }}`
- Base UI `focusRing` switched from box-shadow glow to an outline sharing the same ring color, and skips elements the global ring already covers (`data-lobe-focus-ring="managed"`)
- Docs in `ConfigProvider/index.mdx`; playwright proof script in `tests/global-focus-ring.browser.ts`

## Test plan
- [ ] `pnpm dev`, tab through a docs page: native controls, Base UI controls and controls outside the provider subtree all get one ring
- [ ] `pnpm exec tsx tests/global-focus-ring.browser.ts http://localhost:<port>`
- [ ] Verify reduced-motion / forced-colors and `data-lobe-focus-ring="off"` opt-out

https://claude.ai/code/session_01Ee1HGYYoaPTGdAhTmLhz6y