### PR TITLE
🐛 fix: keep MarkdownTable copy button from jumping on press

### DIFF
--- a/src/Markdown/components/MarkdownTable/index.tsx
+++ b/src/Markdown/components/MarkdownTable/index.tsx
@@ -15,8 +15,8 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     /* Vertical center of the header row = top padding (0.75em) + half of
        the text line-box (line-height * 0.5em). Pulling the button up by
        50% of its own height parks it on that exact line.
-       Use CSS `translate` instead of `transform`: Motion's whileTap
-       scale writes `transform` on the same element and would overwrite
+       Use CSS translate instead of transform: Motion's whileTap scale
+       writes transform on the same element and would overwrite
        translateY, causing the button to jump down on press. */
     inset-block-start: calc(0.75em + (var(--lobe-markdown-line-height) * 0.5em));
     inset-inline-end: 0.5em;

--- a/src/Markdown/components/MarkdownTable/index.tsx
+++ b/src/Markdown/components/MarkdownTable/index.tsx
@@ -14,10 +14,13 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
     /* Vertical center of the header row = top padding (0.75em) + half of
        the text line-box (line-height * 0.5em). Pulling the button up by
-       50% of its own height with transform parks it on that exact line. */
+       50% of its own height parks it on that exact line.
+       Use CSS `translate` instead of `transform`: Motion's whileTap
+       scale writes `transform` on the same element and would overwrite
+       translateY, causing the button to jump down on press. */
     inset-block-start: calc(0.75em + (var(--lobe-markdown-line-height) * 0.5em));
     inset-inline-end: 0.5em;
-    transform: translateY(-50%);
+    translate: 0 -50%;
 
     opacity: 0;
     background: ${cssVar.colorBgContainer};


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🐛 fix

#### 🔀 变更说明 | Description of Change

The Markdown table copy button is vertically centered with `transform: translateY(-50%)`. Motion's `whileTap={{ scale: 0.98 }}` writes `transform` on the same element, so the centering offset is dropped on press and the button jumps down.

Switch the copy button to CSS `translate: 0 -50%`, which composes independently of Motion's `transform`. Hover/focus visibility, copy behavior, and other Button/ActionIcon components are unchanged.

Fixes LOBE-13921

#### 📝 补充信息 | Additional Information

No new unit test: MarkdownTable has no style tests, and a CSS-string source assertion would not catch the runtime transform overwrite.